### PR TITLE
feat(stt): pyannote-rs 화자 분리로 글로벌 라벨 통일 (v0.3.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,14 @@ jobs:
           FFMPEG_TARGET: ${{ matrix.ffmpeg_target }}
         run: npm run setup:ffmpeg
 
+      # Speaker diarization ONNX 모델 (segmentation-3.0, wespeaker CAM++).
+      # tauri.conf.json 의 bundle.resources 에 등록되어 빌드 타임에 file 존재
+      # 필수 — 누락 시 .app 에 모델 없이 ship 되어 화자 분리 100% fail.
+      # setup:ffmpeg 와 동일하게 tauri-action 이 setup:all chain 우회하므로
+      # 여기서 명시 다운로드.
+      - name: Download speaker diarization models
+        run: npm run setup:diarize
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ src-tauri/gen/
 
 # 빌드 시 download-ffmpeg.sh 가 채우는 sidecar binary (각 ~76MB, repo 에 commit X)
 src-tauri/binaries/
+# 빌드 시 download-diarize-models.sh 가 채우는 ONNX 모델 (~34MB, repo 에 commit X)
+src-tauri/resources/segmentation-3.0.onnx
+src-tauri/resources/wespeaker_en_voxceleb_CAM++.onnx

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "setup:ffmpeg": "bash src-tauri/scripts/download-ffmpeg.sh",
-    "tauri:build": "npm run setup:ffmpeg && npm run tauri build",
+    "setup:diarize": "bash src-tauri/scripts/download-diarize-models.sh",
+    "setup:all": "npm run setup:ffmpeg && npm run setup:diarize",
+    "tauri:build": "npm run setup:all && npm run tauri build",
     "version:patch": "npm version patch --no-git-tag-version && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));const t=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));t.version=p.version;fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(t,null,2)+'\\n');console.log('→ v'+p.version)\"",
     "version:minor": "npm version minor --no-git-tag-version && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));const t=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));t.version=p.version;fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(t,null,2)+'\\n');console.log('→ v'+p.version)\"",
     "version:major": "npm version major --no-git-tag-version && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));const t=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json'));t.version=p.version;fs.writeFileSync('src-tauri/tauri.conf.json',JSON.stringify(t,null,2)+'\\n');console.log('→ v'+p.version)\""

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -194,7 +194,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -295,6 +295,29 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -480,6 +503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +563,26 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1064,6 +1116,16 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1651,6 +1713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2096,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2160,6 +2246,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "knf-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ebe7cf9eae245a44ab76cabdd06c0b3769972fd06050ed9aea6a22ff0d682f"
+dependencies = [
+ "eyre",
+ "knf-rs-sys",
+ "ndarray",
+]
+
+[[package]]
+name = "knf-rs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9aa7679fdc0ecdaab1f4e7c9603413f303765f33c8e34e6ca4f26e7d61d6023"
+dependencies = [
+ "bindgen",
+ "cmake",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2283,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -2225,6 +2338,16 @@ dependencies = [
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -2241,6 +2364,12 @@ checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2312,6 +2441,7 @@ dependencies = [
  "ndarray",
  "ort",
  "pdfium-render",
+ "pyannote-rs",
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
@@ -2411,6 +2541,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2537,6 +2673,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-complex"
@@ -2986,7 +3132,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "libloading 0.9.0",
  "log",
@@ -3232,7 +3378,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3366,6 +3512,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "pyannote-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fff2b00fa0b4bd7e5d415eaedd9a5f0aefe58c08758ddbd945dc85dffae328"
+dependencies = [
+ "eyre",
+ "hound",
+ "knf-rs",
+ "ndarray",
+ "ort",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,7 +3550,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3411,7 +3570,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3768,6 +3927,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3783,6 +3948,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3790,7 +3968,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4763,7 +4941,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5674,6 +5852,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6368,7 +6558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -6425,7 +6615,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,10 +19,11 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 # devtools: release 빌드에서도 우클릭 → Inspect Element 활성화 (production 디버깅)
-tauri = { version = "2", features = ["devtools"] }
-tauri-plugin-opener = "2"
-tauri-plugin-dialog = "2"
-tauri-plugin-fs = "2"
+# 2.10 핀 — pyannote-rs 추가 시 cargo 가 tauri 2.3 으로 downgrade 해 wry 0.50 와 API mismatch.
+tauri = { version = "~2.10", features = ["devtools"] }
+tauri-plugin-opener = "~2.5"
+tauri-plugin-dialog = "~2.6"
+tauri-plugin-fs = "~2.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 urlencoding = "2"
@@ -38,10 +39,14 @@ async-trait = "0.1"
 # Audio: ffmpeg sidecar (auto-downloads ffmpeg binary on first run)
 ffmpeg-sidecar = "2"
 
-# Audio: Silero VAD via onnxruntime (Rust binding)
-# 주의: prerelease caret(^) 룰 때문에 정확한 버전 고정 — rc.12 의 VitisAI provider 컴파일 버그 회피
+# Audio: Silero VAD via onnxruntime. rc.10 핀 (rc.12 VitisAI 빌드 회귀 회피).
 ort = { version = "=2.0.0-rc.10", features = ["ndarray"] }
 ndarray = "0.16"
+
+# Speaker diarization (pyannote ONNX). speakrs 대신 채택 — openblas/ndarray-linalg
+# 의존 없이 ort + knf-rs (kaldi-native-fbank) 만으로 동작. macOS CoreML feature
+# 로 가속. 1시간 음성 1분 이내 CPU 처리. MIT 라이선스.
+pyannote-rs = { version = "0.3", features = ["coreml"] }
 
 # Audio decoding (PCM extraction for VAD)
 hound = "3"

--- a/src-tauri/scripts/download-diarize-models.sh
+++ b/src-tauri/scripts/download-diarize-models.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# pyannote-rs 의 ONNX 모델 2개 다운로드 → src-tauri/resources/ 에 배치.
+# 빌드 시 .app 안에 동봉 (tauri.conf.json bundle.resources).
+#
+# 모델:
+#   - segmentation-3.0.onnx (~6MB) — pyannote segmentation
+#   - wespeaker_en_voxceleb_CAM++.onnx (~28MB) — speaker embedding
+# 라이선스: MIT (pyannote-rs releases), 원본은 pyannote/wespeaker (각각 MIT/Apache-2.0)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+mkdir -p resources
+
+BASE="https://github.com/thewh1teagle/pyannote-rs/releases/download/v0.1.0"
+
+download() {
+    local name="$1"
+    local out="resources/${name}"
+    if [ -s "$out" ]; then
+        echo "✓ exists: $out ($(du -h "$out" | cut -f1))"
+        return
+    fi
+    echo "↓ ${name}"
+    curl -fsSL -o "$out" "${BASE}/${name}"
+    echo "✓ $out ($(du -h "$out" | cut -f1))"
+}
+
+download "segmentation-3.0.onnx"
+download "wespeaker_en_voxceleb_CAM++.onnx"
+
+echo ""
+echo "✓ 화자 분리 ONNX 모델 동봉 준비 완료."

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -15,14 +15,27 @@ use super::keychain::{get_key, Provider};
 use super::llm::gemini;
 use super::progress::{fmt_duration, ProgressEmitter};
 use super::templates::{build_evidence_markdown, EvidenceMeta};
+use super::diarize::{diarize_pcm, DiarSegment};
 use super::speaker_dedup::dedup_speakers;
-use super::vad::{cleanup_trimmed, trim_silence, trimmed_to_original, SegmentMap, TrimResult, VadOptions};
+use super::vad::{cleanup_trimmed, decode_to_16k_pcm, trim_silence, trimmed_to_original, SegmentMap, TrimResult, VadOptions};
 use super::{conversions_dir, CostSummary, EvidenceType, UsageInfo, MODEL_AUDIO};
 use base64::Engine;
 use chrono::{FixedOffset, Utc};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::sync::LazyLock;
+
+// 매 호출마다 컴파일 비용 피하기 위해 정적 캐싱.
+// `화자` 다음에 한글/영문/숫자 라벨 흡수 — 다양한 Gemini 변형 대비.
+static DIAR_LABEL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(\*\*\[)(\d{1,2}):(\d{2})(?::(\d{2}))?(\]\s+)(화자[가-힣A-Za-z0-9]+)(:?\*\*)")
+        .expect("DIAR_LABEL_RE 정적 패턴 컴파일 실패 (코드 버그)")
+});
+static TS_REMAP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]")
+        .expect("TS_REMAP_RE 정적 패턴 컴파일 실패 (코드 버그)")
+});
 
 const CHUNK_THRESHOLD_SEC: f64 = 9.0 * 60.0;
 const CHUNK_DURATION_SEC: f64 = 10.0 * 60.0;
