### PR TITLE
fix: 파일 열기 빈 페이지·테이블 데이터 소실·커스텀 배경/코드블록/테이블 폭 (v0.3.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,17 @@ pub fn run() {
             if let tauri::RunEvent::Opened { urls } = &event {
                 for url in urls {
                     if let Ok(path) = url.to_file_path() {
+                        // OS 더블클릭으로 전달된 파일 = 사용자가 의도한 파일.
+                        // capabilities 의 정적 fs scope ($HOME/** 등) 밖 경로
+                        // (외장 드라이브 /Volumes, 숨김 .폴더 포함 경로 — macOS 는
+                        // require_literal_leading_dot 기본 true) 는 readTextFile 이
+                        // 조용히 거부돼 빈 페이지가 됐음 → 런타임 scope 허용.
+                        {
+                            use tauri_plugin_fs::FsExt;
+                            if let Err(e) = app.fs_scope().allow_file(&path) {
+                                eprintln!("[open-file] fs scope allow_file 실패: {e}");
+                            }
+                        }
                         if let Some(path_str) = path.to_str() {
                             let path_string = path_str.to_string();
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -1902,20 +1902,22 @@ body.is-resizing .split-pane {
   font-size: 0.92em;
 }
 
+/* 코드 블록 — 본문(거의 흰 배경)과 명확히 구분되도록 GitHub 표준 색 채택.
+   회색 배경 + 뚜렷한 경계선 + 둥근 모서리 + 넉넉한 padding (WCAG 대비 충족). */
 [data-theme="light"] .markdown-body pre,
 [data-theme="light"] .tiptap-rich pre {
-  background: rgba(0, 0, 0, 0.05);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 6px;
-  padding: 1em;
+  background: #f6f8fa;
+  border: 1px solid #d1d9e0;
+  border-radius: 8px;
+  padding: 14px 16px;
   overflow-x: auto;
 }
 [data-theme="dark"] .markdown-body pre,
 [data-theme="dark"] .tiptap-rich pre {
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  padding: 1em;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 14px 16px;
   overflow-x: auto;
 }
 
@@ -2024,15 +2026,22 @@ body.is-resizing .split-pane {
   /* baseline 보정 — flex container 안에서 첫 줄 정중앙 */
   margin-top: 0.15em;
 }
+/* table-layout: auto + width: auto → 컬럼이 content 폭에 맞춰 유연하게.
+   숫자(#)처럼 글자수 적은 컬럼은 좁게, 긴 컬럼은 넓게. max-width 100% 로
+   넘칠 때만 채움 폭 제한 (이전 fixed+100% 는 모든 컬럼 균등 분배라 # 컬럼이
+   과도하게 넓었음). */
 .tiptap-rich table {
   border-collapse: collapse;
-  table-layout: fixed;
-  width: 100%;
+  table-layout: auto;
+  width: auto;
+  max-width: 100%;
 }
 .tiptap-rich table td, .tiptap-rich table th {
   border: 1px solid var(--border-primary);
   padding: 6px 10px;
   vertical-align: middle;
+  /* 빈/짧은 셀이 너무 좁아 편집 클릭이 어려워지는 것 방지 */
+  min-width: 2.5em;
 }
 
 /* YAML frontmatter — Preview 상단 메타 박스 */
@@ -2214,7 +2223,10 @@ body.is-resizing .split-pane {
 }
 
 .markdown-body table {
-  width: 100%;
+  /* content 기반 폭 — 짧은 컬럼은 좁게, 길면 max-width 까지 (Rich Text 와 동일 정책) */
+  width: auto;
+  max-width: 100%;
+  table-layout: auto;
   border-collapse: collapse;
   margin: 1em 0;
   font-size: var(--text-sm);

--- a/src/App.css
+++ b/src/App.css
@@ -2337,7 +2337,11 @@ body.is-resizing .split-pane {
 }
 
 /* ---------- Highlight.js Override ---------- */
-.hljs {
+/* hljs 토큰 컨테이너(code)만 배경/패딩 제거 — pre 의 배경·패딩(코드 블록 스타일)은 보존.
+   ⚠️ 리치텍스트 코드블록은 <pre class="hljs"> 구조라, .hljs 로 두면 pre 의 배경·패딩까지
+   !important 로 죽여 코드 블록 구분이 사라졌음. code.hljs 로 한정해 pre 스타일을 살린다.
+   (읽기 전용은 <pre><code class="hljs"> 라 code 에 hljs → 동일하게 처리됨) */
+code.hljs {
   background: transparent !important;
   padding: 0 !important;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1782,7 +1782,7 @@ body.is-resizing .split-pane {
   background: var(--user-bg) !important;
   filter: brightness(0.95);
 }
-[data-theme="dark"][data-custom-bg] .cm-activeLineGutter {
+[data-theme="dark"] [data-custom-bg] .cm-activeLineGutter {
   filter: brightness(1.15);
 }
 
@@ -1809,62 +1809,62 @@ body.is-resizing .split-pane {
    ─────────────────────────────────────────────────────────────── */
 
 /* 테이블 헤더(th) — 고정 stripe(#F8F8F8) 대신 배경 위 약간 진한 톤 */
-[data-theme="light"][data-custom-bg] .markdown-body th,
-[data-theme="light"][data-custom-bg] .tiptap-rich th {
+[data-theme="light"] [data-custom-bg] .markdown-body th,
+[data-theme="light"] [data-custom-bg] .tiptap-rich th {
   background: rgba(0, 0, 0, 0.06);
 }
-[data-theme="dark"][data-custom-bg] .markdown-body th,
-[data-theme="dark"][data-custom-bg] .tiptap-rich th {
+[data-theme="dark"] [data-custom-bg] .markdown-body th,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich th {
   background: rgba(255, 255, 255, 0.08);
 }
 
 /* 테이블 border(td·th) — 고정 회색(#E0E0E0 / --border-primary) 대신 반투명 */
-[data-theme="light"][data-custom-bg] .markdown-body th,
-[data-theme="light"][data-custom-bg] .markdown-body td,
-[data-theme="light"][data-custom-bg] .tiptap-rich th,
-[data-theme="light"][data-custom-bg] .tiptap-rich td {
+[data-theme="light"] [data-custom-bg] .markdown-body th,
+[data-theme="light"] [data-custom-bg] .markdown-body td,
+[data-theme="light"] [data-custom-bg] .tiptap-rich th,
+[data-theme="light"] [data-custom-bg] .tiptap-rich td {
   border-color: rgba(0, 0, 0, 0.18);
 }
-[data-theme="dark"][data-custom-bg] .markdown-body th,
-[data-theme="dark"][data-custom-bg] .markdown-body td,
-[data-theme="dark"][data-custom-bg] .tiptap-rich th,
-[data-theme="dark"][data-custom-bg] .tiptap-rich td {
+[data-theme="dark"] [data-custom-bg] .markdown-body th,
+[data-theme="dark"] [data-custom-bg] .markdown-body td,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich th,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich td {
   border-color: rgba(255, 255, 255, 0.20);
 }
 
 /* bullet/번호 ::marker — 중립 회색(--text-secondary) 대신 반투명(배경 비침) */
-[data-theme="light"][data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
-[data-theme="light"][data-custom-bg] .markdown-body ol li::marker,
-[data-theme="light"][data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
-[data-theme="light"][data-custom-bg] .tiptap-rich ol li::marker {
+[data-theme="light"] [data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
+[data-theme="light"] [data-custom-bg] .markdown-body ol li::marker,
+[data-theme="light"] [data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
+[data-theme="light"] [data-custom-bg] .tiptap-rich ol li::marker {
   color: rgba(0, 0, 0, 0.55);
 }
-[data-theme="dark"][data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
-[data-theme="dark"][data-custom-bg] .markdown-body ol li::marker,
-[data-theme="dark"][data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
-[data-theme="dark"][data-custom-bg] .tiptap-rich ol li::marker {
+[data-theme="dark"] [data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
+[data-theme="dark"] [data-custom-bg] .markdown-body ol li::marker,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich ol li::marker {
   color: rgba(255, 255, 255, 0.60);
 }
 
 /* code block(pre) — custom 배경일 때 배경 hue 가 더 분명히 드러나게 농도 보정 + 반투명 border */
-[data-theme="light"][data-custom-bg] .markdown-body pre,
-[data-theme="light"][data-custom-bg] .tiptap-rich pre {
+[data-theme="light"] [data-custom-bg] .markdown-body pre,
+[data-theme="light"] [data-custom-bg] .tiptap-rich pre {
   background: rgba(0, 0, 0, 0.07);
   border-color: rgba(0, 0, 0, 0.12);
 }
-[data-theme="dark"][data-custom-bg] .markdown-body pre,
-[data-theme="dark"][data-custom-bg] .tiptap-rich pre {
+[data-theme="dark"] [data-custom-bg] .markdown-body pre,
+[data-theme="dark"] [data-custom-bg] .tiptap-rich pre {
   background: rgba(255, 255, 255, 0.10);
   border-color: rgba(255, 255, 255, 0.14);
 }
 
 /* inline code — 배경 hue 가 드러나게 농도 보정 (텍스트 강조색은 syntax 의미라 유지) */
-[data-theme="light"][data-custom-bg] .markdown-body code:not(pre code),
-[data-theme="light"][data-custom-bg] .tiptap-rich code:not(pre code) {
+[data-theme="light"] [data-custom-bg] .markdown-body code:not(pre code),
+[data-theme="light"] [data-custom-bg] .tiptap-rich code:not(pre code) {
   background: rgba(0, 0, 0, 0.08);
 }
-[data-theme="dark"][data-custom-bg] .markdown-body code:not(pre code),
-[data-theme="dark"][data-custom-bg] .tiptap-rich code:not(pre code) {
+[data-theme="dark"] [data-custom-bg] .markdown-body code:not(pre code),
+[data-theme="dark"] [data-custom-bg] .tiptap-rich code:not(pre code) {
   background: rgba(255, 255, 255, 0.12);
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1801,6 +1801,73 @@ body.is-resizing .split-pane {
   margin: 1.5em 0;
 }
 
+/* ───────────────────────────────────────────────────────────────
+   사용자 정의 배경색(data-custom-bg)일 때 — 고정 회색 대신 반투명으로 통일.
+   반투명(border-color / ::marker color / 반투명 bg)은 모두 뒤 배경색이 비쳐
+   배경 hue 가 들어간 톤이 됨 (blockquote/code 와 동일 패턴). rgba 의 alpha 만
+   톤 강도 조절 — 베이지·하늘·다크 어떤 배경이든 그 계열의 진한색으로 따라감.
+   ─────────────────────────────────────────────────────────────── */
+
+/* 테이블 헤더(th) — 고정 stripe(#F8F8F8) 대신 배경 위 약간 진한 톤 */
+[data-theme="light"][data-custom-bg] .markdown-body th,
+[data-theme="light"][data-custom-bg] .tiptap-rich th {
+  background: rgba(0, 0, 0, 0.06);
+}
+[data-theme="dark"][data-custom-bg] .markdown-body th,
+[data-theme="dark"][data-custom-bg] .tiptap-rich th {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* 테이블 border(td·th) — 고정 회색(#E0E0E0 / --border-primary) 대신 반투명 */
+[data-theme="light"][data-custom-bg] .markdown-body th,
+[data-theme="light"][data-custom-bg] .markdown-body td,
+[data-theme="light"][data-custom-bg] .tiptap-rich th,
+[data-theme="light"][data-custom-bg] .tiptap-rich td {
+  border-color: rgba(0, 0, 0, 0.18);
+}
+[data-theme="dark"][data-custom-bg] .markdown-body th,
+[data-theme="dark"][data-custom-bg] .markdown-body td,
+[data-theme="dark"][data-custom-bg] .tiptap-rich th,
+[data-theme="dark"][data-custom-bg] .tiptap-rich td {
+  border-color: rgba(255, 255, 255, 0.20);
+}
+
+/* bullet/번호 ::marker — 중립 회색(--text-secondary) 대신 반투명(배경 비침) */
+[data-theme="light"][data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
+[data-theme="light"][data-custom-bg] .markdown-body ol li::marker,
+[data-theme="light"][data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
+[data-theme="light"][data-custom-bg] .tiptap-rich ol li::marker {
+  color: rgba(0, 0, 0, 0.55);
+}
+[data-theme="dark"][data-custom-bg] .markdown-body ul:not([data-type="taskList"]) li::marker,
+[data-theme="dark"][data-custom-bg] .markdown-body ol li::marker,
+[data-theme="dark"][data-custom-bg] .tiptap-rich ul:not([data-type="taskList"]) li::marker,
+[data-theme="dark"][data-custom-bg] .tiptap-rich ol li::marker {
+  color: rgba(255, 255, 255, 0.60);
+}
+
+/* code block(pre) — custom 배경일 때 배경 hue 가 더 분명히 드러나게 농도 보정 + 반투명 border */
+[data-theme="light"][data-custom-bg] .markdown-body pre,
+[data-theme="light"][data-custom-bg] .tiptap-rich pre {
+  background: rgba(0, 0, 0, 0.07);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+[data-theme="dark"][data-custom-bg] .markdown-body pre,
+[data-theme="dark"][data-custom-bg] .tiptap-rich pre {
+  background: rgba(255, 255, 255, 0.10);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+/* inline code — 배경 hue 가 드러나게 농도 보정 (텍스트 강조색은 syntax 의미라 유지) */
+[data-theme="light"][data-custom-bg] .markdown-body code:not(pre code),
+[data-theme="light"][data-custom-bg] .tiptap-rich code:not(pre code) {
+  background: rgba(0, 0, 0, 0.08);
+}
+[data-theme="dark"][data-custom-bg] .markdown-body code:not(pre code),
+[data-theme="dark"][data-custom-bg] .tiptap-rich code:not(pre code) {
+  background: rgba(255, 255, 255, 0.12);
+}
+
 [data-theme="light"] .markdown-body blockquote,
 [data-theme="light"] .tiptap-rich blockquote {
   border-left: 3px solid rgba(0, 0, 0, 0.25);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -458,10 +458,20 @@ function App() {
         if (label === 'main') return; // main 은 useFileSystem 의 get_pending_file 흐름이 처리
         const path = await invoke<string | null>('take_pending_file', { label });
         if (!path) return;
-        const { readTextFile } = await import('@tauri-apps/plugin-fs');
-        const content = await readTextFile(path);
-        const name = path.split('/').pop() || 'Untitled.md';
-        openFromRecent(path, content, name);
+        try {
+          const { readTextFile } = await import('@tauri-apps/plugin-fs');
+          const content = await readTextFile(path);
+          const name = path.split('/').pop() || 'Untitled.md';
+          openFromRecent(path, content, name);
+        } catch (readErr) {
+          // 실패가 console 에만 남으면 새 윈도우가 "빈 페이지" 로만 보임 — 다이얼로그로 표시
+          console.error('Failed to load pending file:', readErr);
+          const { message } = await import('@tauri-apps/plugin-dialog');
+          await message(`파일을 열 수 없습니다.\n\n${path}\n\n${String(readErr)}`, {
+            title: 'MarkMind',
+            kind: 'error',
+          });
+        }
       } catch (err) {
         console.error('Failed to load pending file:', err);
       }

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -9,7 +9,6 @@ import { StarterKit } from '@tiptap/starter-kit';
 import { Link } from '@tiptap/extension-link';
 import { TaskList } from '@tiptap/extension-task-list';
 import { TaskItem } from '@tiptap/extension-task-item';
-import { Table } from '@tiptap/extension-table';
 import { TableRow } from '@tiptap/extension-table-row';
 import { TableCell } from '@tiptap/extension-table-cell';
 import { TableHeader } from '@tiptap/extension-table-header';
@@ -17,6 +16,7 @@ import { Markdown } from 'tiptap-markdown';
 import { SearchAndReplace } from '@sereneinserenade/tiptap-search-and-replace';
 import { Typography } from '@tiptap/extension-typography';
 import { InlineCheckbox } from '../extensions/InlineCheckbox';
+import { MarkdownTable } from '../extensions/MarkdownTable';
 import { TableBubbleMenu } from './TableBubbleMenu';
 import {
     Bold, Italic, Strikethrough, Code,
@@ -141,6 +141,121 @@ function splitFrontmatter(md: string): FrontmatterParts {
     return { fields, body, rawFrontmatter };
 }
 
+// ─── HTML 테이블 블록 (병합 셀 — MarkdownTable 확장이 직렬화) 분리 ───
+// react-markdown 은 rehype-raw 없이는 raw HTML 을 리터럴 텍스트로 표시하므로,
+// 읽기 전용 뷰에서는 <table>…</table> 블록만 분리해 sanitize 후 직접 렌더.
+// code fence 안의 <table> 예시는 분리 대상에서 제외 (line scan 으로 fence 추적).
+interface BodySegment {
+    kind: 'md' | 'table';
+    text: string;
+}
+
+function splitHtmlTableBlocks(md: string): BodySegment[] {
+    const lines = md.replace(/\r\n/g, '\n').split('\n');
+    const segments: BodySegment[] = [];
+    let buf: string[] = [];
+    let fenceClose: RegExp | null = null;
+
+    const flush = () => {
+        if (buf.length) {
+            segments.push({ kind: 'md', text: buf.join('\n') });
+            buf = [];
+        }
+    };
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (fenceClose) {
+            buf.push(line);
+            if (fenceClose.test(line)) fenceClose = null;
+            continue;
+        }
+        const fenceOpen = line.match(/^[ ]{0,3}(([`~])\2{2,})/);
+        if (fenceOpen) {
+            const ch = fenceOpen[2] === '`' ? '`' : '~';
+            fenceClose = new RegExp(`^[ ]{0,3}${ch}{${fenceOpen[1].length},}[ \\t]*$`);
+            buf.push(line);
+            continue;
+        }
+        if (/^[ \t]*<table[\s>]/i.test(line)) {
+            let closeLine = -1;
+            for (let j = i; j < lines.length; j++) {
+                if (/<\/table>[ \t]*$/i.test(lines[j])) {
+                    closeLine = j;
+                    break;
+                }
+            }
+            if (closeLine !== -1) {
+                flush();
+                segments.push({ kind: 'table', text: lines.slice(i, closeLine + 1).join('\n') });
+                i = closeLine;
+                continue;
+            }
+        }
+        buf.push(line);
+    }
+    flush();
+    return segments;
+}
+
+// dangerouslySetInnerHTML 에 넣기 전 allowlist sanitize.
+// 허용 태그 외 요소는 textContent 로 치환, 허용 외 속성은 제거,
+// href/src 는 안전한 스킴만 통과 — 외부 의존성 없이 DOMParser 로 처리.
+const TABLE_ALLOWED_TAGS = new Set([
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption', 'colgroup', 'col',
+    'p', 'br', 'hr', 'strong', 'b', 'em', 'i', 's', 'del', 'u', 'code', 'span', 'a',
+    'ul', 'ol', 'li', 'input', 'label', 'img', 'blockquote', 'pre',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+]);
+const TABLE_ALLOWED_ATTRS = new Set([
+    'colspan', 'rowspan', 'href', 'src', 'alt', 'type', 'checked', 'disabled', 'start',
+]);
+
+function isSafeUrl(value: string): boolean {
+    const trimmed = value.trim();
+    if (trimmed.startsWith('#')) return true;
+    try {
+        const url = new URL(trimmed, 'https://local.invalid/');
+        return ['http:', 'https:', 'mailto:'].includes(url.protocol);
+    } catch {
+        return false;
+    }
+}
+
+function sanitizeTableHtml(html: string): string {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+
+    const sanitizeElement = (el: Element) => {
+        // 자식 먼저 처리 (치환 시 하위 순회 불필요해지도록 복사본 순회)
+        for (const child of Array.from(el.children)) {
+            sanitizeElement(child);
+        }
+        if (!TABLE_ALLOWED_TAGS.has(el.tagName.toLowerCase())) {
+            el.replaceWith(doc.createTextNode(el.textContent ?? ''));
+            return;
+        }
+        for (const attr of Array.from(el.attributes)) {
+            const name = attr.name.toLowerCase();
+            if (!TABLE_ALLOWED_ATTRS.has(name)) {
+                el.removeAttribute(attr.name);
+                continue;
+            }
+            if ((name === 'href' || name === 'src') && !isSafeUrl(attr.value)) {
+                el.removeAttribute(attr.name);
+            }
+        }
+        // 읽기 전용 뷰 — 체크박스는 비활성으로
+        if (el.tagName.toLowerCase() === 'input') {
+            el.setAttribute('disabled', '');
+        }
+    };
+
+    for (const child of Array.from(doc.body.children)) {
+        sanitizeElement(child);
+    }
+    return doc.body.innerHTML;
+}
+
 // ─── 읽기 전용 마크다운 렌더 (기존 react-markdown 흐름) ───
 function ReadOnlyView({
     fields,
@@ -151,6 +266,9 @@ function ReadOnlyView({
     body: string;
     fontSize: number;
 }) {
+    // 병합 셀 테이블 (HTML 직렬화분) 은 react-markdown 이 리터럴 텍스트로
+    // 보여주므로 블록 단위로 분리해 sanitize 후 직접 렌더
+    const segments = useMemo(() => splitHtmlTableBlocks(body), [body]);
     return (
         <div
             className="markdown-body fade-in"
@@ -168,15 +286,26 @@ function ReadOnlyView({
                     </dl>
                 </aside>
             )}
-            <ReactMarkdown
-                remarkPlugins={[
-                    remarkFrontmatter,
-                    [remarkGfm, { singleTilde: false }],
-                ]}
-                rehypePlugins={[rehypeHighlight]}
-            >
-                {body}
-            </ReactMarkdown>
+            {segments.map((seg, i) =>
+                seg.kind === 'table' ? (
+                    <div
+                        key={i}
+                        // eslint-disable-next-line react/no-danger
+                        dangerouslySetInnerHTML={{ __html: sanitizeTableHtml(seg.text) }}
+                    />
+                ) : (
+                    <ReactMarkdown
+                        key={i}
+                        remarkPlugins={[
+                            remarkFrontmatter,
+                            [remarkGfm, { singleTilde: false }],
+                        ]}
+                        rehypePlugins={[rehypeHighlight]}
+                    >
+                        {seg.text}
+                    </ReactMarkdown>
+                ),
+            )}
         </div>
     );
 }
@@ -473,7 +602,8 @@ function RichEditor({
             Link.configure({ openOnClick: false, autolink: false }),
             TaskList,
             TaskItem.configure({ nested: true }),
-            Table.configure({ resizable: false }),
+            // 병합 셀 테이블을 HTML 로 직렬화/복원하는 보강판 (기본 Table 확장)
+            MarkdownTable.configure({ resizable: false }),
             TableRow,
             TableHeader,
             TableCell,

--- a/src/extensions/MarkdownTable.ts
+++ b/src/extensions/MarkdownTable.ts
@@ -1,0 +1,188 @@
+import { Table } from '@tiptap/extension-table';
+import { getHTMLFromFragment } from '@tiptap/core';
+import { Fragment, type Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+// ─── tiptap-markdown 테이블 직렬화 보강 ───
+//
+// GFM 테이블은 셀 병합(colspan/rowspan)과 셀 내 다중 블록을 표현할 문법이 없음.
+// tiptap-markdown 기본 table 직렬화기는 그런 테이블을 만나면 HTML 폴백을 타는데,
+// 에디터가 html:false 라서 폴백이 `[table]` placeholder 텍스트만 출력 →
+// 병합하는 순간 테이블 데이터 전체가 파괴되는 사고가 있었음.
+//
+// 이 확장은 기본 스펙을 덮어써서 (tiptap-markdown 의 getMarkdownSpec 은
+// extension.storage.markdown 을 기본 스펙보다 우선):
+//   - GFM 으로 표현 가능한 테이블 → 기본과 동일하게 GFM 파이프 테이블로 직렬화
+//   - 표현 불가(병합/다중 블록) 테이블 → HTML <table> 로 직렬화 (데이터 보존,
+//     HTML-in-Markdown 은 GFM 표준 관행)
+//   - 로드 시 markdown-it 에 block rule 을 추가해, html:false 에서도
+//     <table>…</table> 블록만은 raw HTML 로 통과 → ProseMirror DOMParser 가
+//     colspan/rowspan 포함 테이블 노드로 복원 (round-trip 성립)
+
+/** tiptap-markdown MarkdownSerializerState 중 사용하는 표면만 구조 타이핑 */
+interface MarkdownState {
+    inTable: boolean;
+    write(content: string): void;
+    ensureNewLine(): void;
+    renderInline(node: ProseMirrorNode): void;
+    closeBlock(node: ProseMirrorNode): void;
+}
+
+/** markdown-it StateBlock 중 사용하는 표면만 구조 타이핑 */
+interface MdStateBlock {
+    src: string;
+    bMarks: number[];
+    eMarks: number[];
+    tShift: number[];
+    blkIndent: number;
+    line: number;
+    push(type: string, tag: string, nesting: number): {
+        map: [number, number] | null;
+        content: string;
+    };
+    getLines(begin: number, end: number, indent: number, keepLastLF: boolean): string;
+}
+
+interface MdInstance {
+    block: {
+        ruler: {
+            before(
+                beforeName: string,
+                ruleName: string,
+                fn: (
+                    state: MdStateBlock,
+                    startLine: number,
+                    endLine: number,
+                    silent: boolean,
+                ) => boolean,
+            ): void;
+        };
+    };
+}
+
+function childNodes(node: ProseMirrorNode): ProseMirrorNode[] {
+    const children: ProseMirrorNode[] = [];
+    node.forEach((child) => children.push(child));
+    return children;
+}
+
+function hasSpan(cell: ProseMirrorNode): boolean {
+    return cell.attrs.colspan > 1 || cell.attrs.rowspan > 1;
+}
+
+/** tiptap-markdown 기본 판정과 동일 — 병합/다중 블록 셀이 있으면 GFM 표현 불가 */
+function isGfmSerializable(node: ProseMirrorNode): boolean {
+    const rows = childNodes(node);
+    const firstRow = rows[0];
+    if (!firstRow) return false;
+    const bodyRows = rows.slice(1);
+
+    if (
+        childNodes(firstRow).some(
+            (cell) => cell.type.name !== 'tableHeader' || hasSpan(cell) || cell.childCount > 1,
+        )
+    ) {
+        return false;
+    }
+    if (
+        bodyRows.some((row) =>
+            childNodes(row).some(
+                (cell) => cell.type.name === 'tableHeader' || hasSpan(cell) || cell.childCount > 1,
+            ),
+        )
+    ) {
+        return false;
+    }
+    return true;
+}
+
+// parse.setup 은 tiptap-markdown 이 parse 호출마다 모든 확장에 대해 실행 —
+// 같은 markdown-it 인스턴스에 rule 중복 등록 방지
+const patchedInstances = new WeakSet<object>();
+
+/**
+ * `<table` 로 시작하는 줄부터 `</table>` 로 끝나는 줄까지를 raw html_block
+ * 토큰으로 통과시키는 markdown-it block rule. markdown-it 의 html_block
+ * renderer 는 options.html 과 무관하게 content 를 raw 출력하므로,
+ * 전역 html:false 를 유지한 채 테이블 HTML 만 선택적으로 허용된다.
+ */
+function htmlTableBlockRule(
+    state: MdStateBlock,
+    startLine: number,
+    endLine: number,
+    silent: boolean,
+): boolean {
+    const start = state.bMarks[startLine] + state.tShift[startLine];
+    const firstLine = state.src.slice(start, state.eMarks[startLine]);
+    if (!/^<table[\s>]/i.test(firstLine)) return false;
+
+    // 닫는 태그가 줄 끝에 오는 라인까지 스캔 — 없으면 매치 포기 (일반 텍스트로 폴백)
+    let closeLine = -1;
+    for (let line = startLine; line < endLine; line++) {
+        const text = state.src.slice(
+            state.bMarks[line] + state.tShift[line],
+            state.eMarks[line],
+        );
+        if (/<\/table>\s*$/i.test(text)) {
+            closeLine = line;
+            break;
+        }
+    }
+    if (closeLine === -1) return false;
+    if (silent) return true;
+
+    const token = state.push('html_block', '', 0);
+    token.map = [startLine, closeLine + 1];
+    token.content = state.getLines(startLine, closeLine + 1, state.blkIndent, true);
+    state.line = closeLine + 1;
+    return true;
+}
+
+export const MarkdownTable = Table.extend({
+    addStorage() {
+        return {
+            markdown: {
+                serialize(state: MarkdownState, node: ProseMirrorNode) {
+                    if (!isGfmSerializable(node)) {
+                        // 병합/다중 블록 — HTML 로 직렬화해 데이터 보존
+                        const html = getHTMLFromFragment(Fragment.from(node), node.type.schema);
+                        state.write(html);
+                        state.closeBlock(node);
+                        return;
+                    }
+                    // GFM 파이프 테이블 — tiptap-markdown 기본 로직과 동일
+                    state.inTable = true;
+                    node.forEach((row, _offset, i) => {
+                        state.write('| ');
+                        row.forEach((col, _colOffset, j) => {
+                            if (j) {
+                                state.write(' | ');
+                            }
+                            const cellContent = col.firstChild;
+                            if (cellContent && cellContent.textContent.trim()) {
+                                state.renderInline(cellContent);
+                            }
+                        });
+                        state.write(' |');
+                        state.ensureNewLine();
+                        if (!i) {
+                            const delimiterRow = Array.from({ length: row.childCount })
+                                .map(() => '---')
+                                .join(' | ');
+                            state.write(`| ${delimiterRow} |`);
+                            state.ensureNewLine();
+                        }
+                    });
+                    state.closeBlock(node);
+                    state.inTable = false;
+                },
+                parse: {
+                    setup(md: MdInstance) {
+                        if (patchedInstances.has(md)) return;
+                        patchedInstances.add(md);
+                        md.block.ruler.before('paragraph', 'markmind_html_table', htmlTableBlockRule);
+                    },
+                },
+            },
+        };
+    },
+});

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -81,6 +81,16 @@ export function useFileSystem(onFileOpened?: () => void) {
           }
         } catch (err) {
           console.error('Failed to open file:', err);
+          // 실패가 console 에만 남으면 사용자에겐 "빈 페이지" 로만 보임 — 다이얼로그로 표시
+          try {
+            const { message } = await import('@tauri-apps/plugin-dialog');
+            await message(`파일을 열 수 없습니다.\n\n${path}\n\n${String(err)}`, {
+              title: 'MarkMind',
+              kind: 'error',
+            });
+          } catch {
+            // dialog 자체 실패 시엔 console 로그만 유지
+          }
         }
       };
 


### PR DESCRIPTION
## Summary
macOS 파일 열기·리치텍스트 테이블·테마/렌더링 관련 버그 5종 수정 + v0.3.5 릴리즈.

## Changes
- **fix(open)**: macOS 더블클릭 시 fs scope 밖 경로(외장 드라이브·숨김 폴더)가 `readTextFile`에서 조용히 거부돼 빈 페이지가 되던 문제 — `RunEvent::Opened` 경로를 `fs_scope().allow_file()`로 런타임 허용 + 읽기 실패를 삼키던 catch에 에러 다이얼로그 추가
- **fix(table)**: 병합 셀(colspan/rowspan)·셀 내 다중 블록 테이블이 저장 시 `[table]` 텍스트만 남고 데이터가 소실되던 문제 — GFM 표현 불가 테이블만 HTML `<table>`로 직렬화/복원하는 `MarkdownTable` 확장 추가 (round-trip), 읽기 전용 뷰는 allowlist sanitize 후 렌더
- **fix(theme)**: 커스텀 배경색일 때 테이블 헤더/border·코드·리스트 마커가 고정 회색이던 문제 — `[data-theme] [data-custom-bg]` 자손 결합자로 배경 hue 비치는 반투명 적용 (결합 셀렉터 오류 수정 포함)
- **fix(theme)**: 코드 블록이 본문과 구분 안 되던 문제 — GitHub 표준 색(`#f6f8fa`/`#161b22`) + 경계선 + 패딩. `.hljs` 리셋이 `<pre class="hljs">`의 배경·패딩을 `!important`로 죽이던 근본 원인을 `code.hljs`로 한정해 해결
- **fix(table)**: 테이블 컬럼이 `table-layout: fixed`로 균등 분배되던 문제 — `auto` + `width: auto` + `max-width: 100%`로 content 기반 유연 폭(짧은 컬럼 좁게)
- **release**: v0.3.5

## Test plan
- [ ] 외장 드라이브/숨김 폴더 `.md` 더블클릭 → 정상 열림 (실패 시 에러 다이얼로그)
- [ ] 리치텍스트 테이블 셀 병합 → 저장 → 재열기 → 병합 복원
- [ ] 병합 없는 일반 테이블이 GFM 파이프 문법으로 저장되는지 (회귀)
- [ ] 배경색 변경 시 헤더/border/코드/마커가 배경색 계열로 따라가는지
- [ ] 코드 블록이 회색 배경 + 경계선 + 패딩으로 구분되는지
- [ ] 숫자(#)처럼 짧은 컬럼이 좁게 렌더되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)