### PR TITLE
fix(preview): LLM 회의록 multi-line table row 정상화 preprocess

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -42,6 +42,35 @@ function fixEmphasis(md: string): string {
     return md.replace(/(\S)(\*{1,2})(?=[^\s*\p{P}])/gu, '$1$2​');
 }
 
+// GFM table row 는 한 줄에 시작·종료가 정상이지만, LLM 회의록 자동 생성
+// (Gemini/Claude) 이 긴 row 를 시각적 wrap 형태로 multi-line 으로 출력하면
+// GFM parser 가 첫 줄을 단일 셀 row 로, 다음 줄을 plain text 로 깨뜨림.
+// 휴리스틱: `|` 로 시작 + `|` 로 안 끝나는 줄 + (선택 빈 줄들) + leading
+// whitespace + `|` 시작 줄 → 공백 하나로 join. 다단계 wrap 도 loop 로 흡수.
+// ``` fence 안은 mask 후 복원.
+function joinBrokenTableRows(md: string): string {
+    // ``` fence 안 markdown 은 row join 대상 제외. NUL byte sentinel (실제 문서에
+    // 등장할 일 없음) 으로 mask 후 복원 — 평이한 토큰은 본문 충돌 위험.
+    const fenceParts: string[] = [];
+    const masked = md.replace(/```[\s\S]*?```/g, (m) => {
+        const placeholder = `\x00MMF${fenceParts.length}\x00`;
+        fenceParts.push(m);
+        return placeholder;
+    });
+
+    let result = masked;
+    let prev: string | null = null;
+    while (prev !== result) {
+        prev = result;
+        result = result.replace(
+            /^(\|[^\n]*[^|\s])[ \t]*\n(?:[ \t]*\n)*[ \t]+(\|)/gm,
+            '$1 $2',
+        );
+    }
+
+    return result.replace(/\x00MMF(\d+)\x00/g, (_, i) => fenceParts[Number(i)]);
+}
+
 /** save 시점에 fixEmphasis 가 삽입한 zero-width 제거 */
 function stripDisplayHelpers(md: string): string {
     return md.replace(/​/g, '');
@@ -437,7 +466,7 @@ function RichEditor({
             // Smart typography — `->` → `→`, `--` → `—`, `(c)` → `©` 등 자동 치환
             Typography,
         ],
-        content: fixEmphasis(body), // ** 인접 bold 인식되도록 zero-width 삽입
+        content: fixEmphasis(joinBrokenTableRows(body)), // ** 인접 bold 인식되도록 zero-width 삽입 + LLM multi-line table row 정상화
         onUpdate: ({ editor }) => {
             const md: string = editor.storage.markdown?.getMarkdown() ?? '';
             // 직렬화 시 fixEmphasis 의 zero-width 제거 → 파일에는 비가시 문자 안 들어감
@@ -518,7 +547,7 @@ function RichEditor({
         // fast-path: 길이 차이 ≥ 8 면 trim 비교 skip — 큰 문서 비용 절감
         const lenDiff = Math.abs(cleanedCurrent.length - body.length);
         if (lenDiff > 8 || cleanedCurrent.trim() !== body.trim()) {
-            editor.commands.setContent(fixEmphasis(body), { emitUpdate: false });
+            editor.commands.setContent(fixEmphasis(joinBrokenTableRows(body)), { emitUpdate: false });
         }
     }, [body, editor]);
 
@@ -537,7 +566,7 @@ export function Preview({ content, fontSize = 14, onChange }: PreviewProps) {
         return {
             fields: split.fields,
             body: split.body,
-            processedBody: fixEmphasis(split.body),
+            processedBody: fixEmphasis(joinBrokenTableRows(split.body)),
             rawFrontmatter: split.rawFrontmatter,
         };
     }, [content]);

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -49,22 +49,46 @@ function fixEmphasis(md: string): string {
 // whitespace + `|` 시작 줄 → 공백 하나로 join. 다단계 wrap 도 loop 로 흡수.
 // ``` fence 안은 mask 후 복원.
 function joinBrokenTableRows(md: string): string {
-    // GFM fence (``` 또는 ~~~, 3개 이상) 안 markdown 은 row join 대상 제외.
-    // GFM spec 4.5 — fence 는 line 시작 + 0~3 leading spaces 만 인정. 코드 블록
-    // 내부의 inline ``` 시퀀스 (JS 문자열, 문서 예시 등) 는 fence 아님.
-    // m flag + `^...$` 로 line-anchored 매치, backreference \1 로 같은 종류·길이
-    // 종료 fence 만 닫기. NUL byte sentinel (실제 문서 등장 가능성 0) 으로 mask.
-    const fenceParts: string[] = [];
-    const masked = md.replace(
-        /^[ ]{0,3}(`{3,}|~{3,}).*$[\s\S]*?^[ ]{0,3}\1[ \t]*$/gm,
-        (m) => {
-            const placeholder = `\x00MMF${fenceParts.length}\x00`;
-            fenceParts.push(m);
-            return placeholder;
-        },
-    );
+    // CRLF → LF 통일 (Windows 파일 호환). Renderer 단 normalize 라 saved file 의
+    // line ending 영향 X (tiptap-markdown 출력은 항상 LF, ReadOnly 는 display 만).
+    const normalized = md.replace(/\r\n/g, '\n');
 
-    let result = masked;
+    // GFM fence (``` 또는 ~~~) line-by-line scan. backreference 패턴은 종료 fence
+    // 가 시작보다 긴 경우 (GFM spec 4.5 허용 — 예: ```` 시작 ``` 종료, code 안 백틱
+    // 노출용 흔한 패턴) 를 못 잡으므로 scan 으로 종료 길이 ≥ 시작 길이 dynamic
+    // 매치. line-anchored 라 inline ``` 시퀀스 (JS 문자열, 문서 예시) 는 fence
+    // 로 오인 안 됨. NUL byte sentinel 로 mask 후 복원.
+    const fenceParts: string[] = [];
+    const lines = normalized.split('\n');
+    const out: string[] = [];
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const openMatch = line.match(/^[ ]{0,3}(([`~])\2{2,})/);
+        if (openMatch) {
+            const fenceChar = openMatch[2];
+            const minLen = openMatch[1].length;
+            const escaped = fenceChar === '`' ? '`' : '~';
+            const closeRe = new RegExp(
+                `^[ ]{0,3}${escaped}{${minLen},}[ \\t]*$`,
+            );
+            let j = i + 1;
+            while (j < lines.length && !closeRe.test(lines[j])) j++;
+            if (j < lines.length) {
+                const block = lines.slice(i, j + 1).join('\n');
+                fenceParts.push(block);
+                out.push(`\x00MMF${fenceParts.length - 1}\x00`);
+                i = j + 1;
+                continue;
+            }
+            // 종료 fence 없음 (unterminated) → mask 안 함, 그 줄 그대로 진행
+        }
+        out.push(line);
+        i++;
+    }
+    let result = out.join('\n');
+
+    // multi-line table row join. CRLF 는 위에서 LF 로 통일됨.
     let prev: string | null = null;
     while (prev !== result) {
         prev = result;
@@ -74,7 +98,7 @@ function joinBrokenTableRows(md: string): string {
         );
     }
 
-    return result.replace(/\x00MMF(\d+)\x00/g, (_, i) => fenceParts[Number(i)]);
+    return result.replace(/\x00MMF(\d+)\x00/g, (_, idx) => fenceParts[Number(idx)]);
 }
 
 /** save 시점에 fixEmphasis 가 삽입한 zero-width 제거 */

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -49,10 +49,11 @@ function fixEmphasis(md: string): string {
 // whitespace + `|` 시작 줄 → 공백 하나로 join. 다단계 wrap 도 loop 로 흡수.
 // ``` fence 안은 mask 후 복원.
 function joinBrokenTableRows(md: string): string {
-    // ``` fence 안 markdown 은 row join 대상 제외. NUL byte sentinel (실제 문서에
-    // 등장할 일 없음) 으로 mask 후 복원 — 평이한 토큰은 본문 충돌 위험.
+    // GFM fence (``` 또는 ~~~, 3개 이상) 안 markdown 은 row join 대상 제외.
+    // backreference \1 로 같은 종류·길이 종료까지 매치 (GFM spec 4.5).
+    // NUL byte sentinel (실제 문서 등장 가능성 0) 으로 mask 후 복원.
     const fenceParts: string[] = [];
-    const masked = md.replace(/```[\s\S]*?```/g, (m) => {
+    const masked = md.replace(/(`{3,}|~{3,})[\s\S]*?\1/g, (m) => {
         const placeholder = `\x00MMF${fenceParts.length}\x00`;
         fenceParts.push(m);
         return placeholder;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -74,14 +74,15 @@ function joinBrokenTableRows(md: string): string {
             );
             let j = i + 1;
             while (j < lines.length && !closeRe.test(lines[j])) j++;
-            if (j < lines.length) {
-                const block = lines.slice(i, j + 1).join('\n');
-                fenceParts.push(block);
-                out.push(`\x00MMF${fenceParts.length - 1}\x00`);
-                i = j + 1;
-                continue;
-            }
-            // 종료 fence 없음 (unterminated) → mask 안 함, 그 줄 그대로 진행
+            // GFM/CommonMark spec: unterminated fence (j === lines.length) 는
+            // EOF 까지 code block 으로 처리. 우리도 같은 방식으로 끝까지 mask 해
+            // join 이 code 영역 침범하는 것 차단.
+            const endIdx = j < lines.length ? j + 1 : j;
+            const block = lines.slice(i, endIdx).join('\n');
+            fenceParts.push(block);
+            out.push(`\x00MMF${fenceParts.length - 1}\x00`);
+            i = endIdx;
+            continue;
         }
         out.push(line);
         i++;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -50,14 +50,19 @@ function fixEmphasis(md: string): string {
 // ``` fence 안은 mask 후 복원.
 function joinBrokenTableRows(md: string): string {
     // GFM fence (``` 또는 ~~~, 3개 이상) 안 markdown 은 row join 대상 제외.
-    // backreference \1 로 같은 종류·길이 종료까지 매치 (GFM spec 4.5).
-    // NUL byte sentinel (실제 문서 등장 가능성 0) 으로 mask 후 복원.
+    // GFM spec 4.5 — fence 는 line 시작 + 0~3 leading spaces 만 인정. 코드 블록
+    // 내부의 inline ``` 시퀀스 (JS 문자열, 문서 예시 등) 는 fence 아님.
+    // m flag + `^...$` 로 line-anchored 매치, backreference \1 로 같은 종류·길이
+    // 종료 fence 만 닫기. NUL byte sentinel (실제 문서 등장 가능성 0) 으로 mask.
     const fenceParts: string[] = [];
-    const masked = md.replace(/(`{3,}|~{3,})[\s\S]*?\1/g, (m) => {
-        const placeholder = `\x00MMF${fenceParts.length}\x00`;
-        fenceParts.push(m);
-        return placeholder;
-    });
+    const masked = md.replace(
+        /^[ ]{0,3}(`{3,}|~{3,}).*$[\s\S]*?^[ ]{0,3}\1[ \t]*$/gm,
+        (m) => {
+            const placeholder = `\x00MMF${fenceParts.length}\x00`;
+            fenceParts.push(m);
+            return placeholder;
+        },
+    );
 
     let result = masked;
     let prev: string | null = null;


### PR DESCRIPTION
## Summary

회의록 자동 생성 시 LLM (Gemini/Claude) 이 긴 GFM 테이블 row 를 시각적 wrap 형태로 multi-line 으로 출력 → GFM parser 가 첫 줄을 단일 셀 row 로, 다음 줄들을 plain text 로 깨뜨림. 사용자가 본 \"헤더 + 첫 셀만 살고 나머진 줄바꿈된 plain text\" 증상의 직접 원인.

## Root Cause (workflow 4-차원 검증 종합)

**Layer 1 — Input 오염 (상류, 주범)**: [notes_pipeline.rs:75-80](src-tauri/src/converters/notes_pipeline.rs#L75-L80) prompt '출력 규칙' 에 markdown table 작성 룰 없음 + 빌트인 템플릿 3개에 table 예시 0건 → LLM 이 참조할 schema 없음. 저장 직전 normalize/lint 0건.

**Layer 2 — Renderer 가 fix 불가 (하류)**: GFM spec §4.10 — row 는 single-line, 빈 줄 만나면 table 종료. \`remark-gfm\` / \`tiptap-markdown\` 모두 row recovery 옵션 없음 (remark-gfm issue #40 \"not planned\" close 2022). **renderer 단에서 spec 상 고칠 방법 존재 안 함** → 진입 전 source preprocess 가 유일한 fix.

**Aggravator**: [Preview.tsx:429](src/components/Preview.tsx#L429) \`Markdown.configure({ breaks: true })\` (v0.3.0 PR #20 도입) — 머리말 단락 합쳐짐 fix 용이지만 이미 깨진 cell 안 \`\\n\` 을 \`<br>\` 로 변환해 Rich Text 편집/저장 시 \`[hardBreak]\` 리터럴 손실까지 발생.

## 변경

**[Preview.tsx](src/components/Preview.tsx)** — \`joinBrokenTableRows()\` 함수 추가, 3곳 호출 지점 적용:

\`\`\`ts
function joinBrokenTableRows(md: string): string {
    // ``` fence 안 markdown 은 row join 대상 제외. NUL byte sentinel.
    const fenceParts: string[] = [];
    const masked = md.replace(/\`\`\`[\\s\\S]*?\`\`\`/g, (m) => {
        const placeholder = \`\\x00MMF\${fenceParts.length}\\x00\`;
        fenceParts.push(m);
        return placeholder;
    });

    let result = masked;
    let prev: string | null = null;
    while (prev !== result) {
        prev = result;
        result = result.replace(
            /^(\\|[^\\n]*[^|\\s])[ \\t]*\\n(?:[ \\t]*\\n)*[ \\t]+(\\|)/gm,
            '\$1 \$2',
        );
    }

    return result.replace(/\\x00MMF(\\d+)\\x00/g, (_, i) => fenceParts[Number(i)]);
}
\`\`\`

**휴리스틱**: \`|\` 로 시작 + \`|\` 로 안 끝나는 줄 + (선택 빈 줄들) + leading whitespace + \`|\` 시작 줄 → 공백 하나로 join. 다단계 wrap 도 \`while (prev !== result)\` loop 로 흡수.

**3곳 호출**:
- read-only ReactMarkdown 경로 (\`processedBody\`)
- Rich Text content init (\`content: fixEmphasis(joinBrokenTableRows(body))\`)
- body prop 변경 시 setContent

## 남은 작업 (별도 issue)

- **단기**: notes_pipeline prompt 에 table 작성 룰 추가 (재발 차단)
- **장기**: \`breaks: true\` 적용 범위 축소 (table 영역 우회 또는 머리말 패턴 detect)

## 빌드 검증

- \`npm run build\` (tsc + vite) — 4.23s pass
- 회귀 위험 낮음 (preprocess 추가만, 기존 동작 영향 X)

## Test plan

- [ ] LLM 자동 생성 회의록 .md (multi-line table row 포함) 열기 → 테이블 정상 렌더링 확인
- [ ] 정상 single-line table 도 그대로 렌더링 (회귀 없음)
- [ ] \`\`\` 코드 블록 안에 \`|\` 시작 문자열 있는 경우 영향 없음 (fence mask 동작)
- [ ] Rich Text 모드에서 multi-line table 편집 → 저장 → 다시 열기 (round-trip 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)