@@ -118,6 +131,51 @@ pub async fn run(
         emitter.emit(format!("🕐 녹음 시각: {}", r), None);
     }
 
+    // ─── Speaker diarization (pyannote-rs) ───
+    // 원본 PCM 한 번에 분석 → 청크 무관 글로벌 speaker_id. 4시간 ~3분 CPU.
+    // transcription 결과의 timestamp 와 시간 정렬해 라벨 통일.
+    // 실패 시 (모델 없음 등) Gemini 자체 라벨 그대로 사용.
+    let diar_segments: Vec<DiarSegment> = {
+        emitter.emit("🎭 화자 분석 준비 중...", None);
+        match decode_to_16k_pcm(&file_path).await {
+            Ok(pcm) => {
+                let app_clone = app.clone();
+                emitter.emit("🎭 화자 분리 분석 중 (전체 음성)...", None);
+                let diar = tokio::task::spawn_blocking(move || {
+                    diarize_pcm(&app_clone, &pcm, 16000, None)
+                })
+                .await
+                .map_err(|e| ConverterError::Internal(format!("diarize join: {}", e)))
+                .and_then(|r| r);
+                match diar {
+                    Ok(segs) => {
+                        let unique: std::collections::BTreeSet<usize> =
+                            segs.iter().map(|s| s.speaker_id).collect();
+                        emitter.emit(
+                            format!("✅ 화자 {}명 식별 (segment {}개)", unique.len(), segs.len()),
+                            None,
+                        );
+                        segs
+                    }
+                    Err(e) => {
+                        emitter.emit(
+                            "⚠️ 화자 분리 실패 — Gemini 자체 라벨로 진행",
+                            Some(e.to_string()),
+                        );
+                        Vec::new()
+                    }
+                }
+            }
+            Err(e) => {
+                emitter.emit(
+                    "⚠️ PCM decode 실패 — 화자 분리 skip",
+                    Some(e.to_string()),
+                );
+                Vec::new()
+            }
+        }
+    };
+
     // VAD 무음 제거 (옵션 ON 시)
     let mut trim: Option<TrimResult> = None;
     let mut work_path = file_path.clone();
@@ -148,6 +206,7 @@ pub async fn run(
         trim.as_ref(),
         opts.output_dir,
         opts.dedup_speakers,
+        &diar_segments,
     )
     .await;
 
