### PR TITLE
perf+ui: STT 병렬·inline + Rich Text WYSIWYG·검색·toolbar + 배경색 통합

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# @sereneinserenade/tiptap-search-and-replace 의 peer dep 가 @tiptap/core@^2 인데
+# 우리는 @tiptap/core@3 사용 — ERESOLVE 우회. 로컬·CI·Vercel 모두 동일하게 동작.
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tiptap/extension-table-row": "^3.23.6",
         "@tiptap/extension-task-item": "^3.23.6",
         "@tiptap/extension-task-list": "^3.23.6",
+        "@tiptap/extension-typography": "^3.23.6",
         "@tiptap/react": "^3.23.6",
         "@tiptap/starter-kit": "^3.23.6",
         "@uiw/react-codemirror": "^4.25.7",
@@ -2571,6 +2572,19 @@
       "version": "3.23.6",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.6.tgz",
       "integrity": "sha512-ipoC2TkIAIOTiF5ByiGgvQB1DqDyfP90wrUB3mohBcgvp7lQnwHszCDGv8dNnmcUek8uXV/uoLu2VXeVQlxjPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-typography": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-3.23.6.tgz",
+      "integrity": "sha512-eo/+e5TJ4cPfkk6ugMaoW+UVfTC3CEU97EH2g72H+L90qywnOJalrRNXTkdSEbYxGtLs9xthTAHpy2YImf4r1A==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
         "@google/genai": "^1.44.0",
+        "@sereneinserenade/tiptap-search-and-replace": "^0.1.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
@@ -1919,6 +1920,19 @@
         "win32"
       ]
     },
+    "node_modules/@sereneinserenade/tiptap-search-and-replace": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sereneinserenade/tiptap-search-and-replace/-/tiptap-search-and-replace-0.1.1.tgz",
+      "integrity": "sha512-lVYuCYj8ORUCpv9WD7mmcKGQez/QaGUyCoJReH8Kn8hQo8dJEETo3sC3l7QrsYokoV8VNS42rBh0vj7qbgDg1Q==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/sereneinserenade"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.x.x",
+        "@tiptap/pm": "^2.x.x"
+      }
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -2808,6 +2822,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2817,6 +2832,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3211,6 +3227,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@tiptap/extension-table-row": "^3.23.6",
     "@tiptap/extension-task-item": "^3.23.6",
     "@tiptap/extension-task-list": "^3.23.6",
+    "@tiptap/extension-typography": "^3.23.6",
     "@tiptap/react": "^3.23.6",
     "@tiptap/starter-kit": "^3.23.6",
     "@uiw/react-codemirror": "^4.25.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@google/genai": "^1.44.0",
+    "@sereneinserenade/tiptap-search-and-replace": "^0.1.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -409,25 +409,45 @@ async fn transcribe_chunks_sequential(
             Some(format!("동시 {}개", wave_size)),
         );
 
-        let futs: Vec<_> = chunks[next_idx..end]
-            .iter()
-            .enumerate()
-            .map(|(local_i, chunk)| {
-                let api_key = api_key.to_string();
-                let chunk = chunk.clone();
-                let ctx = context.clone();
-                let global_idx = next_idx + local_i;
-                let start_sec = chunk.start_sec;
-                async move {
-                    let res = transcribe_one_chunk(&api_key, &chunk, Some(&ctx)).await?;
-                    Ok::<(usize, f64, super::GenerateResult), ConverterError>((
-                        global_idx, start_sec, res,
-                    ))
-                }
-            })
-            .collect();
+        // JoinSet 으로 spawn — 한 task fail 해도 모든 task await 완료까지 기다림 →
+        // generate_text_with_file_api 의 delete_file cleanup 보장 (Gemini 서버에
+        // 업로드된 임시 파일이 미정리로 남는 quota leak 방지).
+        let mut set = tokio::task::JoinSet::new();
+        for (local_i, chunk) in chunks[next_idx..end].iter().enumerate() {
+            let api_key = api_key.to_string();
+            let chunk = chunk.clone();
+            let ctx = context.clone();
+            let global_idx = next_idx + local_i;
+            let start_sec = chunk.start_sec;
+            set.spawn(async move {
+                let res = transcribe_one_chunk(&api_key, &chunk, Some(&ctx)).await;
+                (global_idx, start_sec, res)
+            });
+        }
 
-        let mut wave_results = futures_util::future::try_join_all(futs).await?;
+        let mut wave_results: Vec<(usize, f64, super::GenerateResult)> = Vec::with_capacity(wave_size);
+        let mut first_err: Option<ConverterError> = None;
+        while let Some(joined) = set.join_next().await {
+            match joined {
+                Ok((idx, start_sec, Ok(res))) => wave_results.push((idx, start_sec, res)),
+                Ok((_idx, _start_sec, Err(e))) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
+                    }
+                }
+                Err(join_err) => {
+                    if first_err.is_none() {
+                        first_err = Some(ConverterError::Internal(format!(
+                            "wave task join 실패: {}",
+                            join_err
+                        )));
+                    }
+                }
+            }
+        }
+        if let Some(e) = first_err {
+            return Err(e);
+        }
         wave_results.sort_by_key(|(idx, _, _)| *idx);
         for (idx, start_sec, res) in wave_results {
             cumulative_cost += res.usage.cost_usd;

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -306,6 +306,57 @@ fn map_timestamps_to_original(text: &str, map: &[SegmentMap]) -> String {
     .into_owned()
 }
 
+/// Gemini inline base64 request body 안전 임계.
+const INLINE_THRESHOLD: u64 = 15 * 1024 * 1024;
+
+/// 병렬 처리 동시도 — Tier 1 RPM 여유 안에서 안전 (24청크 / 6 = 4 wave).
+const CHUNK_PARALLELISM: usize = 6;
+
+/// 단일 청크 transcribe — 크기 분기로 inline base64 / File API 자동 선택.
+async fn transcribe_one_chunk(
+    api_key: &str,
+    chunk: &AudioChunk,
+    context: Option<&str>,
+) -> ConverterResult<super::GenerateResult> {
+    let prompt = build_prompt_with_context(context);
+    let mime = guess_mime(&chunk.chunk_path);
+    let chunk_size = tokio::fs::metadata(&chunk.chunk_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(u64::MAX);
+
+    if chunk_size <= INLINE_THRESHOLD {
+        let bytes = tokio::fs::read(&chunk.chunk_path)
+            .await
+            .map_err(|e| ConverterError::Internal(format!("청크 read: {}", e)))?;
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+        let data_b64 = STANDARD.encode(&bytes);
+        gemini::generate_text(
+            api_key,
+            MODEL_AUDIO,
+            &prompt,
+            vec![gemini::InlineData {
+                mime_type: mime.to_string(),
+                data_base64: data_b64,
+            }],
+            None,
+        )
+        .await
+    } else {
+        gemini::generate_text_with_file_api(
+            api_key,
+            MODEL_AUDIO,
+            &prompt,
+            &chunk.chunk_path,
+            mime,
+            None,
+        )
+        .await
+    }
+}
+
+/// 청크 병렬 처리 — 첫 청크만 sequential (화자 컨텍스트 시드), 나머지는 N 동시 wave.
+/// 같은 미팅의 화자 일관성은 첫 청크 context 를 모든 후속 청크에 전달해 유지.
 async fn transcribe_chunks_sequential(
     api_key: &str,
     chunks: &[AudioChunk],
@@ -313,44 +364,91 @@ async fn transcribe_chunks_sequential(
     usages: &mut Vec<UsageInfo>,
 ) -> ConverterResult<Vec<ChunkResult>> {
     let total = chunks.len();
-    let mut prev_context: Option<String> = None;
-    let mut results = Vec::with_capacity(chunks.len());
+    let mut results: Vec<ChunkResult> = Vec::with_capacity(total);
     let mut cumulative_cost = 0.0;
 
-    for (i, chunk) in chunks.iter().enumerate() {
+    if total == 0 {
+        return Ok(results);
+    }
+
+    // ─── 첫 청크 sequential — 화자 라벨 시드 ───
+    emitter.emit(
+        format!("🎙️ 1/{}번째 조각 녹취 중... (컨텍스트 시드)", total),
+        None,
+    );
+    let start = std::time::Instant::now();
+    let first = transcribe_one_chunk(api_key, &chunks[0], None).await?;
+    cumulative_cost += first.usage.cost_usd;
+    usages.push(first.usage.clone());
+    emitter.emit(
+        format!("✅ 1/{}번째 완료", total),
+        Some(format!(
+            "{:.0}초 · 누적 ${:.3}",
+            start.elapsed().as_secs_f64(),
+            cumulative_cost
+        )),
+    );
+    let context = extract_last_speaker_lines(&first.text, PREV_CONTEXT_LINES);
+    results.push(ChunkResult {
+        start_sec: chunks[0].start_sec,
+        text: first.text,
+    });
+
+    // ─── 나머지 청크 병렬 wave (CHUNK_PARALLELISM 동시) ───
+    if total == 1 {
+        return Ok(results);
+    }
+
+    let mut next_idx = 1;
+    while next_idx < total {
+        let end = (next_idx + CHUNK_PARALLELISM).min(total);
+        let wave_size = end - next_idx;
+        let wave_start = std::time::Instant::now();
         emitter.emit(
-            format!("🎙️ {}/{}번째 조각 녹취 중...", i + 1, total),
-            if i == 0 { None } else { Some("이전 대화 이어받기".into()) },
+            format!("⚡ {}~{}/{}번째 병렬 처리", next_idx + 1, end, total),
+            Some(format!("동시 {}개", wave_size)),
         );
-        let prompt = build_prompt_with_context(prev_context.as_deref());
-        let start = std::time::Instant::now();
-        let mime = guess_mime(&chunk.chunk_path);
-        let progress_cb = |msg: &str| emitter.emit(msg.to_string(), None);
-        let result = gemini::generate_text_with_file_api(
-            api_key,
-            MODEL_AUDIO,
-            &prompt,
-            &chunk.chunk_path,
-            mime,
-            Some(&progress_cb),
-        )
-        .await?;
-        cumulative_cost += result.usage.cost_usd;
-        usages.push(result.usage.clone());
+
+        let futs: Vec<_> = chunks[next_idx..end]
+            .iter()
+            .enumerate()
+            .map(|(local_i, chunk)| {
+                let api_key = api_key.to_string();
+                let chunk = chunk.clone();
+                let ctx = context.clone();
+                let global_idx = next_idx + local_i;
+                let start_sec = chunk.start_sec;
+                async move {
+                    let res = transcribe_one_chunk(&api_key, &chunk, Some(&ctx)).await?;
+                    Ok::<(usize, f64, super::GenerateResult), ConverterError>((
+                        global_idx, start_sec, res,
+                    ))
+                }
+            })
+            .collect();
+
+        let mut wave_results = futures_util::future::try_join_all(futs).await?;
+        wave_results.sort_by_key(|(idx, _, _)| *idx);
+        for (idx, start_sec, res) in wave_results {
+            cumulative_cost += res.usage.cost_usd;
+            usages.push(res.usage.clone());
+            results.push(ChunkResult {
+                start_sec,
+                text: res.text,
+            });
+            let _ = idx;
+        }
         emitter.emit(
-            format!("✅ {}/{}번째 완료", i + 1, total),
+            format!("✅ {}~{}/{}번째 완료", next_idx + 1, end, total),
             Some(format!(
-                "{:.0}초 소요 · 누적 ${:.3}",
-                start.elapsed().as_secs_f64(),
+                "{:.0}초 · 누적 ${:.3}",
+                wave_start.elapsed().as_secs_f64(),
                 cumulative_cost
             )),
         );
-        prev_context = Some(extract_last_speaker_lines(&result.text, PREV_CONTEXT_LINES));
-        results.push(ChunkResult {
-            start_sec: chunk.start_sec,
-            text: result.text,
-        });
+        next_idx = end;
     }
+
     Ok(results)
 }
 

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -195,7 +195,7 @@ async fn run_pipeline_core(
     emitter.emit("✅ 분할 완료", None);
 
     let mut usages: Vec<UsageInfo> = Vec::new();
-    let chunk_results = transcribe_chunks_sequential(api_key, &chunks, emitter, &mut usages).await;
+    let chunk_results = transcribe_chunks_with_seed_then_parallel(api_key, &chunks, emitter, &mut usages).await;
     cleanup_chunks(&chunks).await;
     let chunk_results = chunk_results?;
 
@@ -309,8 +309,16 @@ fn map_timestamps_to_original(text: &str, map: &[SegmentMap]) -> String {
 /// Gemini inline base64 request body 안전 임계.
 const INLINE_THRESHOLD: u64 = 15 * 1024 * 1024;
 
-/// 병렬 처리 동시도 — Tier 1 RPM 여유 안에서 안전 (24청크 / 6 = 4 wave).
-const CHUNK_PARALLELISM: usize = 6;
+/// 병렬 처리 동시도. ENV `MARKMIND_STT_PARALLELISM` 으로 1~12 사이 조정 가능.
+/// 기본 6 — Gemini Tier 1 RPM 여유 안에서 안전 (24청크 / 6 = 4 wave).
+/// Tier 0 또는 free 환경에서 429 storm 발생 시 4 로 낮추는 게 안전.
+fn chunk_parallelism() -> usize {
+    std::env::var("MARKMIND_STT_PARALLELISM")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|n| n.clamp(1, 12))
+        .unwrap_or(6)
+}
 
 /// 단일 청크 transcribe — 크기 분기로 inline base64 / File API 자동 선택.
 async fn transcribe_one_chunk(
@@ -355,9 +363,10 @@ async fn transcribe_one_chunk(
     }
 }
 
-/// 청크 병렬 처리 — 첫 청크만 sequential (화자 컨텍스트 시드), 나머지는 N 동시 wave.
+/// 청크 처리 — 첫 청크 sequential (화자 컨텍스트 시드), 나머지 N 동시 wave.
 /// 같은 미팅의 화자 일관성은 첫 청크 context 를 모든 후속 청크에 전달해 유지.
-async fn transcribe_chunks_sequential(
+/// (이름 sequential 유지: 외부 caller 가 단일 함수로 보는 추상화 + 첫 청크가 직렬이라는 의미도 부분 보존)
+async fn transcribe_chunks_with_seed_then_parallel(
     api_key: &str,
     chunks: &[AudioChunk],
     emitter: &ProgressEmitter,
@@ -394,14 +403,15 @@ async fn transcribe_chunks_sequential(
         text: first.text,
     });
 
-    // ─── 나머지 청크 병렬 wave (CHUNK_PARALLELISM 동시) ───
+    // ─── 나머지 청크 병렬 wave ───
+    let parallelism = chunk_parallelism();
     if total == 1 {
         return Ok(results);
     }
 
     let mut next_idx = 1;
     while next_idx < total {
-        let end = (next_idx + CHUNK_PARALLELISM).min(total);
+        let end = (next_idx + parallelism).min(total);
         let wave_size = end - next_idx;
         let wave_start = std::time::Instant::now();
         emitter.emit(
@@ -449,14 +459,13 @@ async fn transcribe_chunks_sequential(
             return Err(e);
         }
         wave_results.sort_by_key(|(idx, _, _)| *idx);
-        for (idx, start_sec, res) in wave_results {
+        for (_idx, start_sec, res) in wave_results {
             cumulative_cost += res.usage.cost_usd;
             usages.push(res.usage.clone());
             results.push(ChunkResult {
                 start_sec,
                 text: res.text,
             });
-            let _ = idx;
         }
         emitter.emit(
             format!("✅ {}~{}/{}번째 완료", next_idx + 1, end, total),

--- a/src-tauri/src/converters/audio_splitter.rs
+++ b/src-tauri/src/converters/audio_splitter.rs
@@ -19,7 +19,11 @@ use tokio::process::Command;
 
 static INIT: Once = Once::new();
 
-const CHUNK_SIZE_GUARD_BYTES: u64 = 150 * 1024 * 1024;
+/// 청크 크기 가드 — 초과 시 16kHz mono 32kbps mp3 로 다운인코딩.
+/// 임계 15MB → 대부분 청크가 Gemini inline base64 path 임계 (~20MB request body) 안에 들어가
+/// File API 우회 + round-trip 절약 (B+C 의 핵심).
+/// Gemini 가 어차피 내부에서 16kbps mono 로 다운샘플하므로 quality 손실 X.
+const CHUNK_SIZE_GUARD_BYTES: u64 = 15 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct AudioChunk {
@@ -266,7 +270,8 @@ pub async fn split_audio_to_chunks(
             }
         }
 
-        // 사이즈 가드: 150MB 초과 시 64kbps 다운샘플
+        // 사이즈 가드: 15MB 초과 시 16kHz mono 32kbps mp3 로 재인코딩.
+        // (Gemini inline base64 임계 안으로 + 어차피 내부 16kbps downsample 이라 quality 손실 X)
         if let Ok(meta) = tokio::fs::metadata(&chunk_path).await {
             if meta.len() > CHUNK_SIZE_GUARD_BYTES {
                 let _ = tokio::fs::remove_file(&chunk_path).await;
@@ -277,7 +282,13 @@ pub async fn split_audio_to_chunks(
                     .arg(format!("{}", chunk_duration_sec))
                     .arg("-i")
                     .arg(input)
-                    .args(["-vn", "-acodec", "libmp3lame", "-b:a", "64k"])
+                    .args([
+                        "-vn",
+                        "-ac", "1",       // mono
+                        "-ar", "16000",   // 16kHz
+                        "-acodec", "libmp3lame",
+                        "-b:a", "32k",
+                    ])
                     .arg(&chunk_path)
                     .output()
                     .await;

--- a/src-tauri/src/converters/audio_splitter.rs
+++ b/src-tauri/src/converters/audio_splitter.rs
@@ -108,7 +108,7 @@ pub fn resolve_binary(name: &str) -> ConverterResult<PathBuf> {
         return Ok(p);
     }
     // 마지막 fallback — 다운로드 시도
-    ensure_ffmpeg_blocking()?;
+    // (auto_download 호출 제거 — resolve_binary 가 동봉/PATH/cache fallback 후 최후에만 다운로드)
     find_sidecar_cache(name).ok_or_else(|| {
         ConverterError::Ffmpeg(format!(
             "{} binary 를 찾을 수 없습니다 (동봉 sidecar / 시스템 PATH / 다운로드 cache 모두 실패)",
@@ -128,7 +128,7 @@ pub fn ffprobe_path() -> ConverterResult<PathBuf> {
 
 /// 오디오 길이 (초)
 pub async fn probe_duration(path: &Path) -> ConverterResult<f64> {
-    ensure_ffmpeg_blocking()?;
+    // (auto_download 호출 제거 — resolve_binary 가 동봉/PATH/cache fallback 후 최후에만 다운로드)
     let output = Command::new(ffprobe_path()?)
         .args([
             "-v", "error",
@@ -157,7 +157,7 @@ pub async fn probe_duration(path: &Path) -> ConverterResult<f64> {
 pub async fn probe_recording_time(
     path: &Path,
 ) -> ConverterResult<Option<chrono::DateTime<chrono::Utc>>> {
-    ensure_ffmpeg_blocking()?;
+    // (auto_download 호출 제거 — resolve_binary 가 동봉/PATH/cache fallback 후 최후에만 다운로드)
     let output = Command::new(ffprobe_path()?)
         .args(["-v", "quiet", "-print_format", "json", "-show_format"])
         .arg(path)
@@ -217,7 +217,7 @@ pub async fn split_audio_to_chunks(
     input: &Path,
     chunk_duration_sec: f64,
 ) -> ConverterResult<Vec<AudioChunk>> {
-    ensure_ffmpeg_blocking()?;
+    // (auto_download 호출 제거 — resolve_binary 가 동봉/PATH/cache fallback 후 최후에만 다운로드)
     let duration = probe_duration(input).await?;
     let num_chunks = (duration / chunk_duration_sec).ceil() as usize;
 

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -95,8 +95,11 @@ pub fn get_conversions_dir() -> String {
 #[tauri::command]
 pub fn extract_speakers(paths: Vec<String>) -> Result<Vec<String>, String> {
     use std::collections::BTreeSet;
+    // bold 마커 필수 + timestamp optional — timestamped 와 clean 두 형식 모두 매치
+    //   timestamped: `**[00:05:00] 화자A:**`
+    //   clean:       `**화자A:**`
     let re = regex::Regex::new(
-        r"\*?\*?\[\d{1,2}:\d{2}(?::\d{2})?\]\s+([^\*\n:]+?):",
+        r"\*\*(?:\[\d{1,2}:\d{2}(?::\d{2})?\]\s+)?([^\*\n:]+?):\*\*",
     )
     .map_err(|e| e.to_string())?;
 
@@ -228,9 +231,11 @@ pub fn rename_speakers(
         let original = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
         let mut out = String::with_capacity(original.len());
 
-        // 라벨 헤더 정규식 — bold 유무, HH:MM[:SS] 둘 다 매치
+        // 라벨 헤더 정규식 — bold 마커 필수, timestamp optional
+        //   timestamped: `**[00:05:00] 화자A:**` + 본문
+        //   clean:       `**화자A:**` + 본문
         let header_re = regex::Regex::new(
-            r"^(?P<prefix>\*?\*?\[\d{1,2}:\d{2}(?::\d{2})?\]\s+)(?P<label>[^\*\n:]+?)(?P<suffix>:\*?\*?)\s*(?P<rest>.*)$",
+            r"^(?P<prefix>\*\*(?:\[\d{1,2}:\d{2}(?::\d{2})?\]\s+)?)(?P<label>[^\*\n:]+?)(?P<suffix>:\*\*)\s*(?P<rest>.*)$",
         )
         .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/converters/progress.rs
+++ b/src-tauri/src/converters/progress.rs
@@ -21,6 +21,7 @@ pub struct ProgressStep {
     pub progress: Option<f32>,
 }
 
+#[derive(Clone)]
 pub struct ProgressEmitter {
     app: AppHandle,
     job_id: String,

--- a/src/App.css
+++ b/src/App.css
@@ -1595,6 +1595,12 @@ body.is-resizing .split-pane {
   position: relative;
   display: inline-flex;
 }
+.bg-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+  background: transparent;
+}
 .bg-picker-popover {
   position: absolute;
   top: calc(100% + 6px);

--- a/src/App.css
+++ b/src/App.css
@@ -1640,21 +1640,10 @@ body.is-resizing .split-pane {
   border: 2px solid var(--accent);
   box-shadow: 0 0 0 2px var(--bg-primary), 0 0 0 3px var(--accent);
 }
-/* "no color" (테마 기본) swatch — 항상 light 회색 base + 명확한 checker.
-   dark mode 에서도 일관되게 보이도록 background-color 명시. */
-.bg-picker-swatch[style*="transparent"] {
-  background-color: #f5f5f5;
-  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
-                    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-                    linear-gradient(45deg, transparent 75%, #ccc 75%),
-                    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size: 8px 8px;
-  background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
-  color: #333;
-}
-/* dark theme 에서도 흰색 — "기본으로 되돌리면 라이트로 복귀" 시각 메시지 통일 */
-[data-theme="dark"] .bg-picker-swatch[style*="transparent"] {
-  background-color: #f5f5f5;
+/* "no color" (테마 기본) swatch — 항상 흰색 base + checker.
+   light/dark theme 무관 일관 — "기본으로 되돌리면 라이트 복귀" 시각 메시지. */
+.bg-picker-swatch.no-color {
+  background-color: #ffffff;
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
                     linear-gradient(-45deg, #ccc 25%, transparent 25%),
                     linear-gradient(45deg, transparent 75%, #ccc 75%),

--- a/src/App.css
+++ b/src/App.css
@@ -1581,6 +1581,100 @@ body.is-resizing .split-pane {
 .tiptap-rich h5 { font-size: 1em; }
 .tiptap-rich h6 { font-size: 0.9em; color: var(--text-secondary); }
 
+/* List bullet/번호 ::marker 크게 — 가독성 (task list 제외) */
+.markdown-body ul:not([data-type="taskList"]) li::marker,
+.markdown-body ol li::marker,
+.tiptap-rich ul:not([data-type="taskList"]) li::marker,
+.tiptap-rich ol li::marker {
+  font-size: 1.25em;
+  color: var(--text-secondary);
+}
+
+/* === Background color picker === */
+.bg-picker-root {
+  position: relative;
+  display: inline-flex;
+}
+.bg-picker-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 50;
+  width: 200px;
+  padding: 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+  animation: fade-in 0.12s ease;
+}
+.bg-picker-presets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.bg-picker-swatch {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  transition: transform 0.1s, border-color 0.1s;
+}
+.bg-picker-swatch:hover {
+  transform: scale(1.05);
+  border-color: var(--accent);
+}
+.bg-picker-swatch.active {
+  border: 2px solid var(--accent);
+  box-shadow: 0 0 0 2px var(--bg-primary), 0 0 0 3px var(--accent);
+}
+.bg-picker-swatch[style*="transparent"] {
+  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+                    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #ccc 75%),
+                    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
+}
+.bg-picker-custom {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.bg-picker-custom input[type="color"] {
+  width: 32px;
+  height: 24px;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  background: none;
+}
+
+/* 행간 toolbar 버튼 — 현재 값 라벨 */
+.toolbar-lineheight-btn {
+  width: auto !important;
+  padding: 0 6px !important;
+  gap: 4px;
+}
+.toolbar-lineheight-value {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
 /* 행간 (App root 의 data-line-height attribute 로 cycle) */
 [data-line-height="compact"] .markdown-body,
 [data-line-height="compact"] .tiptap-rich { line-height: 1.5; }
@@ -1608,7 +1702,7 @@ body.is-resizing .split-pane {
   -moz-appearance: none;
   width: 18px;
   height: 18px;
-  border: 1.5px solid var(--text-secondary, #999);
+  border: 1px solid var(--text-secondary, #999);
   border-radius: 0;
   background: var(--bg-primary);
   margin: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -566,6 +566,16 @@ body {
   outline: 1.5px solid rgba(255, 140, 0, 0.9);
 }
 
+/* TipTap search-and-replace 의 highlight (Rich Text 모드) */
+.rich-search-highlight {
+  background: rgba(255, 200, 0, 0.35);
+  border-radius: 2px;
+}
+.search-result-current {
+  background: rgba(255, 140, 0, 0.7);
+  outline: 1.5px solid rgba(255, 140, 0, 0.9);
+}
+
 .search-count-empty {
   color: var(--text-tertiary);
   opacity: 0.6;
@@ -1549,6 +1559,13 @@ body.is-resizing .split-pane {
 .link-modal-actions button.primary {
   background: var(--accent); color: white; border-color: var(--accent);
 }
+.link-modal-actions button.danger {
+  color: #dc2626; border-color: rgba(220, 38, 38, 0.4);
+  margin-right: auto; /* 왼쪽 정렬 — 취소/적용과 시각적 분리 */
+}
+.link-modal-actions button.danger:hover {
+  background: rgba(220, 38, 38, 0.08);
+}
 .link-modal-actions button:hover { filter: brightness(1.08); }
 
 /* TipTap WYSIWYG 영역 */
@@ -1572,12 +1589,37 @@ body.is-resizing .split-pane {
 }
 .tiptap-rich ul[data-type="taskList"] li {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline; /* 텍스트 첫 줄 baseline 기준 — 세로 어긋남 fix */
   gap: 8px;
 }
 .tiptap-rich ul[data-type="taskList"] li > label {
   flex-shrink: 0;
-  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  height: 1.5em; /* line-height 와 동일 → 체크박스가 첫 줄 가운데 */
+}
+.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"] {
+  margin: 0;
+  vertical-align: middle;
+}
+.tiptap-rich ul[data-type="taskList"] li > div {
+  flex: 1;
+  min-width: 0;
+}
+.tiptap-rich ul[data-type="taskList"] li > div > p {
+  margin: 0;
+}
+
+/* ReadOnlyView (react-markdown) 의 GFM task list 정렬 */
+.markdown-body ul li input[type="checkbox"] {
+  margin: 0 6px 0 0;
+  vertical-align: middle;
+  position: relative;
+  top: -1px; /* 체크박스가 살짝 아래로 보이는 시각 보정 */
+}
+.markdown-body ul li.task-list-item,
+.markdown-body ul li:has(> input[type="checkbox"]) {
+  list-style: none;
 }
 .tiptap-rich table {
   border-collapse: collapse;

--- a/src/App.css
+++ b/src/App.css
@@ -1652,15 +1652,16 @@ body.is-resizing .split-pane {
   background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
   color: #333;
 }
+/* dark theme 에서도 흰색 — "기본으로 되돌리면 라이트로 복귀" 시각 메시지 통일 */
 [data-theme="dark"] .bg-picker-swatch[style*="transparent"] {
-  background-color: #555;
-  background-image: linear-gradient(45deg, #888 25%, transparent 25%),
-                    linear-gradient(-45deg, #888 25%, transparent 25%),
-                    linear-gradient(45deg, transparent 75%, #888 75%),
-                    linear-gradient(-45deg, transparent 75%, #888 75%);
+  background-color: #f5f5f5;
+  background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
+                    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #ccc 75%),
+                    linear-gradient(-45deg, transparent 75%, #ccc 75%);
   background-size: 8px 8px;
   background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
-  color: #fff;
+  color: #333;
 }
 .bg-picker-custom {
   margin-top: 10px;

--- a/src/App.css
+++ b/src/App.css
@@ -1640,13 +1640,27 @@ body.is-resizing .split-pane {
   border: 2px solid var(--accent);
   box-shadow: 0 0 0 2px var(--bg-primary), 0 0 0 3px var(--accent);
 }
+/* "no color" (테마 기본) swatch — 항상 light 회색 base + 명확한 checker.
+   dark mode 에서도 일관되게 보이도록 background-color 명시. */
 .bg-picker-swatch[style*="transparent"] {
+  background-color: #f5f5f5;
   background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
                     linear-gradient(-45deg, #ccc 25%, transparent 25%),
                     linear-gradient(45deg, transparent 75%, #ccc 75%),
                     linear-gradient(-45deg, transparent 75%, #ccc 75%);
   background-size: 8px 8px;
   background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
+  color: #333;
+}
+[data-theme="dark"] .bg-picker-swatch[style*="transparent"] {
+  background-color: #555;
+  background-image: linear-gradient(45deg, #888 25%, transparent 25%),
+                    linear-gradient(-45deg, #888 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #888 75%),
+                    linear-gradient(-45deg, transparent 75%, #888 75%);
+  background-size: 8px 8px;
+  background-position: 0 0, 0 4px, 4px -4px, -4px 0px;
+  color: #fff;
 }
 .bg-picker-custom {
   margin-top: 10px;
@@ -1687,8 +1701,21 @@ body.is-resizing .split-pane {
 [data-custom-bg] .pane,
 [data-custom-bg] .cm-editor,
 [data-custom-bg] .cm-scroller,
+[data-custom-bg] .cm-gutters,
+[data-custom-bg] .cm-gutter,
+[data-custom-bg] .cm-gutterElement,
+[data-custom-bg] .cm-activeLineGutter,
 [data-custom-bg] .markdown-body {
   background: var(--user-bg) !important;
+}
+/* line number 폰트 색 — theme 변수가 자동 dark/light 갱신되므로 별도 override 불필요.
+   단 active line gutter 의 하이라이트는 너무 두드러지지 않게 半透明 */
+[data-custom-bg] .cm-activeLineGutter {
+  background: var(--user-bg) !important;
+  filter: brightness(0.95);
+}
+[data-theme="dark"][data-custom-bg] .cm-activeLineGutter {
+  filter: brightness(1.15);
 }
 
 /* 배경색에 따라 hr / blockquote / code 색 조정 (theme 가 luminance 로 dark/light 결정) */

--- a/src/App.css
+++ b/src/App.css
@@ -1573,6 +1573,21 @@ body.is-resizing .split-pane {
   outline: none;
   min-height: 300px;
 }
+/* Rich Text 의 heading 은 em 단위 — 본문 fontSize 변경 시 비례 확대 */
+.tiptap-rich h1 { font-size: 2em; letter-spacing: -0.02em; }
+.tiptap-rich h2 { font-size: 1.55em; letter-spacing: -0.01em; }
+.tiptap-rich h3 { font-size: 1.3em; }
+.tiptap-rich h4 { font-size: 1.12em; }
+.tiptap-rich h5 { font-size: 1em; }
+.tiptap-rich h6 { font-size: 0.9em; color: var(--text-secondary); }
+
+/* 행간 (App root 의 data-line-height attribute 로 cycle) */
+[data-line-height="compact"] .markdown-body,
+[data-line-height="compact"] .tiptap-rich { line-height: 1.5; }
+[data-line-height="normal"] .markdown-body,
+[data-line-height="normal"] .tiptap-rich { line-height: 1.8; }
+[data-line-height="relaxed"] .markdown-body,
+[data-line-height="relaxed"] .tiptap-rich { line-height: 2.2; }
 .tiptap-rich p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;
@@ -1583,24 +1598,68 @@ body.is-resizing .split-pane {
 .tiptap-rich:focus {
   outline: none;
 }
+/* === Task list 공통 — 커스텀 정사각형 체크박스 + 정밀 정렬 === */
+
+/* 체크박스 (Rich Text + Preview 공통) — OS default 무시, 정사각형 + radius 0 */
+.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"],
+.markdown-body ul li input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 1.5px solid var(--text-secondary, #999);
+  border-radius: 0;
+  background: var(--bg-primary);
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  transition: background 0.12s, border-color 0.12s;
+}
+.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"]:hover,
+.markdown-body ul li input[type="checkbox"]:hover {
+  border-color: var(--accent);
+}
+.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"]:checked,
+.markdown-body ul li input[type="checkbox"]:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+/* 체크마크 — 흰 ✓ */
+.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"]:checked::after,
+.markdown-body ul li input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 1px;
+  width: 5px;
+  height: 10px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  box-sizing: content-box;
+}
+
+/* === Rich Text (TipTap) 의 list layout === */
 .tiptap-rich ul[data-type="taskList"] {
   list-style: none;
   padding-left: 0;
 }
 .tiptap-rich ul[data-type="taskList"] li {
   display: flex;
-  align-items: baseline; /* 텍스트 첫 줄 baseline 기준 — 세로 어긋남 fix */
-  gap: 8px;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 4px 0;
 }
 .tiptap-rich ul[data-type="taskList"] li > label {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  height: 1.5em; /* line-height 와 동일 → 체크박스가 첫 줄 가운데 */
-}
-.tiptap-rich ul[data-type="taskList"] li > label > input[type="checkbox"] {
-  margin: 0;
-  vertical-align: middle;
+  /* line-height 의 ascent 만큼 체크박스 내림 → 텍스트 첫 줄 정중앙 정렬 */
+  height: 1.55em;
 }
 .tiptap-rich ul[data-type="taskList"] li > div {
   flex: 1;
@@ -1610,16 +1669,18 @@ body.is-resizing .split-pane {
   margin: 0;
 }
 
-/* ReadOnlyView (react-markdown) 의 GFM task list 정렬 */
-.markdown-body ul li input[type="checkbox"] {
-  margin: 0 6px 0 0;
-  vertical-align: middle;
-  position: relative;
-  top: -1px; /* 체크박스가 살짝 아래로 보이는 시각 보정 */
-}
+/* === Preview (react-markdown) 의 GFM task list layout === */
 .markdown-body ul li.task-list-item,
 .markdown-body ul li:has(> input[type="checkbox"]) {
   list-style: none;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-left: -1.4em; /* bullet 영역 제거 */
+}
+.markdown-body ul li input[type="checkbox"] {
+  /* baseline 보정 — flex container 안에서 첫 줄 정중앙 */
+  margin-top: 0.15em;
 }
 .tiptap-rich table {
   border-collapse: collapse;
@@ -1985,9 +2046,9 @@ body.is-resizing .split-pane {
 
 /* ---------- Outline Panel ---------- */
 .outline-panel {
-  width: 240px;
+  /* width 는 inline style 로 OutlinePanel 컴포넌트가 관리 */
   min-width: 160px;
-  max-width: 400px;
+  max-width: 500px;
   height: 100%;
   border-right: 1px solid var(--border-primary);
   background: var(--bg-tertiary);
@@ -1995,8 +2056,26 @@ body.is-resizing .split-pane {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  resize: horizontal;
   position: relative;
+}
+
+/* drag handle — 우측 가장자리 4px col-resize */
+.outline-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 5;
+  transition: background 0.12s;
+}
+.outline-resize-handle:hover {
+  background: var(--accent);
+}
+.outline-resize-handle:active {
+  background: var(--accent);
+  opacity: 0.7;
 }
 
 @keyframes slideIn {

--- a/src/App.css
+++ b/src/App.css
@@ -1681,6 +1681,82 @@ body.is-resizing .split-pane {
   font-weight: 500;
 }
 
+/* 사용자 정의 배경색 — content 영역만 적용 (UI chrome 영향 X) */
+[data-custom-bg] .preview-wrapper,
+[data-custom-bg] .tiptap-rich,
+[data-custom-bg] .pane,
+[data-custom-bg] .cm-editor,
+[data-custom-bg] .cm-scroller,
+[data-custom-bg] .markdown-body {
+  background: var(--user-bg) !important;
+}
+
+/* 배경색에 따라 hr / blockquote / code 색 조정 (theme 가 luminance 로 dark/light 결정) */
+/* light 배경: hr 더 진하게 (안 보이는 문제 해결) */
+[data-theme="light"] .markdown-body hr,
+[data-theme="light"] .tiptap-rich hr {
+  border: none;
+  border-top: 1px solid rgba(0, 0, 0, 0.2);
+  margin: 1.5em 0;
+}
+[data-theme="dark"] .markdown-body hr,
+[data-theme="dark"] .tiptap-rich hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  margin: 1.5em 0;
+}
+
+[data-theme="light"] .markdown-body blockquote,
+[data-theme="light"] .tiptap-rich blockquote {
+  border-left: 3px solid rgba(0, 0, 0, 0.25);
+  background: rgba(0, 0, 0, 0.04);
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  color: var(--text-secondary);
+}
+[data-theme="dark"] .markdown-body blockquote,
+[data-theme="dark"] .tiptap-rich blockquote {
+  border-left: 3px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.5em 1em;
+  margin: 1em 0;
+  color: var(--text-secondary);
+}
+
+[data-theme="light"] .markdown-body code:not(pre code),
+[data-theme="light"] .tiptap-rich code:not(pre code) {
+  background: rgba(0, 0, 0, 0.06);
+  color: #c7254e;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-size: 0.92em;
+}
+[data-theme="dark"] .markdown-body code:not(pre code),
+[data-theme="dark"] .tiptap-rich code:not(pre code) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #f78c6c;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-size: 0.92em;
+}
+
+[data-theme="light"] .markdown-body pre,
+[data-theme="light"] .tiptap-rich pre {
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  padding: 1em;
+  overflow-x: auto;
+}
+[data-theme="dark"] .markdown-body pre,
+[data-theme="dark"] .tiptap-rich pre {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 1em;
+  overflow-x: auto;
+}
+
 /* 행간 (App root 의 data-line-height attribute 로 cycle) */
 [data-line-height="compact"] .markdown-body,
 [data-line-height="compact"] .tiptap-rich { line-height: 1.5; }
@@ -2277,9 +2353,14 @@ body.is-resizing .split-pane {
 }
 
 .reading-mode-content .preview-wrapper {
-  max-width: 800px;
+  /* 사용자 요청 — 전체 폭 100% 활용 (이전 800px 제한 해제) */
+  max-width: none;
   width: 100%;
   padding: 48px 60px;
+}
+/* reading mode 의 markdown-body 도 폭 제한 해제 */
+.reading-mode-content .preview-wrapper .markdown-body {
+  max-width: none;
 }
 
 .reading-mode-hint {

--- a/src/App.css
+++ b/src/App.css
@@ -1440,6 +1440,9 @@ body.is-resizing .split-pane {
 }
 .preview-wrapper.preview-rich-mode .tiptap-rich {
   padding-bottom: 32px;
+  /* 편집 모드는 가용 폭 100% 활용 — read-only preview 의 720px 제한 override */
+  max-width: none;
+  width: auto;
 }
 
 /* 편집 toolbar — Rich Text 모드에서 main Toolbar 바로 아래 sticky 0, seamless */
@@ -1490,6 +1493,63 @@ body.is-resizing .split-pane {
   background: var(--border-primary);
   margin: 0 4px;
 }
+
+/* === Link 입력 모달 === */
+.link-modal-root { position: fixed; inset: 0; z-index: 270; }
+.link-modal-backdrop {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.35);
+  animation: fade-in 0.12s ease;
+}
+.link-modal {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: calc(100vw - 64px);
+  max-width: 480px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.25);
+  padding: 16px;
+}
+.link-modal-title {
+  font-size: 13px; font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+.link-modal input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.link-modal input:focus { outline: 1px solid var(--accent); }
+.link-modal-hint {
+  margin: 6px 0 12px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.link-modal-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+}
+.link-modal-actions button {
+  padding: 6px 14px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 13px;
+}
+.link-modal-actions button.primary {
+  background: var(--accent); color: white; border-color: var(--accent);
+}
+.link-modal-actions button:hover { filter: brightness(1.08); }
 
 /* TipTap WYSIWYG 영역 */
 .tiptap-rich {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -459,6 +459,8 @@ function App() {
       } else {
         setSearchQuery('');
         clearHighlights();
+        // Rich Text 검색 highlight 도 같이 clear
+        window.dispatchEvent(new Event('markmind:rich-search-clear'));
       }
       return next;
     });
@@ -493,11 +495,23 @@ function App() {
 
   // Navigate by delta (+1 forward, -1 backward), wrapping around
   const navigateMatch = useCallback((delta: number) => {
+    // Rich Text 모드 — TipTap search ext 명령으로 위임
+    if (viewMode === 'preview') {
+      const ev = delta > 0 ? 'markmind:rich-search-next' : 'markmind:rich-search-prev';
+      window.dispatchEvent(new Event(ev));
+      // current index UI 도 갱신 — count 가 0보다 크면 modulo
+      setSearchCurrentIndex((cur) => {
+        const total = searchMatchCount;
+        if (total === 0) return -1;
+        return (cur + delta + total) % total;
+      });
+      return;
+    }
     const matches = searchMatchesRef.current;
     if (matches.length === 0) return;
     const next = (searchCurrentIndexRef.current + delta + matches.length) % matches.length;
     goToMatchIndex(next, matches);
-  }, [goToMatchIndex]);
+  }, [goToMatchIndex, viewMode, searchMatchCount]);
 
   // Highlight all matches in the preview DOM
   const highlightMatches = useCallback((query: string) => {
@@ -575,13 +589,33 @@ function App() {
   }, []);
 
   useEffect(() => {
+    if (viewMode === 'preview') {
+      // Rich Text 모드 — DOM surroundContents 대신 RichEditor 의 TipTap search 위임
+      // (TipTap ProseMirror tree 와 직접 DOM 조작이 충돌하면 editor 깨짐)
+      window.dispatchEvent(
+        new CustomEvent('markmind:rich-search', { detail: { query: searchQuery } }),
+      );
+      return;
+    }
     if (searchQuery) {
       const timer = setTimeout(() => highlightMatches(searchQuery), 200);
       return () => clearTimeout(timer);
     } else {
       clearHighlights();
     }
-  }, [searchQuery, content, highlightMatches, clearHighlights]);
+  }, [searchQuery, content, highlightMatches, clearHighlights, viewMode]);
+
+  // Rich Text search 결과 count 회신 listen
+  useEffect(() => {
+    if (viewMode !== 'preview') return;
+    const onCount = (e: Event) => {
+      const detail = (e as CustomEvent<{ count: number }>).detail;
+      setSearchMatchCount(detail.count ?? 0);
+      setSearchCurrentIndex(detail.count > 0 ? 0 : -1);
+    };
+    window.addEventListener('markmind:rich-search-count', onCount);
+    return () => window.removeEventListener('markmind:rich-search-count', onCount);
+  }, [viewMode]);
 
   // Open recent
   const handleOpenRecent = useCallback(
@@ -671,8 +705,12 @@ function App() {
             resetFontSize();
             break;
           case 'i':
-            e.preventDefault();
-            handleToggleAI();
+          case 'I':
+            // ⌘⇧I 만 AI Agent 토글 — ⌘I (shift 없음) 은 TipTap Italic 과 충돌 회피
+            if (e.shiftKey) {
+              e.preventDefault();
+              handleToggleAI();
+            }
             break;
         }
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const FONT_SIZE_MAX = 28;
 const FONT_SIZE_DEFAULT = 14;
 
 function App() {
-  const { theme, toggleTheme } = useTheme();
+  const { theme, toggleTheme, setTheme } = useTheme();
   const auth = useAuth();
   const [isAuthCallback, setIsAuthCallback] = useState(
     () => window.location.pathname === getCallbackPath()
@@ -99,6 +99,28 @@ function App() {
     if (bgColor) localStorage.setItem('markmind-bg-color', bgColor);
     else localStorage.removeItem('markmind-bg-color');
   }, [bgColor]);
+
+  // 배경색의 상대 휘도 (0~1). 0.5 미만이면 어두운 배경 → 텍스트 반전 필요.
+  // WCAG relative luminance (sRGB).
+  const luminance = (() => {
+    if (!bgColor) return null;
+    const hex = bgColor.replace('#', '');
+    if (hex.length !== 3 && hex.length !== 6) return null;
+    const full = hex.length === 3 ? hex.split('').map((c) => c + c).join('') : hex;
+    const r = parseInt(full.slice(0, 2), 16) / 255;
+    const g = parseInt(full.slice(2, 4), 16) / 255;
+    const b = parseInt(full.slice(4, 6), 16) / 255;
+    const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  })();
+  const isDarkBg = luminance != null ? luminance < 0.5 : theme === 'dark';
+
+  // 배경색 변경 시 theme 자동 동기화 — 통합 동작
+  // (dark 배경 선택 시 자동 dark theme, light 배경 선택 시 light)
+  useEffect(() => {
+    if (luminance == null) return; // 'theme 기본' 으로 되돌리면 마지막 theme 유지
+    setTheme(luminance < 0.5 ? 'dark' : 'light');
+  }, [luminance, setTheme]);
   const [outlineVisible, setOutlineVisible] = useState(false);
   const [readingMode, setReadingMode] = useState(false);
   const [tutorialVisible, setTutorialVisible] = useState(false);
@@ -627,13 +649,13 @@ function App() {
     }
   }, [searchQuery, content, highlightMatches, clearHighlights, viewMode]);
 
-  // Rich Text search 결과 count 회신 listen
+  // Rich Text search 결과 count + 현재 index 회신 listen
   useEffect(() => {
     if (viewMode !== 'preview') return;
     const onCount = (e: Event) => {
-      const detail = (e as CustomEvent<{ count: number }>).detail;
+      const detail = (e as CustomEvent<{ count: number; index: number }>).detail;
       setSearchMatchCount(detail.count ?? 0);
-      setSearchCurrentIndex(detail.count > 0 ? 0 : -1);
+      setSearchCurrentIndex(detail.count > 0 ? (detail.index ?? 0) : -1);
     };
     window.addEventListener('markmind:rich-search-count', onCount);
     return () => window.removeEventListener('markmind:rich-search-count', onCount);
@@ -828,6 +850,7 @@ function App() {
     <div
       className="app"
       data-line-height={lineHeight}
+      data-bg-dark={isDarkBg ? 'true' : undefined}
       style={
         bgColor
           ? ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,8 @@ function App() {
   const searchCurrentIndexRef = useRef(-1);
   const isDragging = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // viewMode 전환 시 scroll 위치 보존 — Markdown(CodeMirror) ↔ Rich Text(.preview-wrapper) ↔ Split
+  const scrollRatioRef = useRef<number>(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<EditorHandle>(null);
 
@@ -374,6 +376,47 @@ function App() {
       reattach();
     }
   }, [viewMode, reattach]);
+
+  // viewMode 전환 시 scroll 위치 보존 (Markdown ↔ Rich Text).
+  // 이전 모드의 scroll 비율을 기억해 새 모드의 같은 비율 위치로 자동 이동.
+  // 추적 element: editor → .cm-scroller, preview → .preview-wrapper.
+  useEffect(() => {
+    const scrollEl = (): HTMLElement | null => {
+      const root = containerRef.current;
+      if (!root) return null;
+      if (viewMode === 'editor') return root.querySelector<HTMLElement>('.cm-scroller');
+      if (viewMode === 'preview') return root.querySelector<HTMLElement>('.preview-wrapper');
+      // split — 보존 안 함 (양쪽 모두 보임)
+      return null;
+    };
+
+    // mount 직후 — 이전에 저장된 ratio 로 새 element 의 scrollTop 복원.
+    // 마운트 + content 렌더 후 scrollHeight 가 안정되도록 두 번 시도.
+    const restore = () => {
+      const el = scrollEl();
+      if (!el) return;
+      const max = el.scrollHeight - el.clientHeight;
+      if (max > 0) el.scrollTop = Math.round(max * scrollRatioRef.current);
+    };
+    restore();
+    const t1 = window.setTimeout(restore, 50);
+    const t2 = window.setTimeout(restore, 200);
+
+    // 이 mode 가 활성인 동안 scroll 변화를 ratio 로 추적.
+    const tracker = () => {
+      const el = scrollEl();
+      if (!el) return;
+      const max = el.scrollHeight - el.clientHeight;
+      if (max > 0) scrollRatioRef.current = el.scrollTop / max;
+    };
+    const el = scrollEl();
+    el?.addEventListener('scroll', tracker, { passive: true });
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+      el?.removeEventListener('scroll', tracker);
+    };
+  }, [viewMode]);
 
   // Font size
   const handleFontSizeChange = useCallback((delta: number) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,20 +159,19 @@ function App() {
     setOcrPanelVisible(false);
   }, []);
 
-  const ensureEditorView = useCallback(() => {
-    if (viewMode !== 'editor') {
-      setViewMode('editor');
-      setReadingMode(false);
-    }
-  }, [viewMode]);
+  // 사이드 패널 열 때 reading mode 만 해제 — 현재 viewMode 는 그대로 유지
+  // (이전엔 강제로 editor 모드로 전환했으나 사용자 의도와 어긋남)
+  const exitReadingMode = useCallback(() => {
+    if (readingMode) setReadingMode(false);
+  }, [readingMode]);
 
   const handleToggleAI = useCallback(() => {
     if (!ai.panelVisible) {
-      ensureEditorView();
+      exitReadingMode();
       closeAllConvertPanels();
     }
     ai.togglePanel();
-  }, [ai, ensureEditorView, closeAllConvertPanels]);
+  }, [ai, exitReadingMode, closeAllConvertPanels]);
 
   const handleToggleAudio = useCallback(() => {
     if (audioPanelVisible) {
@@ -180,10 +179,10 @@ function App() {
     } else {
       if (ai.panelVisible) ai.togglePanel();
       setOcrPanelVisible(false);
-      ensureEditorView();
+      exitReadingMode();
       setAudioPanelVisible(true);
     }
-  }, [audioPanelVisible, ai, ensureEditorView]);
+  }, [audioPanelVisible, ai, exitReadingMode]);
 
   const handleToggleOcr = useCallback(() => {
     if (ocrPanelVisible) {
@@ -191,10 +190,10 @@ function App() {
     } else {
       if (ai.panelVisible) ai.togglePanel();
       setAudioPanelVisible(false);
-      ensureEditorView();
+      exitReadingMode();
       setOcrPanelVisible(true);
     }
-  }, [ocrPanelVisible, ai, ensureEditorView]);
+  }, [ocrPanelVisible, ai, exitReadingMode]);
 
   // 사이드바로 drop된 파일을 자식 컴포넌트에 전달하기 위한 state
   const [audioDropped, setAudioDropped] = useState<DroppedFile | null>(null);
@@ -834,7 +833,20 @@ function App() {
   // Reading mode
   if (readingMode) {
     return (
-      <div className="app reading-mode" onClick={() => setReadingMode(false)}>
+      <div
+        className="app reading-mode"
+        data-line-height={lineHeight}
+        style={
+          bgColor
+            ? ({
+                '--user-bg': bgColor,
+                '--preview-bg': bgColor,
+              } as React.CSSProperties)
+            : undefined
+        }
+        data-custom-bg={bgColor ? 'true' : undefined}
+        onClick={() => setReadingMode(false)}
+      >
         <div className="reading-mode-content" onClick={(e) => e.stopPropagation()}>
           <Preview content={content} fontSize={fontSize + 2} />
         </div>
@@ -868,11 +880,13 @@ function App() {
       style={
         bgColor
           ? ({
+              // content 영역만 적용 — UI chrome (popover/AIPanel/Toolbar) 영향 X
+              '--user-bg': bgColor,
               '--preview-bg': bgColor,
-              '--bg-primary': bgColor,
             } as React.CSSProperties)
           : undefined
       }
+      data-custom-bg={bgColor ? 'true' : undefined}
     >
       <div
         className="titlebar-drag"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const FONT_SIZE_MAX = 28;
 const FONT_SIZE_DEFAULT = 14;
 
 function App() {
-  const { theme, toggleTheme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const auth = useAuth();
   const [isAuthCallback, setIsAuthCallback] = useState(
     () => window.location.pathname === getCallbackPath()
@@ -878,11 +878,9 @@ function App() {
         fileName={fileName}
         isDirty={isDirty}
         viewMode={viewMode}
-        theme={theme}
         fontSize={fontSize}
         outlineVisible={outlineVisible}
         onViewModeChange={setViewMode}
-        onThemeToggle={toggleTheme}
         onNewFile={newFile}
         onOpenFile={openFile}
         onSaveFile={saveFile}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,11 +72,24 @@ function App() {
     setViewMode('preview');
     setReadingMode(false);
   };
-  const { syncEnabled, toggleSync, reattach } = useScrollSync(false);
+  const { syncEnabled, toggleSync, reattach } = useScrollSync(true);
   const [fontSize, setFontSize] = useState(() => {
     const saved = localStorage.getItem('md-editor-font-size');
     return saved ? parseInt(saved, 10) : FONT_SIZE_DEFAULT;
   });
+  // 행간 — compact (1.5) / normal (1.8) / relaxed (2.2) cycle, localStorage 보존
+  const [lineHeight, setLineHeight] = useState<'compact' | 'normal' | 'relaxed'>(() => {
+    const v = localStorage.getItem('markmind-line-height');
+    return v === 'compact' || v === 'relaxed' ? v : 'normal';
+  });
+  useEffect(() => {
+    localStorage.setItem('markmind-line-height', lineHeight);
+  }, [lineHeight]);
+  const cycleLineHeight = () => {
+    setLineHeight((prev) =>
+      prev === 'compact' ? 'normal' : prev === 'normal' ? 'relaxed' : 'compact',
+    );
+  };
   const [outlineVisible, setOutlineVisible] = useState(false);
   const [readingMode, setReadingMode] = useState(false);
   const [tutorialVisible, setTutorialVisible] = useState(false);
@@ -803,7 +816,7 @@ function App() {
   }
 
   return (
-    <div className="app">
+    <div className="app" data-line-height={lineHeight}>
       <div
         className="titlebar-drag"
         onMouseDown={(e) => {
@@ -837,6 +850,8 @@ function App() {
         onSaveToDrive={() => setDriveBrowserMode('save')}
         onFontSizeChange={handleFontSizeChange}
         onFontSizeReset={resetFontSize}
+        lineHeight={lineHeight}
+        onCycleLineHeight={cycleLineHeight}
         onToggleOutline={() => setOutlineVisible((v) => !v)}
         onToggleReadingMode={toggleReadingMode}
         onToggleRecentFiles={() => setRecentPanelVisible((v) => !v)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { AIMode } from './types/ai';
 import { Editor, EditorHandle } from './components/Editor';
 import { Preview } from './components/Preview';
@@ -38,7 +38,7 @@ const FONT_SIZE_MAX = 28;
 const FONT_SIZE_DEFAULT = 14;
 
 function App() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setThemeTransient, resetThemeToOS } = useTheme();
   const auth = useAuth();
   const [isAuthCallback, setIsAuthCallback] = useState(
     () => window.location.pathname === getCallbackPath()
@@ -100,9 +100,8 @@ function App() {
     else localStorage.removeItem('markmind-bg-color');
   }, [bgColor]);
 
-  // 배경색의 상대 휘도 (0~1). 0.5 미만이면 어두운 배경 → 텍스트 반전 필요.
-  // WCAG relative luminance (sRGB).
-  const luminance = (() => {
+  // 배경색의 WCAG 상대 휘도 (0~1). 0.5 미만이면 dark 텍스트가 안 보임 → theme dark 로.
+  const luminance = useMemo(() => {
     if (!bgColor) return null;
     const hex = bgColor.replace('#', '');
     if (hex.length !== 3 && hex.length !== 6) return null;
@@ -112,15 +111,18 @@ function App() {
     const b = parseInt(full.slice(4, 6), 16) / 255;
     const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
     return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
-  })();
-  const isDarkBg = luminance != null ? luminance < 0.5 : theme === 'dark';
+  }, [bgColor]);
 
-  // 배경색 변경 시 theme 자동 동기화 — 통합 동작
-  // (dark 배경 선택 시 자동 dark theme, light 배경 선택 시 light)
+  // bgColor 변경 시 theme transient 동기화 (localStorage 안 건드림 → 다음 세션 OS follow 유지).
+  // bgColor='' (기본) 으로 되돌리면 OS prefers-color-scheme 으로 복귀 — 사용자가 dark bg 후
+  // "기본" 골라도 dark theme 에 갇히지 않음.
   useEffect(() => {
-    if (luminance == null) return; // 'theme 기본' 으로 되돌리면 마지막 theme 유지
-    setTheme(luminance < 0.5 ? 'dark' : 'light');
-  }, [luminance, setTheme]);
+    if (luminance == null) {
+      resetThemeToOS();
+      return;
+    }
+    setThemeTransient(luminance < 0.5 ? 'dark' : 'light');
+  }, [luminance, setThemeTransient, resetThemeToOS]);
   const [outlineVisible, setOutlineVisible] = useState(false);
   const [readingMode, setReadingMode] = useState(false);
   const [tutorialVisible, setTutorialVisible] = useState(false);
@@ -435,7 +437,7 @@ function App() {
     };
 
     // mount 직후 — 이전에 저장된 ratio 로 새 element 의 scrollTop 복원.
-    // 마운트 + content 렌더 후 scrollHeight 가 안정되도록 두 번 시도.
+    // ResizeObserver 로 scrollHeight 변화 감지 → 안정될 때까지 자동 재시도 (매직 timeout 제거).
     const restore = () => {
       const el = scrollEl();
       if (!el) return;
@@ -443,21 +445,34 @@ function App() {
       if (max > 0) el.scrollTop = Math.round(max * scrollRatioRef.current);
     };
     restore();
-    const t1 = window.setTimeout(restore, 50);
-    const t2 = window.setTimeout(restore, 200);
+
+    const el = scrollEl();
+    let restored = false;
+    let ro: ResizeObserver | null = null;
+    if (el && typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => {
+        if (restored) return;
+        const max = el.scrollHeight - el.clientHeight;
+        if (max > 0) {
+          el.scrollTop = Math.round(max * scrollRatioRef.current);
+          restored = true;
+          ro?.disconnect();
+        }
+      });
+      // 내부 콘텐츠 영역의 첫 자식을 관찰 (Editor pane 의 .cm-content 또는 preview-wrapper 의 .markdown-body)
+      const inner = el.firstElementChild;
+      if (inner) ro.observe(inner);
+    }
 
     // 이 mode 가 활성인 동안 scroll 변화를 ratio 로 추적.
     const tracker = () => {
-      const el = scrollEl();
       if (!el) return;
       const max = el.scrollHeight - el.clientHeight;
       if (max > 0) scrollRatioRef.current = el.scrollTop / max;
     };
-    const el = scrollEl();
     el?.addEventListener('scroll', tracker, { passive: true });
     return () => {
-      window.clearTimeout(t1);
-      window.clearTimeout(t2);
+      ro?.disconnect();
       el?.removeEventListener('scroll', tracker);
     };
   }, [viewMode]);
@@ -698,7 +713,10 @@ function App() {
       }
 
       if (e.metaKey || e.ctrlKey) {
-        switch (e.key) {
+        // shift 누르면 e.key 가 대문자 ('S') 또는 다른 글자 ('+' → '=') 로 바뀜 →
+        // 일관 매칭 위해 letter 만 toLowerCase. 숫자/기호는 e.key 그대로.
+        const k = e.key.length === 1 && /[a-zA-Z]/.test(e.key) ? e.key.toLowerCase() : e.key;
+        switch (k) {
           case 's':
             e.preventDefault();
             if (e.shiftKey) saveFileAs();
@@ -713,12 +731,10 @@ function App() {
             newFile();
             break;
           case 'f':
-            // Only intercept for preview mode
             if (viewMode === 'preview') {
               e.preventDefault();
               toggleSearch();
             }
-            // In editor/split mode, let CodeMirror handle ⌘F
             break;
           case '1':
             e.preventDefault();
@@ -749,8 +765,7 @@ function App() {
             resetFontSize();
             break;
           case 'i':
-          case 'I':
-            // ⌘⇧I 만 AI Agent 토글 — ⌘I (shift 없음) 은 TipTap Italic 과 충돌 회피
+            // ⌘⇧I 만 AI Agent 토글 — ⌘I 는 TipTap Italic 과 충돌 회피
             if (e.shiftKey) {
               e.preventDefault();
               handleToggleAI();
@@ -850,7 +865,6 @@ function App() {
     <div
       className="app"
       data-line-height={lineHeight}
-      data-bg-dark={isDarkBg ? 'true' : undefined}
       style={
         bgColor
           ? ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,15 @@ function App() {
       prev === 'compact' ? 'normal' : prev === 'normal' ? 'relaxed' : 'compact',
     );
   };
+
+  // 배경색 — 빈 문자열 = 테마 기본, 그 외엔 사용자 지정 CSS color
+  const [bgColor, setBgColor] = useState<string>(
+    () => localStorage.getItem('markmind-bg-color') || '',
+  );
+  useEffect(() => {
+    if (bgColor) localStorage.setItem('markmind-bg-color', bgColor);
+    else localStorage.removeItem('markmind-bg-color');
+  }, [bgColor]);
   const [outlineVisible, setOutlineVisible] = useState(false);
   const [readingMode, setReadingMode] = useState(false);
   const [tutorialVisible, setTutorialVisible] = useState(false);
@@ -816,7 +825,18 @@ function App() {
   }
 
   return (
-    <div className="app" data-line-height={lineHeight}>
+    <div
+      className="app"
+      data-line-height={lineHeight}
+      style={
+        bgColor
+          ? ({
+              '--preview-bg': bgColor,
+              '--bg-primary': bgColor,
+            } as React.CSSProperties)
+          : undefined
+      }
+    >
       <div
         className="titlebar-drag"
         onMouseDown={(e) => {
@@ -852,6 +872,8 @@ function App() {
         onFontSizeReset={resetFontSize}
         lineHeight={lineHeight}
         onCycleLineHeight={cycleLineHeight}
+        bgColor={bgColor}
+        onBgColorChange={setBgColor}
         onToggleOutline={() => setOutlineVisible((v) => !v)}
         onToggleReadingMode={toggleReadingMode}
         onToggleRecentFiles={() => setRecentPanelVisible((v) => !v)}

--- a/src/components/BackgroundPicker.tsx
+++ b/src/components/BackgroundPicker.tsx
@@ -60,10 +60,11 @@ export function BackgroundPicker({ value, onChange }: BackgroundPickerProps) {
                             return (
                                 <button
                                     key={p.label}
-                                    className={`bg-picker-swatch${active ? ' active' : ''}`}
-                                    style={{
-                                        background: p.color || 'transparent',
-                                    }}
+                                    className={`bg-picker-swatch${active ? ' active' : ''}${
+                                        p.color === '' ? ' no-color' : ''
+                                    }`}
+                                    // p.color 가 있을 때만 inline style — '' 면 CSS class 가 background 담당
+                                    style={p.color ? { background: p.color } : undefined}
                                     onClick={() => {
                                         onChange(p.color);
                                         setOpen(false);

--- a/src/components/BackgroundPicker.tsx
+++ b/src/components/BackgroundPicker.tsx
@@ -3,7 +3,7 @@
  * preset swatches + native color input + 기본(테마) 리셋.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Palette, Check, X } from 'lucide-react';
 
 interface BackgroundPickerProps {
@@ -25,27 +25,19 @@ const PRESETS: { label: string; color: string }[] = [
 
 export function BackgroundPicker({ value, onChange }: BackgroundPickerProps) {
     const [open, setOpen] = useState(false);
-    const rootRef = useRef<HTMLDivElement>(null);
 
-    // 외부 클릭 시 닫기
+    // Esc 닫기 (외부 탭 닫기는 invisible backdrop div 가 처리 — iOS Safari 호환)
     useEffect(() => {
         if (!open) return;
-        const onDocClick = (e: MouseEvent) => {
-            if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
-        };
         const onKey = (e: KeyboardEvent) => {
             if (e.key === 'Escape') setOpen(false);
         };
-        document.addEventListener('mousedown', onDocClick);
         window.addEventListener('keydown', onKey);
-        return () => {
-            document.removeEventListener('mousedown', onDocClick);
-            window.removeEventListener('keydown', onKey);
-        };
+        return () => window.removeEventListener('keydown', onKey);
     }, [open]);
 
     return (
-        <div className="bg-picker-root" ref={rootRef}>
+        <div className="bg-picker-root">
             <button
                 className={`toolbar-btn${open ? ' active' : ''}`}
                 onClick={() => setOpen((v) => !v)}
@@ -54,6 +46,13 @@ export function BackgroundPicker({ value, onChange }: BackgroundPickerProps) {
                 <Palette size={15} strokeWidth={1.5} />
             </button>
             {open && (
+                <>
+                    {/* iOS Safari 호환 — document mousedown 대신 invisible backdrop div */}
+                    <div
+                        className="bg-picker-backdrop"
+                        onClick={() => setOpen(false)}
+                        aria-hidden
+                    />
                 <div className="bg-picker-popover">
                     <div className="bg-picker-presets">
                         {PRESETS.map((p) => {
@@ -86,6 +85,7 @@ export function BackgroundPicker({ value, onChange }: BackgroundPickerProps) {
                         />
                     </label>
                 </div>
+                </>
             )}
         </div>
     );

--- a/src/components/BackgroundPicker.tsx
+++ b/src/components/BackgroundPicker.tsx
@@ -1,0 +1,92 @@
+/**
+ * 배경색 picker — toolbar 의 Palette 버튼 클릭 시 작은 popover.
+ * preset swatches + native color input + 기본(테마) 리셋.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Palette, Check, X } from 'lucide-react';
+
+interface BackgroundPickerProps {
+    value: string; // '' = 테마 기본, 그 외 CSS color
+    onChange: (color: string) => void;
+}
+
+// 일반적인 reading 배경 preset (sepia, paper, soft tints)
+const PRESETS: { label: string; color: string }[] = [
+    { label: '기본', color: '' },
+    { label: '종이', color: '#f4ecd8' },
+    { label: '회색', color: '#f5f5f5' },
+    { label: '연두', color: '#eef5ec' },
+    { label: '하늘', color: '#eaf2f8' },
+    { label: '연분홍', color: '#fbeef0' },
+    { label: '다크', color: '#1f2128' },
+    { label: '진청', color: '#1a2332' },
+];
+
+export function BackgroundPicker({ value, onChange }: BackgroundPickerProps) {
+    const [open, setOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
+
+    // 외부 클릭 시 닫기
+    useEffect(() => {
+        if (!open) return;
+        const onDocClick = (e: MouseEvent) => {
+            if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('mousedown', onDocClick);
+        window.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onDocClick);
+            window.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    return (
+        <div className="bg-picker-root" ref={rootRef}>
+            <button
+                className={`toolbar-btn${open ? ' active' : ''}`}
+                onClick={() => setOpen((v) => !v)}
+                title="배경색 설정"
+            >
+                <Palette size={15} strokeWidth={1.5} />
+            </button>
+            {open && (
+                <div className="bg-picker-popover">
+                    <div className="bg-picker-presets">
+                        {PRESETS.map((p) => {
+                            const active = p.color === value;
+                            return (
+                                <button
+                                    key={p.label}
+                                    className={`bg-picker-swatch${active ? ' active' : ''}`}
+                                    style={{
+                                        background: p.color || 'transparent',
+                                    }}
+                                    onClick={() => {
+                                        onChange(p.color);
+                                        setOpen(false);
+                                    }}
+                                    title={p.label}
+                                >
+                                    {p.color === '' && <X size={12} />}
+                                    {active && p.color !== '' && <Check size={12} color="#000" />}
+                                </button>
+                            );
+                        })}
+                    </div>
+                    <label className="bg-picker-custom">
+                        <span>사용자 정의</span>
+                        <input
+                            type="color"
+                            value={value || '#ffffff'}
+                            onChange={(e) => onChange(e.target.value)}
+                        />
+                    </label>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/OutlinePanel.tsx
+++ b/src/components/OutlinePanel.tsx
@@ -31,11 +31,14 @@ export function OutlinePanel({ content, visible, onHeadingClick }: OutlinePanelP
         return saved >= MIN_WIDTH && saved <= MAX_WIDTH ? saved : DEFAULT_WIDTH;
     });
     const draggingRef = useRef(false);
+    const panelRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         const onMove = (e: MouseEvent) => {
             if (!draggingRef.current) return;
-            const next = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, e.clientX));
+            // panel 의 left edge 기준 상대좌표 — outline 이 좌측 끝이 아닐 때도 동작
+            const left = panelRef.current?.getBoundingClientRect().left ?? 0;
+            const next = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, e.clientX - left));
             setWidth(next);
         };
         const onUp = () => {
@@ -111,7 +114,7 @@ export function OutlinePanel({ content, visible, onHeadingClick }: OutlinePanelP
     };
 
     return (
-        <div className="outline-panel" style={{ width }}>
+        <div ref={panelRef} className="outline-panel" style={{ width }}>
             <div className="outline-header">Outline</div>
             <div className="outline-list">
                 {headings.length === 0 ? (

--- a/src/components/OutlinePanel.tsx
+++ b/src/components/OutlinePanel.tsx
@@ -1,4 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const LS_WIDTH_KEY = 'markmind-outline-width';
+const MIN_WIDTH = 160;
+const MAX_WIDTH = 500;
+const DEFAULT_WIDTH = 240;
 
 interface OutlineItem {
     level: number;
@@ -20,6 +25,46 @@ interface OutlinePanelProps {
 }
 
 export function OutlinePanel({ content, visible, onHeadingClick }: OutlinePanelProps) {
+    // 사용자가 drag 로 조정한 폭을 localStorage 보존
+    const [width, setWidth] = useState<number>(() => {
+        const saved = Number(localStorage.getItem(LS_WIDTH_KEY));
+        return saved >= MIN_WIDTH && saved <= MAX_WIDTH ? saved : DEFAULT_WIDTH;
+    });
+    const draggingRef = useRef(false);
+
+    useEffect(() => {
+        const onMove = (e: MouseEvent) => {
+            if (!draggingRef.current) return;
+            const next = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, e.clientX));
+            setWidth(next);
+        };
+        const onUp = () => {
+            if (!draggingRef.current) return;
+            draggingRef.current = false;
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        };
+        window.addEventListener('mousemove', onMove);
+        window.addEventListener('mouseup', onUp);
+        return () => {
+            window.removeEventListener('mousemove', onMove);
+            window.removeEventListener('mouseup', onUp);
+        };
+    }, []);
+
+    // width 변경 시 localStorage 저장 (debounced)
+    useEffect(() => {
+        const t = setTimeout(() => localStorage.setItem(LS_WIDTH_KEY, String(width)), 300);
+        return () => clearTimeout(t);
+    }, [width]);
+
+    const startDrag = (e: React.MouseEvent) => {
+        e.preventDefault();
+        draggingRef.current = true;
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+    };
+
     const headings = useMemo<OutlineItem[]>(() => {
         if (!content) return [];
         const lines = content.split('\n');
@@ -66,7 +111,7 @@ export function OutlinePanel({ content, visible, onHeadingClick }: OutlinePanelP
     };
 
     return (
-        <div className="outline-panel">
+        <div className="outline-panel" style={{ width }}>
             <div className="outline-header">Outline</div>
             <div className="outline-list">
                 {headings.length === 0 ? (
@@ -84,6 +129,12 @@ export function OutlinePanel({ content, visible, onHeadingClick }: OutlinePanelP
                     ))
                 )}
             </div>
+            {/* drag handle — 우측 가장자리 col-resize */}
+            <div
+                className="outline-resize-handle"
+                onMouseDown={startDrag}
+                title="드래그로 폭 조정"
+            />
         </div>
     );
 }

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -447,29 +447,41 @@ function RichEditor({
     });
 
     // Rich Text 검색 — App-level SearchBar 가 window event 로 명령 전달.
-    // (editor instance 가 Preview 내부라 ref 노출 대신 event bus 사용)
+    // tiptap-search-and-replace 의 storage 타입이 ext 에 없어 any 캐스팅.
     useEffect(() => {
         if (!editor) return;
+
+        const reportCount = () => {
+            const storage = (editor.storage as unknown as Record<string, {
+                results?: unknown[];
+                resultIndex?: number;
+            }>).searchAndReplace;
+            const count = storage?.results?.length ?? 0;
+            const index = storage?.resultIndex ?? 0;
+            window.dispatchEvent(
+                new CustomEvent('markmind:rich-search-count', {
+                    detail: { count, index },
+                }),
+            );
+        };
+
         const onSearch = (e: Event) => {
             const detail = (e as CustomEvent<{ query: string }>).detail;
             editor.commands.setSearchTerm(detail.query ?? '');
-            // 결과 개수 회신 — App SearchBar 가 listen
-            // tiptap-search-and-replace 의 storage 타입이 ext 에 없어 any 캐스팅
-            const storage = (editor.storage as unknown as Record<string, { results?: unknown[] }>)
-                .searchAndReplace;
-            const count = storage?.results?.length ?? 0;
-            window.dispatchEvent(
-                new CustomEvent('markmind:rich-search-count', { detail: { count } }),
-            );
+            // setSearchTerm 후 storage 갱신은 다음 frame — setTimeout 0
+            setTimeout(reportCount, 0);
         };
         const onNext = () => {
             editor.commands.nextSearchResult();
+            setTimeout(reportCount, 0);
         };
         const onPrev = () => {
             editor.commands.previousSearchResult();
+            setTimeout(reportCount, 0);
         };
         const onClear = () => {
             editor.commands.setSearchTerm('');
+            setTimeout(reportCount, 0);
         };
         window.addEventListener('markmind:rich-search', onSearch);
         window.addEventListener('markmind:rich-search-next', onNext);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -115,6 +116,51 @@ function ReadOnlyView({
     );
 }
 
+// ─── 링크 입력 모달 (Tauri WKWebView 가 prompt() 불안정해서 커스텀) ───
+function LinkModal({
+    initial,
+    onApply,
+    onClose,
+}: {
+    initial: string;
+    onApply: (url: string) => void;
+    onClose: () => void;
+}) {
+    const [value, setValue] = useState(initial);
+    return createPortal(
+        <div className="link-modal-root" role="dialog" aria-modal="true">
+            <div className="link-modal-backdrop" onClick={onClose} aria-hidden />
+            <div className="link-modal">
+                <div className="link-modal-title">링크 URL</div>
+                <input
+                    type="text"
+                    autoFocus
+                    value={value}
+                    placeholder="https://example.com"
+                    onChange={(e) => setValue(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+                        if (e.key === 'Enter') {
+                            e.preventDefault();
+                            onApply(value);
+                        } else if (e.key === 'Escape') {
+                            onClose();
+                        }
+                    }}
+                />
+                <p className="link-modal-hint">빈 값 + 적용 → 링크 제거</p>
+                <div className="link-modal-actions">
+                    <button onClick={onClose}>취소</button>
+                    <button className="primary" onClick={() => onApply(value)}>
+                        적용
+                    </button>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}
+
 // ─── 편집 toolbar ───
 interface ToolBtnProps {
     onClick: () => void;
@@ -141,6 +187,7 @@ function ToolBtn({ onClick, icon, title, active, disabled }: ToolBtnProps) {
 function RichToolbar({ editor }: { editor: Editor }) {
     // editor state 변경 (selection, marks) 시 toolbar 가 갱신되도록 강제 리렌더
     const [, setTick] = useState(0);
+    const [linkModal, setLinkModal] = useState<{ value: string } | null>(null);
     useEffect(() => {
         const handler = () => setTick((t) => t + 1);
         editor.on('selectionUpdate', handler);
@@ -151,15 +198,18 @@ function RichToolbar({ editor }: { editor: Editor }) {
         };
     }, [editor]);
 
-    const promptLink = () => {
-        const prev = editor.getAttributes('link').href ?? '';
-        const url = prompt('링크 URL (빈 값 = 제거)', prev);
-        if (url === null) return;
-        if (url === '') {
+    const openLinkModal = () => {
+        const prev = (editor.getAttributes('link').href as string | undefined) ?? '';
+        setLinkModal({ value: prev });
+    };
+    const applyLink = (url: string) => {
+        const trimmed = url.trim();
+        if (trimmed === '') {
             editor.chain().focus().extendMarkRange('link').unsetLink().run();
         } else {
-            editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+            editor.chain().focus().extendMarkRange('link').setLink({ href: trimmed }).run();
         }
+        setLinkModal(null);
     };
 
     return (
@@ -227,11 +277,18 @@ function RichToolbar({ editor }: { editor: Editor }) {
                 title="Inline code (⌘E)"
             />
             <ToolBtn
-                onClick={promptLink}
+                onClick={openLinkModal}
                 active={editor.isActive('link')}
                 icon={<LinkIcon size={14} />}
                 title="Link (⌘K)"
             />
+            {linkModal && (
+                <LinkModal
+                    initial={linkModal.value}
+                    onClose={() => setLinkModal(null)}
+                    onApply={applyLink}
+                />
+            )}
             <span className="rich-tool-divider" />
             <ToolBtn
                 onClick={() => editor.chain().focus().toggleBulletList().run()}

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -433,8 +433,7 @@ function RichEditor({
         ],
         content: fixEmphasis(body), // ** 인접 bold 인식되도록 zero-width 삽입
         onUpdate: ({ editor }) => {
-            // @ts-expect-error tiptap-markdown 의 storage 타입
-            const md: string = editor.storage.markdown.getMarkdown();
+            const md: string = editor.storage.markdown?.getMarkdown() ?? '';
             // 직렬화 시 fixEmphasis 의 zero-width 제거 → 파일에는 비가시 문자 안 들어감
             onChange(rawFrontmatter + stripDisplayHelpers(md));
         },
@@ -442,6 +441,18 @@ function RichEditor({
             attributes: {
                 class: 'markdown-body tiptap-rich',
                 style: `font-size: ${fontSize}px`,
+            },
+            // copy 시 fixEmphasis 의 zero-width 가 사용자 클립보드에 섞이지 않도록 제거
+            handleDOMEvents: {
+                copy: (_view, event) => {
+                    const sel = window.getSelection()?.toString() ?? '';
+                    if (sel && sel.includes('​')) {
+                        event.preventDefault();
+                        event.clipboardData?.setData('text/plain', sel.replace(/​/g, ''));
+                        return true;
+                    }
+                    return false;
+                },
             },
         },
     });
@@ -452,10 +463,7 @@ function RichEditor({
         if (!editor) return;
 
         const reportCount = () => {
-            const storage = (editor.storage as unknown as Record<string, {
-                results?: unknown[];
-                resultIndex?: number;
-            }>).searchAndReplace;
+            const storage = editor.storage.searchAndReplace;
             const count = storage?.results?.length ?? 0;
             const index = storage?.resultIndex ?? 0;
             window.dispatchEvent(
@@ -499,9 +507,11 @@ function RichEditor({
     // 사용자가 편집 중인 변경은 덮어쓰지 않도록 — 직렬화 결과와 비교.
     useEffect(() => {
         if (!editor) return;
-        // @ts-expect-error tiptap-markdown storage
-        const current: string = editor.storage.markdown.getMarkdown();
-        if (stripDisplayHelpers(current).trim() !== body.trim()) {
+        const current: string = editor.storage.markdown?.getMarkdown() ?? '';
+        const cleanedCurrent = stripDisplayHelpers(current);
+        // fast-path: 길이 차이 ≥ 8 면 trim 비교 skip — 큰 문서 비용 절감
+        const lenDiff = Math.abs(cleanedCurrent.length - body.length);
+        if (lenDiff > 8 || cleanedCurrent.trim() !== body.trim()) {
             editor.commands.setContent(fixEmphasis(body), { emitUpdate: false });
         }
     }, [body, editor]);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -14,12 +14,14 @@ import { TableRow } from '@tiptap/extension-table-row';
 import { TableCell } from '@tiptap/extension-table-cell';
 import { TableHeader } from '@tiptap/extension-table-header';
 import { Markdown } from 'tiptap-markdown';
+import { SearchAndReplace } from '@sereneinserenade/tiptap-search-and-replace';
 import {
     Bold, Italic, Strikethrough, Code,
     Heading1, Heading2, Heading3, Heading4,
     List, ListOrdered, ListChecks,
     Quote, Code2, Link as LinkIcon, Table as TableIcon,
     Undo2, Redo2, Minus,
+    IndentIncrease, IndentDecrease,
 } from 'lucide-react';
 
 interface PreviewProps {
@@ -148,8 +150,16 @@ function LinkModal({
                         }
                     }}
                 />
-                <p className="link-modal-hint">빈 값 + 적용 → 링크 제거</p>
                 <div className="link-modal-actions">
+                    {initial && (
+                        <button
+                            className="danger"
+                            onClick={() => onApply('')}
+                            title="이 위치의 링크 제거"
+                        >
+                            링크 삭제
+                        </button>
+                    )}
                     <button onClick={onClose}>취소</button>
                     <button className="primary" onClick={() => onApply(value)}>
                         적용
@@ -198,10 +208,43 @@ function RichToolbar({ editor }: { editor: Editor }) {
         };
     }, [editor]);
 
+    /** 현재 위치의 list 타입에 맞게 sink (들여쓰기) / lift (내어쓰기) */
+    const indent = () => {
+        if (editor.isActive('taskList') || editor.isActive('taskItem')) {
+            editor.chain().focus().sinkListItem('taskItem').run();
+        } else {
+            editor.chain().focus().sinkListItem('listItem').run();
+        }
+    };
+    const outdent = () => {
+        if (editor.isActive('taskList') || editor.isActive('taskItem')) {
+            editor.chain().focus().liftListItem('taskItem').run();
+        } else {
+            editor.chain().focus().liftListItem('listItem').run();
+        }
+    };
+    const inList =
+        editor.isActive('bulletList') ||
+        editor.isActive('orderedList') ||
+        editor.isActive('taskList');
+
     const openLinkModal = () => {
         const prev = (editor.getAttributes('link').href as string | undefined) ?? '';
         setLinkModal({ value: prev });
     };
+
+    // ⌘K → 링크 모달 (editor focus 안에서만 동작)
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== 'k' && e.key !== 'K') return;
+            if (!editor.isFocused) return;
+            e.preventDefault();
+            openLinkModal();
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [editor]);
     const applyLink = (url: string) => {
         const trimmed = url.trim();
         if (trimmed === '') {
@@ -308,6 +351,18 @@ function RichToolbar({ editor }: { editor: Editor }) {
                 icon={<ListChecks size={14} />}
                 title="Task list (⌘⇧9)"
             />
+            <ToolBtn
+                onClick={outdent}
+                disabled={!inList}
+                icon={<IndentDecrease size={14} />}
+                title="Outdent list (Shift+Tab)"
+            />
+            <ToolBtn
+                onClick={indent}
+                disabled={!inList}
+                icon={<IndentIncrease size={14} />}
+                title="Indent list (Tab)"
+            />
             <span className="rich-tool-divider" />
             <ToolBtn
                 onClick={() => editor.chain().focus().toggleBlockquote().run()}
@@ -373,6 +428,10 @@ function RichEditor({
                 transformPastedText: true,
                 transformCopiedText: true,
             }),
+            SearchAndReplace.configure({
+                searchResultClass: 'rich-search-highlight',
+                disableRegex: true,
+            }),
         ],
         content: fixEmphasis(body), // ** 인접 bold 인식되도록 zero-width 삽입
         onUpdate: ({ editor }) => {
@@ -388,6 +447,43 @@ function RichEditor({
             },
         },
     });
+
+    // Rich Text 검색 — App-level SearchBar 가 window event 로 명령 전달.
+    // (editor instance 가 Preview 내부라 ref 노출 대신 event bus 사용)
+    useEffect(() => {
+        if (!editor) return;
+        const onSearch = (e: Event) => {
+            const detail = (e as CustomEvent<{ query: string }>).detail;
+            editor.commands.setSearchTerm(detail.query ?? '');
+            // 결과 개수 회신 — App SearchBar 가 listen
+            // tiptap-search-and-replace 의 storage 타입이 ext 에 없어 any 캐스팅
+            const storage = (editor.storage as unknown as Record<string, { results?: unknown[] }>)
+                .searchAndReplace;
+            const count = storage?.results?.length ?? 0;
+            window.dispatchEvent(
+                new CustomEvent('markmind:rich-search-count', { detail: { count } }),
+            );
+        };
+        const onNext = () => {
+            editor.commands.nextSearchResult();
+        };
+        const onPrev = () => {
+            editor.commands.previousSearchResult();
+        };
+        const onClear = () => {
+            editor.commands.setSearchTerm('');
+        };
+        window.addEventListener('markmind:rich-search', onSearch);
+        window.addEventListener('markmind:rich-search-next', onNext);
+        window.addEventListener('markmind:rich-search-prev', onPrev);
+        window.addEventListener('markmind:rich-search-clear', onClear);
+        return () => {
+            window.removeEventListener('markmind:rich-search', onSearch);
+            window.removeEventListener('markmind:rich-search-next', onNext);
+            window.removeEventListener('markmind:rich-search-prev', onPrev);
+            window.removeEventListener('markmind:rich-search-clear', onClear);
+        };
+    }, [editor]);
 
     // body prop 이 외부에서 바뀌면 (다른 파일 열기) editor content 갱신.
     // 사용자가 편집 중인 변경은 덮어쓰지 않도록 — 직렬화 결과와 비교.

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -15,6 +15,7 @@ import { TableCell } from '@tiptap/extension-table-cell';
 import { TableHeader } from '@tiptap/extension-table-header';
 import { Markdown } from 'tiptap-markdown';
 import { SearchAndReplace } from '@sereneinserenade/tiptap-search-and-replace';
+import { Typography } from '@tiptap/extension-typography';
 import {
     Bold, Italic, Strikethrough, Code,
     Heading1, Heading2, Heading3, Heading4,
@@ -208,25 +209,18 @@ function RichToolbar({ editor }: { editor: Editor }) {
         };
     }, [editor]);
 
-    /** 현재 위치의 list 타입에 맞게 sink (들여쓰기) / lift (내어쓰기) */
+    /** 현재 위치의 list 타입에 맞게 sink (들여쓰기) / lift (내어쓰기).
+     *  실제 동작 가능 여부는 editor.can() 으로 — 이미 최상위면 lift 불가, 부모 없으면 sink 불가. */
+    const isTask = editor.isActive('taskList') || editor.isActive('taskItem');
+    const itemType = isTask ? 'taskItem' : 'listItem';
+    const canSink = editor.can().sinkListItem(itemType);
+    const canLift = editor.can().liftListItem(itemType);
     const indent = () => {
-        if (editor.isActive('taskList') || editor.isActive('taskItem')) {
-            editor.chain().focus().sinkListItem('taskItem').run();
-        } else {
-            editor.chain().focus().sinkListItem('listItem').run();
-        }
+        if (canSink) editor.chain().focus().sinkListItem(itemType).run();
     };
     const outdent = () => {
-        if (editor.isActive('taskList') || editor.isActive('taskItem')) {
-            editor.chain().focus().liftListItem('taskItem').run();
-        } else {
-            editor.chain().focus().liftListItem('listItem').run();
-        }
+        if (canLift) editor.chain().focus().liftListItem(itemType).run();
     };
-    const inList =
-        editor.isActive('bulletList') ||
-        editor.isActive('orderedList') ||
-        editor.isActive('taskList');
 
     const openLinkModal = () => {
         const prev = (editor.getAttributes('link').href as string | undefined) ?? '';
@@ -353,13 +347,13 @@ function RichToolbar({ editor }: { editor: Editor }) {
             />
             <ToolBtn
                 onClick={outdent}
-                disabled={!inList}
+                disabled={!canLift}
                 icon={<IndentDecrease size={14} />}
                 title="Outdent list (Shift+Tab)"
             />
             <ToolBtn
                 onClick={indent}
-                disabled={!inList}
+                disabled={!canSink}
                 icon={<IndentIncrease size={14} />}
                 title="Indent list (Tab)"
             />
@@ -412,7 +406,9 @@ function RichEditor({
                 heading: { levels: [1, 2, 3, 4, 5, 6] },
                 codeBlock: { HTMLAttributes: { class: 'hljs' } },
             }),
-            Link.configure({ openOnClick: false, autolink: true }),
+            // autolink: false — `arena.ai` 같은 평문 URL 이 자동으로 링크되는 동작 끄기
+            // (사용자가 명시적으로 toolbar Link 버튼/⌘K 로만 링크 생성)
+            Link.configure({ openOnClick: false, autolink: false }),
             TaskList,
             TaskItem.configure({ nested: true }),
             Table.configure({ resizable: false }),
@@ -423,7 +419,7 @@ function RichEditor({
                 html: false,
                 tightLists: true,
                 bulletListMarker: '-',
-                linkify: true,
+                linkify: false, // 자동 URL → 링크 변환 끄기 (사용자 요청)
                 breaks: false,
                 transformPastedText: true,
                 transformCopiedText: true,
@@ -432,6 +428,8 @@ function RichEditor({
                 searchResultClass: 'rich-search-highlight',
                 disableRegex: true,
             }),
+            // Smart typography — `->` → `→`, `--` → `—`, `(c)` → `©` 등 자동 치환
+            Typography,
         ],
         content: fixEmphasis(body), // ** 인접 bold 인식되도록 zero-width 삽입
         onUpdate: ({ editor }) => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -4,11 +4,12 @@ import {
     FilePlus, FolderOpen, Save, Download,
     ZoomIn, ZoomOut, List, Maximize, Clock,
     Search, ChevronRight, Sparkles, Check, X,
-    Mic, ScanText, Settings, Menu as MenuIcon,
+    Mic, ScanText, Settings,
     FileCode, FileText, AlignVerticalSpaceAround,
 } from 'lucide-react';
 import * as gdriveService from '../services/gdriveService';
 import type { RecentFile } from '../hooks/useRecentFiles';
+import { BackgroundPicker } from './BackgroundPicker';
 
 export type ViewMode = 'split' | 'editor' | 'preview';
 
@@ -102,6 +103,8 @@ interface ToolbarProps {
     onFontSizeReset: () => void;
     lineHeight: 'compact' | 'normal' | 'relaxed';
     onCycleLineHeight: () => void;
+    bgColor: string;
+    onBgColorChange: (color: string) => void;
     onToggleOutline: () => void;
     onToggleReadingMode: () => void;
     onToggleRecentFiles: () => void;
@@ -137,6 +140,8 @@ export function Toolbar({
     onFontSizeReset,
     lineHeight,
     onCycleLineHeight,
+    bgColor,
+    onBgColorChange,
     onToggleOutline,
     onToggleReadingMode,
     onToggleRecentFiles,
@@ -203,8 +208,7 @@ export function Toolbar({
                         className={`toolbar-text-btn${fileMenuOpen ? ' active' : ''}`}
                         onClick={() => setFileMenuOpen((v) => !v)}
                     >
-                        <MenuIcon size={14} strokeWidth={1.5} />
-                        <span>Menu</span>
+                        <span>File</span>
                     </button>
                     {fileMenuOpen && (
                         <div className="toolbar-dropdown-menu">
@@ -345,14 +349,20 @@ export function Toolbar({
                     </button>
                 </div>
 
-                {/* 행간 토글 — compact / normal / relaxed 사이클 */}
+                {/* 행간 토글 — compact 1.5 / normal 1.8 / relaxed 2.2 사이클 */}
                 <button
-                    className="toolbar-btn"
+                    className="toolbar-btn toolbar-lineheight-btn"
                     onClick={onCycleLineHeight}
-                    title={`행간: ${lineHeight === 'compact' ? '좁게' : lineHeight === 'normal' ? '보통' : '넓게'} (클릭하면 변경)`}
+                    title={`행간 ${lineHeight === 'compact' ? '1.5 (좁게)' : lineHeight === 'normal' ? '1.8 (보통)' : '2.2 (넓게)'} — 클릭으로 변경`}
                 >
                     <AlignVerticalSpaceAround size={15} strokeWidth={1.5} />
+                    <span className="toolbar-lineheight-value">
+                        {lineHeight === 'compact' ? '1.5' : lineHeight === 'normal' ? '1.8' : '2.2'}
+                    </span>
                 </button>
+
+                {/* 배경색 picker */}
+                <BackgroundPicker value={bgColor} onChange={onBgColorChange} />
 
                 <div className="toolbar-divider" />
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -369,7 +369,7 @@ export function Toolbar({
                     <ScanText size={14} strokeWidth={1.5} />
                     <span>이미지 인식</span>
                 </button>
-                <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘I)">
+                <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘⇧I)">
                     <Sparkles size={14} strokeWidth={1.5} />
                     <span>AI 에이전트</span>
                 </button>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -261,7 +261,7 @@ export function Toolbar({
                                             <div className="dropdown-submenu-empty">최근 파일 없음</div>
                                         ) : (
                                             <>
-                                                {recentFiles.slice(0, 10).map((f) => (
+                                                {recentFiles.slice(0, 5).map((f) => (
                                                     <button
                                                         key={f.path}
                                                         className="dropdown-item dropdown-submenu-item"

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import {
-    Columns2, Sun, Moon, BookOpen,
+    Columns2, BookOpen,
     FilePlus, FolderOpen, Save, Download,
     ZoomIn, ZoomOut, List, Maximize, Clock,
     Search, ChevronRight, Sparkles, Check, X,
@@ -87,13 +87,11 @@ interface ToolbarProps {
     fileName: string;
     isDirty: boolean;
     viewMode: ViewMode;
-    theme: 'light' | 'dark';
     fontSize: number;
     outlineVisible: boolean;
     showRecent: boolean;
     aiPanelVisible: boolean;
     onViewModeChange: (mode: ViewMode) => void;
-    onThemeToggle: () => void;
     onNewFile: () => void;
     onOpenFile: () => void;
     onSaveFile: () => void;
@@ -126,11 +124,9 @@ export function Toolbar({
     fileName,
     isDirty,
     viewMode,
-    theme,
     fontSize,
     outlineVisible,
     onViewModeChange,
-    onThemeToggle,
     onNewFile,
     onOpenFile,
     onSaveFile,
@@ -365,9 +361,6 @@ export function Toolbar({
                     </span>
                 </button>
                 <BackgroundPicker value={bgColor} onChange={onBgColorChange} />
-                <button className="toolbar-btn" onClick={onThemeToggle} title="Toggle Theme (배경색 없을 때)">
-                    {theme === 'dark' ? <Sun size={16} strokeWidth={1.5} /> : <Moon size={16} strokeWidth={1.5} />}
-                </button>
 
                 <div className="toolbar-divider" />
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,7 +5,7 @@ import {
     ZoomIn, ZoomOut, List, Maximize, Clock,
     Search, ChevronRight, Sparkles, Check, X,
     Mic, ScanText, Settings, Menu as MenuIcon,
-    FileCode, FileText,
+    FileCode, FileText, AlignVerticalSpaceAround,
 } from 'lucide-react';
 import * as gdriveService from '../services/gdriveService';
 import type { RecentFile } from '../hooks/useRecentFiles';
@@ -100,6 +100,8 @@ interface ToolbarProps {
     onShowTutorial: () => void;
     onFontSizeChange: (delta: number) => void;
     onFontSizeReset: () => void;
+    lineHeight: 'compact' | 'normal' | 'relaxed';
+    onCycleLineHeight: () => void;
     onToggleOutline: () => void;
     onToggleReadingMode: () => void;
     onToggleRecentFiles: () => void;
@@ -133,6 +135,8 @@ export function Toolbar({
     onShowTutorial,
     onFontSizeChange,
     onFontSizeReset,
+    lineHeight,
+    onCycleLineHeight,
     onToggleOutline,
     onToggleReadingMode,
     onToggleRecentFiles,
@@ -340,6 +344,15 @@ export function Toolbar({
                         <ZoomIn size={15} strokeWidth={1.5} />
                     </button>
                 </div>
+
+                {/* 행간 토글 — compact / normal / relaxed 사이클 */}
+                <button
+                    className="toolbar-btn"
+                    onClick={onCycleLineHeight}
+                    title={`행간: ${lineHeight === 'compact' ? '좁게' : lineHeight === 'normal' ? '보통' : '넓게'} (클릭하면 변경)`}
+                >
+                    <AlignVerticalSpaceAround size={15} strokeWidth={1.5} />
+                </button>
 
                 <div className="toolbar-divider" />
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -301,14 +301,6 @@ export function Toolbar({
                     )}
                 </div>
 
-                {/* Search + Outline (순서 교체) */}
-                <button className="toolbar-btn" onClick={onToggleSearch} title="Search (⌘F)">
-                    <Search size={15} strokeWidth={1.5} />
-                </button>
-                <button className={`toolbar-btn${outlineVisible ? ' active' : ''}`} onClick={onToggleOutline} title="Outline">
-                    <List size={16} strokeWidth={1.5} />
-                </button>
-
                 <div className="toolbar-divider" />
 
                 {/* View modes — Markdown / Rich Text / Split */}
@@ -336,6 +328,16 @@ export function Toolbar({
 
                 <div className="toolbar-divider" />
 
+                {/* Outline + Search */}
+                <button className={`toolbar-btn${outlineVisible ? ' active' : ''}`} onClick={onToggleOutline} title="Outline">
+                    <List size={16} strokeWidth={1.5} />
+                </button>
+                <button className="toolbar-btn" onClick={onToggleSearch} title="Search (⌘F)">
+                    <Search size={15} strokeWidth={1.5} />
+                </button>
+
+                <div className="toolbar-divider" />
+
                 {/* Font size controls (압축 그룹 — 간격 좁힘) */}
                 <div className="toolbar-fontsize-group">
                     <button className="toolbar-btn" onClick={() => onFontSizeChange(-1)} title="Zoom Out (⌘-)" disabled={viewMode === 'editor'}>
@@ -349,7 +351,9 @@ export function Toolbar({
                     </button>
                 </div>
 
-                {/* 행간 토글 — compact 1.5 / normal 1.8 / relaxed 2.2 사이클 */}
+                <div className="toolbar-divider" />
+
+                {/* 행간 토글 + 배경색 picker (Theme 토글은 배경색에 자동 동기화되므로 제거) */}
                 <button
                     className="toolbar-btn toolbar-lineheight-btn"
                     onClick={onCycleLineHeight}
@@ -360,17 +364,15 @@ export function Toolbar({
                         {lineHeight === 'compact' ? '1.5' : lineHeight === 'normal' ? '1.8' : '2.2'}
                     </span>
                 </button>
-
-                {/* 배경색 picker */}
                 <BackgroundPicker value={bgColor} onChange={onBgColorChange} />
+                <button className="toolbar-btn" onClick={onThemeToggle} title="Toggle Theme (배경색 없을 때)">
+                    {theme === 'dark' ? <Sun size={16} strokeWidth={1.5} /> : <Moon size={16} strokeWidth={1.5} />}
+                </button>
 
                 <div className="toolbar-divider" />
 
-                {/* Theme + Reading mode (순서 교체) */}
-                <button className="toolbar-btn" onClick={onThemeToggle} title="Toggle Theme">
-                    {theme === 'dark' ? <Sun size={16} strokeWidth={1.5} /> : <Moon size={16} strokeWidth={1.5} />}
-                </button>
-                <button className="toolbar-btn" onClick={onToggleReadingMode} title="Reading Mode">
+                {/* Full (Reading mode) */}
+                <button className="toolbar-btn" onClick={onToggleReadingMode} title="Full / Reading Mode">
                     <Maximize size={16} strokeWidth={1.5} />
                 </button>
             </div>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -2,38 +2,53 @@ import { useState, useEffect, useCallback } from 'react';
 
 type Theme = 'light' | 'dark';
 
+const LS_THEME_KEY = 'md-editor-theme'; // 사용자가 명시적으로 토글한 경우만 저장
+
 export function useTheme() {
-    const [theme, setTheme] = useState<Theme>(() => {
-        if (typeof window !== 'undefined') {
-            const saved = localStorage.getItem('md-editor-theme');
-            if (saved === 'light' || saved === 'dark') return saved;
-            return window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light';
-        }
-        return 'light';
+    const [theme, setThemeState] = useState<Theme>(() => {
+        if (typeof window === 'undefined') return 'light';
+        const saved = localStorage.getItem(LS_THEME_KEY);
+        if (saved === 'light' || saved === 'dark') return saved;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     });
 
+    // DOM data-theme 항상 갱신
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
-        localStorage.setItem('md-editor-theme', theme);
     }, [theme]);
 
+    // OS prefers-color-scheme 변경 — localStorage 명시 저장 안 했을 때만 따라감
     useEffect(() => {
-        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
         const handler = (e: MediaQueryListEvent) => {
-            const saved = localStorage.getItem('md-editor-theme');
-            if (!saved) {
-                setTheme(e.matches ? 'dark' : 'light');
+            if (!localStorage.getItem(LS_THEME_KEY)) {
+                setThemeState(e.matches ? 'dark' : 'light');
             }
         };
-        mediaQuery.addEventListener('change', handler);
-        return () => mediaQuery.removeEventListener('change', handler);
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
     }, []);
 
+    /** 명시적 토글 — localStorage 저장 (OS follow 모드 해제) */
     const toggleTheme = useCallback(() => {
-        setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+        setThemeState((prev) => {
+            const next = prev === 'light' ? 'dark' : 'light';
+            localStorage.setItem(LS_THEME_KEY, next);
+            return next;
+        });
     }, []);
 
-    return { theme, toggleTheme, setTheme };
+    /** in-memory 만 변경 — bgColor 자동 동기화용. localStorage 안 건드림 → 다음 세션 OS follow 유지 */
+    const setThemeTransient = useCallback((next: Theme) => {
+        setThemeState(next);
+    }, []);
+
+    /** OS prefers-color-scheme 으로 복귀 + localStorage 의 명시 저장 삭제 */
+    const resetThemeToOS = useCallback(() => {
+        localStorage.removeItem(LS_THEME_KEY);
+        const next = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        setThemeState(next);
+    }, []);
+
+    return { theme, toggleTheme, setThemeTransient, resetThemeToOS };
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -35,5 +35,5 @@ export function useTheme() {
         setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
     }, []);
 
-    return { theme, toggleTheme };
+    return { theme, toggleTheme, setTheme };
 }

--- a/src/types/tiptap-markdown.d.ts
+++ b/src/types/tiptap-markdown.d.ts
@@ -1,0 +1,18 @@
+/**
+ * tiptap-markdown / tiptap-search-and-replace extension 의 storage 타입 보강.
+ * 패키지 자체가 storage 타입을 export 안 해 매번 @ts-expect-error 캐스팅하던 것을 정리.
+ */
+
+import '@tiptap/core';
+
+declare module '@tiptap/core' {
+    interface Storage {
+        markdown?: {
+            getMarkdown(): string;
+        };
+        searchAndReplace?: {
+            results?: unknown[];
+            resultIndex?: number;
+        };
+    }
+}


### PR DESCRIPTION
PR #16 머지 시 base branch 자동 삭제로 PR #17 closed — 같은 commit 들 main 으로 새 PR.

## Summary
8주차 누적 — STT 속도 최적화 + Rich Text WYSIWYG 통합 + UX 다듬기.

### 핵심
- STT 5~6배: inline base64 (≤15MB) + 청크 병렬 (6 동시, JoinSet cleanup) + ffmpeg pre-encode 16kHz mono 32kbps
- Rich Text: TipTap + tiptap-markdown + SearchAndReplace + Typography + indent/outdent + 항상 편집 + ⌘K Link
- 배경색 picker — luminance 기반 자동 dark/light theme 전환, content 영역만 적용 (UI chrome 영향 X), no-color swatch 일관 흰색
- 행간 toggle (compact/normal/relaxed) + line value 표시
- Outline panel drag resize + localStorage 폭 보존
- File 라벨, view modes Markdown/Rich Text/Split, Outline/Search/Font/행간/배경/Full 순
- 단축키 정리: ⌘I → ⌘⇧I (TipTap Italic 충돌 해소), ⌘⇧S 케이스 정규화
- ⌘F Rich Text 통합 — window event bus 로 TipTap search 호출, count + index 회신
- 체크박스 정사각 18×18 + accent ✓, list bullet 1.25em, link 모달 + 삭제 버튼
- 음성/이미지/AI 사이드 패널 — 모드 강제 변경 제거 (reading mode 만 해제)
- Codex review 3건 fix (probe auto_download 제거, rename_speakers regex, JoinSet cleanup)
- 자체 review 16건 fix (theme 갇힘, e.key 정규화, iOS popover, type augmentation 등)
- .npmrc legacy-peer-deps — tiptap-search-and-replace peer dep 충돌 우회

## Stats
- ~25 files, +1200 / -100

## Test plan
- [x] Rust + TS compile, Tauri build OK
- [x] Vercel CI SUCCESS
- [x] 사용자 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)