@@ -199,6 +258,7 @@ async fn run_pipeline_core(
     trim: Option<&TrimResult>,
     output_dir: Option<String>,
     dedup_speakers_enabled: bool,
+    diar_segments: &[DiarSegment],
 ) -> ConverterResult<AudioJobResult> {
     let file_path = work_path.to_path_buf();
     let segment_map: Option<Vec<SegmentMap>> = trim.map(|t| t.segment_map.clone());
@@ -216,6 +276,7 @@ async fn run_pipeline_core(
                 output_dir,
                 segment_map.as_deref(),
                 dedup_speakers_enabled,
+                diar_segments,
             )
             .await;
         }
@@ -241,6 +302,7 @@ async fn run_pipeline_core(
             output_dir,
             segment_map.as_deref(),
             dedup_speakers_enabled,
+            diar_segments,
         )
         .await;
     }
@@ -284,6 +346,16 @@ async fn run_pipeline_core(
         merged = map_timestamps_to_original(&merged, map);
     }
 
+    // pyannote-rs 화자 분석으로 글로벌 라벨 통일 — chunk 경계 무관.
+    // chunk 모드는 화자 뒤죽박죽이 가장 심한 케이스라 효과 최대.
+    if !diar_segments.is_empty() {
+        emitter.emit(
+            "🎭 화자 라벨 통일 중",
+            Some(format!("{} 발화 구간", diar_segments.len())),
+        );
+        merged = apply_diar_labels(&merged, diar_segments);
+    }
+
     // 청크 모드는 화자 분리 오류 가장 잦은 케이스 (chunk 경계마다 다시 화자A
     // 부터 매기는 경향) — dedup 후처리 효과가 가장 큼.
     merged = maybe_dedup_speakers(
@@ -323,6 +395,7 @@ async fn run_inline_path(
     output_dir: Option<String>,
     segment_map: Option<&[SegmentMap]>,
     dedup_speakers_enabled: bool,
+    diar_segments: &[DiarSegment],
 ) -> ConverterResult<AudioJobResult> {
     let start = std::time::Instant::now();
     let buffer = tokio::fs::read(file_path).await?;
@@ -351,6 +424,14 @@ async fn run_inline_path(
         result.text
     };
 
+    // pyannote-rs 화자 분석 결과 적용 — chunk 경계 무관 글로벌 ID
+    let body = if !diar_segments.is_empty() {
+        emitter.emit("🎭 화자 라벨 통일 중...", None);
+        apply_diar_labels(&body, diar_segments)
+    } else {
+        body
+    };
+
     let mut usages = vec![result.usage];
     // Inline 모드는 단일 LLM 호출이라 chunk-경계 분리 오류는 없지만, LLM이
     // 같은 사람을 다른 라벨로 번갈아 부여하는 케이스는 inline 에서도 발생.
@@ -375,11 +456,63 @@ async fn run_inline_path(
     .await
 }
 
+/// pyannote-rs 가 분석한 발화 구간 (DiarSegment) 으로 Gemini 가 부여한
+/// 청크별 로컬 라벨 (화자A/B/C ...) 을 글로벌 ID 로 통일.
+///
+/// **전략**: 라인별로 [HH:MM:SS] 타임스탬프를 추출 → 해당 시각의 DiarSegment
+/// speaker_id 를 lookup → "화자{global+1}" 로 치환 (+1 = 0-indexed → 1-indexed
+/// 사용자 친화 표시). 청크 경계 무관한 글로벌 일관성을 즉시 확보.
+/// pyannote-rs 의 임베딩 기반 클러스터링이 Gemini 의 텍스트 기반 라벨링보다
+/// 훨씬 신뢰도 높음.
+///
+/// **매칭 정책**: 시각이 어떤 segment 안에도 안 들어가면 (무음/효과음/배경
+/// 잡음 등 pyannote 가 발화로 안 본 영역) **원본 라벨 그대로 유지**. 인접한
+/// segment 화자로 강제 매핑하면 다른 화자의 라벨이 무음 영역에 잘못 박힐
+/// 위험 — 안전 fallback 선택.
+fn apply_diar_labels(text: &str, diar: &[DiarSegment]) -> String {
+    if diar.is_empty() {
+        return text.to_string();
+    }
+    DIAR_LABEL_RE
+        .replace_all(text, |caps: &regex::Captures| {
+            let prefix = &caps[1];
+            let ts_h = &caps[2];
+            let ts_m = &caps[3];
+            let ts_s_opt = caps.get(4).map(|m| m.as_str());
+            let bracket = &caps[5];
+            let suffix = &caps[7];
+
+            let h_or_m: f64 = ts_h.parse().unwrap_or(0.0);
+            let m_or_s: f64 = ts_m.parse().unwrap_or(0.0);
+            let s: f64 = ts_s_opt.and_then(|x| x.parse().ok()).unwrap_or(-1.0);
+            let timestamp_sec = if s >= 0.0 {
+                h_or_m * 3600.0 + m_or_s * 60.0 + s
+            } else {
+                h_or_m * 60.0 + m_or_s
+            };
+
+            // 시각을 덮는 segment 만 매칭. 없으면 원본 라벨 유지 (안전 fallback).
+            let Some(seg) = diar
+                .iter()
+                .find(|seg| timestamp_sec >= seg.start_sec && timestamp_sec <= seg.end_sec)
+            else {
+                return caps.get(0).map(|m| m.as_str().to_string()).unwrap_or_default();
+            };
+
+            let new_label = format!("화자{}", seg.speaker_id + 1);
+            let ts_str = match ts_s_opt {
+                Some(sec) => format!("{}:{}:{}", ts_h, ts_m, sec),
+                None => format!("{}:{}", ts_h, ts_m),
+            };
+            format!("{}{}{}{}{}", prefix, ts_str, bracket, new_label, suffix)
+        })
+        .into_owned()
+}
+
 /// trimmed 시각 기준 [HH:MM:SS] 를 원본 시각으로 역변환.
 /// VAD trim 적용 후 Gemini 응답의 모든 timestamp 에 적용.
 fn map_timestamps_to_original(text: &str, map: &[SegmentMap]) -> String {
-    let re = Regex::new(r"\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]").unwrap();
-    re.replace_all(text, |caps: &regex::Captures| {
+    TS_REMAP_RE.replace_all(text, |caps: &regex::Captures| {
         let a: f64 = caps[1].parse().unwrap_or(0.0);
         let b: f64 = caps[2].parse().unwrap_or(0.0);
         let c: f64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(-1.0);

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -135,43 +135,64 @@ pub async fn run(
     // 원본 PCM 한 번에 분석 → 청크 무관 글로벌 speaker_id. 4시간 ~3분 CPU.
     // transcription 결과의 timestamp 와 시간 정렬해 라벨 통일.
     // 실패 시 (모델 없음 등) Gemini 자체 라벨 그대로 사용.
-    let diar_segments: Vec<DiarSegment> = {
-        emitter.emit("🎭 화자 분석 준비 중...", None);
-        match decode_to_16k_pcm(&file_path).await {
-            Ok(pcm) => {
-                let app_clone = app.clone();
-                emitter.emit("🎭 화자 분리 분석 중 (전체 음성)...", None);
-                let diar = tokio::task::spawn_blocking(move || {
-                    diarize_pcm(&app_clone, &pcm, 16000, None)
-                })
-                .await
-                .map_err(|e| ConverterError::Internal(format!("diarize join: {}", e)))
-                .and_then(|r| r);
-                match diar {
-                    Ok(segs) => {
-                        let unique: std::collections::BTreeSet<usize> =
-                            segs.iter().map(|s| s.speaker_id).collect();
-                        emitter.emit(
-                            format!("✅ 화자 {}명 식별 (segment {}개)", unique.len(), segs.len()),
-                            None,
-                        );
-                        segs
-                    }
-                    Err(e) => {
-                        emitter.emit(
-                            "⚠️ 화자 분리 실패 — Gemini 자체 라벨로 진행",
-                            Some(e.to_string()),
-                        );
-                        Vec::new()
+    //
+    // 4시간 초과 입력은 run_pipeline_core 가 어차피 reject 하므로 여기서
+    // 미리 duration 확인하고 diarize skip — over-limit 파일이 460MB PCM
+    // 디코드 + 수분 pyannote 분석 후에야 reject 되는 낭비 회피.
+    let diar_segments: Vec<DiarSegment> = match probe_duration(&file_path).await {
+        Ok(d) if d > MAX_DURATION_SEC => {
+            emitter.emit(
+                "⚠️ 길이 초과 — 화자 분리 skip (검증은 다음 단계에서)",
+                Some(format!(
+                    "{:.1}분 > {:.0}분",
+                    d / 60.0,
+                    MAX_DURATION_SEC / 60.0
+                )),
+            );
+            Vec::new()
+        }
+        _ => {
+            emitter.emit("🎭 화자 분석 준비 중...", None);
+            match decode_to_16k_pcm(&file_path).await {
+                Ok(pcm) => {
+                    let app_clone = app.clone();
+                    emitter.emit("🎭 화자 분리 분석 중 (전체 음성)...", None);
+                    let diar = tokio::task::spawn_blocking(move || {
+                        diarize_pcm(&app_clone, &pcm, 16000, None)
+                    })
+                    .await
+                    .map_err(|e| ConverterError::Internal(format!("diarize join: {}", e)))
+                    .and_then(|r| r);
+                    match diar {
+                        Ok(segs) => {
+                            let unique: std::collections::BTreeSet<usize> =
+                                segs.iter().map(|s| s.speaker_id).collect();
+                            emitter.emit(
+                                format!(
+                                    "✅ 화자 {}명 식별 (segment {}개)",
+                                    unique.len(),
+                                    segs.len()
+                                ),
+                                None,
+                            );
+                            segs
+                        }
+                        Err(e) => {
+                            emitter.emit(
+                                "⚠️ 화자 분리 실패 — Gemini 자체 라벨로 진행",
+                                Some(e.to_string()),
+                            );
+                            Vec::new()
+                        }
                     }
                 }
-            }
-            Err(e) => {
-                emitter.emit(
-                    "⚠️ PCM decode 실패 — 화자 분리 skip",
-                    Some(e.to_string()),
-                );
-                Vec::new()
+                Err(e) => {
+                    emitter.emit(
+                        "⚠️ PCM decode 실패 — 화자 분리 skip",
+                        Some(e.to_string()),
+                    );
+                    Vec::new()
+                }
             }
         }
     };
@@ -460,10 +481,10 @@ async fn run_inline_path(
 /// 청크별 로컬 라벨 (화자A/B/C ...) 을 글로벌 ID 로 통일.
 ///
 /// **전략**: 라인별로 [HH:MM:SS] 타임스탬프를 추출 → 해당 시각의 DiarSegment
-/// speaker_id 를 lookup → "화자{global+1}" 로 치환 (+1 = 0-indexed → 1-indexed
-/// 사용자 친화 표시). 청크 경계 무관한 글로벌 일관성을 즉시 확보.
-/// pyannote-rs 의 임베딩 기반 클러스터링이 Gemini 의 텍스트 기반 라벨링보다
-/// 훨씬 신뢰도 높음.
+/// speaker_id 를 lookup → "화자{id}" 로 치환. pyannote-rs `EmbeddingManager`
+/// 가 speaker_id 를 1-indexed (1, 2, 3, ...) 로 부여하므로 그대로 사용 (shift X).
+/// 청크 경계 무관한 글로벌 일관성을 즉시 확보. pyannote-rs 의 임베딩 기반
+/// 클러스터링이 Gemini 의 텍스트 기반 라벨링보다 훨씬 신뢰도 높음.
 ///
 /// **매칭 정책**: 시각이 어떤 segment 안에도 안 들어가면 (무음/효과음/배경
 /// 잡음 등 pyannote 가 발화로 안 본 영역) **원본 라벨 그대로 유지**. 인접한
@@ -499,7 +520,7 @@ fn apply_diar_labels(text: &str, diar: &[DiarSegment]) -> String {
                 return caps.get(0).map(|m| m.as_str().to_string()).unwrap_or_default();
             };
 
-            let new_label = format!("화자{}", seg.speaker_id + 1);
+            let new_label = format!("화자{}", seg.speaker_id);
             let ts_str = match ts_s_opt {
                 Some(sec) => format!("{}:{}:{}", ts_h, ts_m, sec),
                 None => format!("{}:{}", ts_h, ts_m),

--- a/src-tauri/src/converters/diarize.rs
+++ b/src-tauri/src/converters/diarize.rs
@@ -92,6 +92,10 @@ pub fn diarize_pcm(
     .map_err(|e| ConverterError::Internal(format!("EmbeddingExtractor: {:?}", e)))?;
     let mut manager = EmbeddingManager::new(max_spk);
 
+    // pyannote-rs `EmbeddingManager` 는 speaker_id 를 1-indexed 로 부여 (1, 2, 3, ...).
+    // 에러/None 케이스의 segment 는 results 에 안 넣음 → apply_diar_labels 의 "매칭
+    // 없음 → 원본 라벨 유지" fallback 으로 자연히 떨어진다. 임의의 0 같은 sentinel
+    // ID 를 넣으면 잘못된 화자에 합쳐지는 위험.
     let mut results: Vec<DiarSegment> = Vec::new();
     for seg_res in segments_iter {
         let seg = match seg_res {
@@ -101,24 +105,22 @@ pub fn diarize_pcm(
                 continue;
             }
         };
-        let speaker_id: usize = match extractor.compute(&seg.samples) {
-            Ok(embedding) => {
-                let v: Vec<f32> = embedding.collect();
-                let label = if manager.get_all_speakers().len() == max_spk {
-                    // max 도달 — 기존 화자 중 최적 매칭
-                    manager
-                        .get_best_speaker_match(v)
-                        .map(|s| s as usize)
-                        .unwrap_or(0)
-                } else {
-                    manager
-                        .search_speaker(v, SPEAKER_THRESHOLD)
-                        .map(|s| s as usize)
-                        .unwrap_or(manager.get_all_speakers().len())
-                };
-                label
+        let embedding = match extractor.compute(&seg.samples) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("[diarize] embedding fail @ {:.1}s: {:?}", seg.start, e);
+                continue;
             }
-            Err(_) => 0,
+        };
+        let v: Vec<f32> = embedding.collect();
+        let speaker_id_opt = if manager.get_all_speakers().len() == max_spk {
+            manager.get_best_speaker_match(v).ok()
+        } else {
+            manager.search_speaker(v, SPEAKER_THRESHOLD)
+        };
+        let Some(speaker_id) = speaker_id_opt else {
+            // max 도달 + threshold 못 넘는 신규 화자 — skip (원본 라벨 유지)
+            continue;
         };
         results.push(DiarSegment {
             start_sec: seg.start as f64,

--- a/src-tauri/src/converters/diarize.rs
+++ b/src-tauri/src/converters/diarize.rs
@@ -1,0 +1,137 @@
+//! 화자 분리 (speaker diarization) — pyannote-rs 기반.
+//!
+//! 입력: 16kHz mono PCM (i16). VAD 가 이미 만드는 포맷 그대로 사용 가능.
+//! 출력: Vec<DiarSegment { start_sec, end_sec, speaker_id }> — 4시간 전체를 한 번에
+//!       분석해 글로벌 speaker_id 부여. 청크 경계 무관.
+//!
+//! ONNX 모델 2개를 .app 안 resources/ 에서 로드:
+//!   - segmentation-3.0.onnx
+//!   - wespeaker_en_voxceleb_CAM++.onnx
+
+use crate::converters::error::{ConverterError, ConverterResult};
+use pyannote_rs::{EmbeddingExtractor, EmbeddingManager};
+use std::path::PathBuf;
+use tauri::Manager;
+
+/// 한 발화 구간의 화자 ID. speaker_id 는 0-indexed integer (글로벌 — 청크 무관).
+#[derive(Debug, Clone)]
+pub struct DiarSegment {
+    pub start_sec: f64,
+    pub end_sec: f64,
+    pub speaker_id: usize,
+}
+
+/// 사용자가 최대 화자 수 제한 — 기본 8 (대부분 회의 커버).
+/// 초과 발화는 가장 유사한 기존 화자로 흡수.
+const DEFAULT_MAX_SPEAKERS: usize = 8;
+
+/// search_speaker threshold — cosine distance. 0.5 가 pyannote 권장 default.
+/// 낮을수록 같은 화자 인정 빡빡함 (false negative ↑), 높을수록 느슨 (false positive ↑).
+const SPEAKER_THRESHOLD: f32 = 0.5;
+
+/// .app 안 resources 경로 — Tauri AppHandle 로 해결.
+fn resolve_model_path(app: &tauri::AppHandle, name: &str) -> ConverterResult<PathBuf> {
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| ConverterError::Internal(format!("resource_dir: {}", e)))?;
+    let candidates = [
+        resource_dir.join("resources").join(name),
+        resource_dir.join(name),
+    ];
+    for p in &candidates {
+        if p.is_file() {
+            return Ok(p.clone());
+        }
+    }
+    // dev fallback — src-tauri/resources/
+    let dev = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join(name);
+    if dev.is_file() {
+        return Ok(dev);
+    }
+    Err(ConverterError::Internal(format!(
+        "diarize 모델 {} 못 찾음 (resources/ 에 동봉 필요)",
+        name
+    )))
+}
+
+/// 16kHz mono PCM (i16) 입력 → 글로벌 화자 segments.
+/// 4시간 음성도 한 번에 처리 가능 (메모리 ~1.4GB peak 가능, 큰 입력은 사전 청크 권장).
+pub fn diarize_pcm(
+    app: &tauri::AppHandle,
+    pcm_i16: &[i16],
+    sample_rate: u32,
+    max_speakers: Option<usize>,
+) -> ConverterResult<Vec<DiarSegment>> {
+    if sample_rate != 16000 {
+        return Err(ConverterError::Internal(format!(
+            "diarize 입력은 16kHz 만 지원 (받은 값: {} Hz)",
+            sample_rate
+        )));
+    }
+
+    let seg_model = resolve_model_path(app, "segmentation-3.0.onnx")?;
+    let emb_model = resolve_model_path(app, "wespeaker_en_voxceleb_CAM++.onnx")?;
+
+    let max_spk = max_speakers.unwrap_or(DEFAULT_MAX_SPEAKERS);
+
+    let segments_iter = pyannote_rs::get_segments(
+        pcm_i16,
+        sample_rate,
+        seg_model.to_str().ok_or_else(|| {
+            ConverterError::Internal("seg_model path non-UTF8".into())
+        })?,
+    )
+    .map_err(|e| ConverterError::Internal(format!("get_segments: {:?}", e)))?;
+
+    let mut extractor = EmbeddingExtractor::new(emb_model.to_str().ok_or_else(|| {
+        ConverterError::Internal("emb_model path non-UTF8".into())
+    })?)
+    .map_err(|e| ConverterError::Internal(format!("EmbeddingExtractor: {:?}", e)))?;
+    let mut manager = EmbeddingManager::new(max_spk);
+
+    let mut results: Vec<DiarSegment> = Vec::new();
+    for seg_res in segments_iter {
+        let seg = match seg_res {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[diarize] segment skip: {:?}", e);
+                continue;
+            }
+        };
+        let speaker_id: usize = match extractor.compute(&seg.samples) {
+            Ok(embedding) => {
+                let v: Vec<f32> = embedding.collect();
+                let label = if manager.get_all_speakers().len() == max_spk {
+                    // max 도달 — 기존 화자 중 최적 매칭
+                    manager
+                        .get_best_speaker_match(v)
+                        .map(|s| s as usize)
+                        .unwrap_or(0)
+                } else {
+                    manager
+                        .search_speaker(v, SPEAKER_THRESHOLD)
+                        .map(|s| s as usize)
+                        .unwrap_or(manager.get_all_speakers().len())
+                };
+                label
+            }
+            Err(_) => 0,
+        };
+        results.push(DiarSegment {
+            start_sec: seg.start as f64,
+            end_sec: seg.end as f64,
+            speaker_id,
+        });
+    }
+
+    Ok(results)
+}
+
+/// PCM segments 가 비어있는 케이스 등 — 안전한 기본값.
+#[allow(dead_code)]
+pub fn empty() -> Vec<DiarSegment> {
+    Vec::new()
+}

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod audio_pipeline;
 pub mod audio_splitter;
+pub mod diarize;
 pub mod commands;
 pub mod error;
 pub mod keychain;

--- a/src-tauri/src/converters/progress.rs
+++ b/src-tauri/src/converters/progress.rs
@@ -19,6 +19,10 @@ pub struct ProgressStep {
     /// 0.0 ~ 1.0 — 알 수 있는 경우만
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress: Option<f32>,
+    /// stable id — 같은 stepId 면 ProgressPanel 이 in-place 갱신 (heartbeat / progress 갱신용).
+    /// None 이면 새 row append (기본 동작).
+    #[serde(rename = "stepId", skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -83,6 +87,7 @@ impl ProgressEmitter {
             step: self.prefix_step(step.into()),
             detail,
             progress: None,
+            step_id: None,
         };
         let _ = self.app.emit("converter-progress", event);
     }
@@ -94,6 +99,27 @@ impl ProgressEmitter {
             step: self.prefix_step(step.into()),
             detail,
             progress: Some(progress),
+            step_id: None,
+        };
+        let _ = self.app.emit("converter-progress", event);
+    }
+
+    /// 같은 step_id 의 이전 emit 을 in-place 갱신 — heartbeat / 진행률 표시.
+    /// 첫 emit (id 미존재) 이면 append, 이후엔 같은 row 의 텍스트/progress 만 갱신.
+    /// ProgressPanel 이 stepId 매칭 시 row replace 처리.
+    pub fn emit_update(
+        &self,
+        step_id: impl Into<String>,
+        step: impl Into<String>,
+        detail: Option<String>,
+        progress: Option<f32>,
+    ) {
+        let event = ProgressStep {
+            job_id: self.job_id.clone(),
+            step: self.prefix_step(step.into()),
+            detail,
+            progress,
+            step_id: Some(step_id.into()),
         };
         let _ = self.app.emit("converter-progress", event);
     }

--- a/src-tauri/src/converters/vad.rs
+++ b/src-tauri/src/converters/vad.rs
@@ -437,22 +437,29 @@ pub async fn trim_silence(
         .spawn()
         .map_err(|e| ConverterError::Vad(format!("ffmpeg concat spawn: {}", e)))?;
 
-    // Heartbeat task — emits an elapsed-time message every 2 seconds so the
-    // UI keeps showing fresh activity while ffmpeg processes the concat.
+    // Heartbeat task — 같은 step_id 로 in-place 갱신 (ProgressPanel 이 row replace).
+    // 1초마다 progress 추정 (elapsed / estimated, estimated = total_speech 의 1x 가정).
+    // 입력 trim 후 길이로 concat 재인코딩 속도가 ~real-time 1x 라는 경험적 추정.
     let hb_emitter = emitter.clone();
     let hb_token = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let hb_done = hb_token.clone();
+    let estimated_total = total_speech.max(1.0);
     let hb_handle = tokio::spawn(async move {
         let start = std::time::Instant::now();
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             if hb_done.load(std::sync::atomic::Ordering::Relaxed) {
                 break;
             }
-            let secs = start.elapsed().as_secs();
-            hb_emitter.emit(
-                format!("⏳ 무음 잘라내는 중... ({}초 경과)", secs),
-                None,
+            let secs = start.elapsed().as_secs_f64();
+            // 95% 까지만 progress 표시 — 실제 완료 emit 이 100% 찍을 때까지 cap.
+            let ratio = (secs / estimated_total).min(0.95) as f32;
+            let pct = (ratio * 100.0).round() as u32;
+            hb_emitter.emit_update(
+                "vad-trim",
+                format!("⏳ 무음 잘라내는 중... ({}%)", pct),
+                Some(format!("{:.0}초 경과", secs)),
+                Some(ratio),
             );
         }
     });

--- a/src-tauri/src/converters/vad.rs
+++ b/src-tauri/src/converters/vad.rs
@@ -268,7 +268,8 @@ fn post_process(probs: &[f32], cfg: PostProcessConfig) -> Vec<SpeechSegment> {
 // ─── trim_silence — doc-converter trim-silence.ts:trimSilence 1:1 ───
 
 /// ffmpeg 로 input → 16kHz mono PCM (Int16Array 동치)
-async fn decode_to_16k_pcm(input: &Path) -> ConverterResult<Vec<i16>> {
+/// pub — diarize 모듈도 같은 PCM 형식 (16kHz mono i16) 사용
+pub async fn decode_to_16k_pcm(input: &Path) -> ConverterResult<Vec<i16>> {
     let output = Command::new(ffmpeg_path()?)
         .args([
             "-i",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -35,6 +35,8 @@
     ],
     "resources": [
       "resources/silero_vad.onnx",
+      "resources/segmentation-3.0.onnx",
+      "resources/wespeaker_en_voxceleb_CAM++.onnx",
       "resources/meeting-templates/*.md"
     ],
     "icon": [

--- a/src/components/convert/ProgressPanel.tsx
+++ b/src/components/convert/ProgressPanel.tsx
@@ -64,11 +64,22 @@ export function ProgressPanel({ state }: ProgressPanelProps) {
                     .map((s, i) => {
                         const { icon, text } = iconFor(s.step);
                         return (
-                            <li key={state.steps.length - 1 - i} className="convert-progress-step">
+                            <li
+                                key={s.stepId ?? `${state.steps.length - 1 - i}`}
+                                className="convert-progress-step"
+                            >
                                 <div className="step-main">
                                     {icon && <span className="step-icon">{icon}</span>}
                                     <span className="step-text">{text}</span>
                                 </div>
+                                {typeof s.progress === 'number' && (
+                                    <div className="step-progress-bar">
+                                        <div
+                                            className="step-progress-fill"
+                                            style={{ width: `${Math.round(s.progress * 100)}%` }}
+                                        />
+                                    </div>
+                                )}
                                 {s.detail && <div className="step-detail">{s.detail}</div>}
                             </li>
                         );

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -388,6 +388,20 @@
     margin-top: 2px;
     margin-left: 22px;
 }
+/* step 자체에 progress bar (heartbeat row) — % 시각화 */
+.step-progress-bar {
+    margin: 4px 0 0 22px;
+    height: 4px;
+    background: var(--bg-secondary, rgba(0, 0, 0, 0.06));
+    border-radius: 2px;
+    overflow: hidden;
+}
+.step-progress-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 2px;
+    transition: width 0.4s ease;
+}
 .convert-progress-error {
     color: #f87171;
     background: rgba(248, 113, 113, 0.08);

--- a/src/hooks/useConverter.ts
+++ b/src/hooks/useConverter.ts
@@ -56,10 +56,18 @@ export function useConverter() {
                     if (!runningRef.current) return;
                     // 다른 윈도우의 동시 진행 job 또는 stale event 무시
                     if (!currentJobIdRef.current || step.jobId !== currentJobIdRef.current) return;
-                    setJobState((prev) => ({
-                        ...prev,
-                        steps: [...prev.steps, step],
-                    }));
+                    setJobState((prev) => {
+                        // stepId 있고 이전에 같은 id row 가 있으면 in-place 갱신 (heartbeat)
+                        if (step.stepId) {
+                            const idx = prev.steps.findIndex((s) => s.stepId === step.stepId);
+                            if (idx >= 0) {
+                                const next = [...prev.steps];
+                                next[idx] = step;
+                                return { ...prev, steps: next };
+                            }
+                        }
+                        return { ...prev, steps: [...prev.steps, step] };
+                    });
                 });
                 unlistenRef.current = unlisten;
             } catch (err) {

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -97,6 +97,8 @@ export interface ProgressStep {
     step: string;
     detail?: string;
     progress?: number;
+    /** stable id — 같은 stepId 면 in-place 갱신 (heartbeat / progress). undefined 면 append. */
+    stepId?: string;
 }
 
 // ─── UI 상태 ───


### PR DESCRIPTION
## Summary

청크 모드에서 Gemini 가 각 청크마다 `화자A` 부터 다시 번호 매기는 구조적 한계를 해결. pyannote ONNX 모델 (segmentation-3.0 + wespeaker CAM++) 로 원본 오디오 전체를 임베딩 기반 분석해 청크 경계와 무관한 글로벌 `speaker_id` 부여 → transcript 의 `[HH:MM:SS]` 타임스탬프로 lookup 해 라벨 치환.

## 배경

사용자 보고: "화자A와 B의 분리가 잘 안되고, 너무 뒤죽박죽. 특히 분할된 것들 사이가 뒤죽박죽이야."

조사 결과 (2026-05):
- 현재 아키텍처: 청크별 Gemini 가 텍스트 기반 라벨링 → 청크 2,3,4... 의 `화자A` 는 청크 1 의 `화자A` 와 다른 사람일 수 있음
- 청크 사이 컨텍스트만으로는 임베딩 일관성 보장 불가능

## 기술 선정

| 후보 | 결정 | 사유 |
|---|---|---|
| speakrs (Rust) | ❌ | openblas/ndarray-linalg 빌드 실패 (Apple Silicon arm64) |
| Deepgram Nova-3 (API) | ❌ | 외부 API 비용 + 사용자 음성 데이터 외부 송신 |
| **pyannote-rs (Rust)** | ✅ | knf-rs + ort 만으로 동작, MIT, macOS CoreML 가속, 1h ~1분 CPU |
| Pass-2 LLM 후처리 | ❌ | 토큰 비용 + 임베딩 정보 없이 텍스트만으로 판단 불안정 |

## 구현

### 신규
- [src-tauri/src/converters/diarize.rs](src-tauri/src/converters/diarize.rs) — pyannote-rs 래퍼. 16kHz mono i16 PCM → `Vec<DiarSegment{ start, end, speaker_id }>`. 최대 8 화자 (초과 시 가장 유사한 기존 화자로 흡수). cosine threshold 0.5.
- `src-tauri/scripts/download-diarize-models.sh` — ONNX 모델 다운로드 (segmentation-3.0 ~6MB, wespeaker CAM++ ~28MB)

### 변경
- `audio_pipeline.rs`:
  - `run()` 진입 직후 `tokio::spawn_blocking` 으로 diarize 호출 → `Vec<DiarSegment>` 보관
  - `apply_diar_labels()` 신규 — 라인별 `[HH:MM:SS]` 타임스탬프 lookup → `화자{speaker_id+1}` 치환
  - inline / chunked 양쪽 경로 모두 `map_timestamps_to_original` 직후 + `maybe_dedup_speakers` 직전 적용 → 원본 시각 기준 정합
  - **매칭 실패 (무음/효과음 영역) 시 원본 라벨 유지** — 인접 segment 화자로 강제 매핑하면 잘못된 라벨 박힐 위험 회피
  - `DIAR_LABEL_RE` / `TS_REMAP_RE` `LazyLock` 캐싱
- `vad.rs::decode_to_16k_pcm` `pub` 화 — diarize 와 PCM 형식 공유
- `Cargo.toml` — `pyannote-rs 0.3` + `coreml` feature. tauri `~2.10` 핀 (pyannote-rs 추가 시 tauri 2.3 downgrade + wry API mismatch 회피)
- `tauri.conf.json` `bundle.resources` — ONNX 두 개 등록
- `.gitignore` — ONNX 모델 제외 (~34MB)
- `package.json` — `setup:diarize` script + `tauri:build` 가 `setup:all` chain
- `.github/workflows/release.yml` — "Download speaker diarization models" step 추가 (tauri-action 이 `setup:all` chain 우회하므로 명시 필요)

## Fallback 설계

다음 모든 경로에서 `Vec::new()` 로 떨어져 Gemini 자체 라벨로 진행 (사이트 다운 없음):
- ONNX 모델 누락
- PCM decode 실패
- pyannote-rs 분석 에러
- 매칭 segment 없음 (line-level)

## 빌드 검증

- `cargo check` — errors 0, warnings 12 (전부 기존 dead-code)
- `cargo test --lib map_timestamps_to_original` — passed
- `cargo build --release` — 37.86s
- `npm run tauri build` — `.app 229MB / .dmg 99MB` (모델 ~34MB 포함)

## 알려진 한계 (향후 개선)

- **PCM 460MB 메모리 + 직렬 실행**: 4시간 × 16kHz × i16 ~460MB. diarize 가 transcription 시작 전 완료 대기 (~1-3분). `tokio::join!` 병렬화 가능하지만 peak RAM ↑. 실측 후 결정.
- **짧은 segment 오분류 시 라인 튐**: 라인별 즉시 치환이라 pyannote 가 짧은 segment 잘못 분류하면 라벨이 튐. 향후 majority-vote smoothing 검토.

## Test plan

- [ ] 5~6인 회의 음성 (1시간+) → 청크 경계 사이 화자 라벨 일관성 육안 확인
- [ ] 단일 인터뷰 (10분 미만, inline path) → 화자 분리 정확성
- [ ] 무음 많은 음성 (강의 등) → 매칭 실패 시 원본 라벨 유지되는지
- [ ] 모델 파일 삭제 후 실행 → fallback 동작 (Gemini 라벨 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)