### PR TITLE
feat: LAN 파일 공유(아이폰) + .local + AirDrop (v0.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -797,6 +797,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -813,6 +823,20 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -839,6 +863,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -892,6 +927,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1579,6 +1645,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2380,6 +2457,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,7 +2507,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2433,6 +2521,7 @@ dependencies = [
  "hound",
  "image",
  "keyring",
+ "local-ip-address",
  "log",
  "mime_guess",
  "ndarray",
@@ -2446,6 +2535,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rmcp",
+ "rust-embed",
  "serde",
  "serde_json",
  "sha2",
@@ -2661,6 +2751,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3968,6 +4087,40 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "0.4.1"
+version = "0.4.2"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,6 +84,14 @@ sha2 = "0.10"       # PKCE S256 challenge
 rmcp = { version = "1.7", features = ["server", "macros", "transport-streamable-http-server"] }
 axum = "0.8"
 
+# === LAN 파일 공유 서버 — 같은 Wi-Fi 의 기기(아이폰 등)가 문서를 읽고 편집 ===
+# 빌드된 프론트(dist)를 바이너리에 임베드해 정적 서빙 + 파일 API.
+# MCP(127.0.0.1 고정)와 달리 설정창에서 Connect 할 때만 0.0.0.0 에 bind(토글).
+# debug 빌드는 런타임에 dist 를 파일시스템에서 읽음(debug-embed 미사용) → dev 중
+# `npm run build` 후 최신 UI 반영. release 는 컴파일 타임 임베드.
+rust-embed = "8"
+local-ip-address = "0.6"
+
 
 # macOS native print API — NSPrintInfo 명시 설정 + WKWebView.printOperationWithPrintInfo
 # 호출. window.print() 가 wry 의 default 사용 (paperSize/centered 미명시 → 좌측

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,8 +104,9 @@ objc2-app-kit = { version = "0.3", features = [
     "NSWindow",
     "NSPrintInfo",
     "NSPrintOperation",
+    "NSSharingService",
 ] }
 objc2-web-kit = { version = "0.3", features = [
     "WKWebView",
 ] }
-objc2-foundation = { version = "0.3", features = ["NSURL", "NSString", "NSError", "NSDictionary"] }
+objc2-foundation = { version = "0.3", features = ["NSURL", "NSString", "NSError", "NSDictionary", "NSArray"] }

--- a/src-tauri/src/lan_server.rs
+++ b/src-tauri/src/lan_server.rs
@@ -1,0 +1,451 @@
+//! LAN 파일 공유 서버 — 같은 Wi-Fi 의 기기(아이폰 브라우저 등)가 지정한 폴더의
+//! 마크다운 문서를 읽고 **in-place 로 편집**하도록 노출한다.
+//!
+//! MCP 서버(`mcp/mod.rs`, 127.0.0.1 고정·상시)와는 의도적으로 **분리**한다:
+//!   - 바인딩이 다르다: MCP=localhost 전용, 이쪽=`0.0.0.0`(LAN 노출).
+//!     한 서버에 합치면 파일 API 를 위해 0.0.0.0 으로 묶는 순간 MCP 까지 LAN 에
+//!     노출돼(같은 망 누구나 Claude tool 로 문서 조작) 위험. → 절대 합치지 않는다.
+//!   - 생명주기가 다르다: MCP 는 앱 시작 시 상시, 이쪽은 설정창에서 **Connect 할
+//!     때만** bind(기본 OFF). 앱 재시작 시 자동 재연결 안 함(명시적 ON 원칙).
+//!
+//! 보안: ① 루트 폴더 1개로 샌드박싱(`..`/심볼릭링크 탈출 차단) ② 확장자
+//! 화이트리스트 ③ 모든 `/api/*` 요청에 토큰(PIN) 검증 ④ 원자적 저장(temp+rename).
+//! 정적 UI(빌드된 dist) 는 토큰 없이 로드 — 민감 정보는 API 뒤에만 있다.
+
+use std::net::SocketAddr;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use axum::{
+    body::Bytes,
+    extract::{Query, State},
+    http::{header, StatusCode, Uri},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use rust_embed::RustEmbed;
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+use walkdir::WalkDir;
+
+/// LAN 파일 서버 포트(MCP 8417 과 분리). 클라이언트는 `http://<ip>:8418`.
+pub const LAN_PORT: u16 = 8418;
+
+/// 읽기/쓰기 허용 확장자(소문자). 그 외 파일은 목록·읽기·쓰기 모두 거부.
+const ALLOWED_EXTS: &[&str] = &["md", "markdown", "mdx", "txt"];
+
+/// 저장 가능한 본문 최대 바이트(거대 payload 방어). 마크다운엔 충분(8MB).
+const MAX_CONTENT_BYTES: usize = 8 * 1024 * 1024;
+
+/// 빌드된 프론트(`dist`)를 바이너리에 임베드해 정적 서빙.
+/// release: 컴파일 타임 임베드. debug: 런타임에 파일시스템에서 read
+/// (`debug-embed` 미사용) → dev 중 `npm run build` 후 최신 UI 반영.
+#[derive(RustEmbed)]
+#[folder = "../dist"]
+struct Frontend;
+
+/// 기동 중인 서버 핸들 — graceful shutdown 채널 + 표시용 메타.
+struct RunningServer {
+    shutdown: oneshot::Sender<()>,
+    addr: String,
+    port: u16,
+    root: String,
+}
+
+/// Tauri 가 manage 하는 LAN 서버 상태(Connect 시 Some, Disconnect 시 None).
+#[derive(Default)]
+pub struct LanState {
+    inner: Mutex<Option<RunningServer>>,
+}
+
+/// axum 핸들러가 공유하는 컨텍스트(루트 폴더 canonical + 토큰).
+#[derive(Clone)]
+struct Ctx {
+    root: Arc<PathBuf>,
+    token: Arc<String>,
+}
+
+/// lan_start 반환 / lan_status 응답 — 접속 정보.
+#[derive(Serialize, Clone)]
+pub struct LanInfo {
+    pub running: bool,
+    pub addr: Option<String>,
+    pub port: Option<u16>,
+    pub root: Option<String>,
+}
+
+// ─── 경로 가드 ───
+
+/// 루트 기준 상대경로를 안전하게 절대경로로 해석. 절대경로/`..`/`.`/드라이브
+/// prefix component 는 거부. 대상이 이미 존재하면(읽기/덮어쓰기) 심볼릭 링크로
+/// 루트를 탈출하지 않았는지 canonicalize 로 재확인.
+fn resolve(root: &Path, rel: &str) -> Result<PathBuf, ()> {
+    let rel = rel.trim_start_matches('/');
+    let mut p = root.to_path_buf();
+    for comp in Path::new(rel).components() {
+        match comp {
+            Component::Normal(c) => p.push(c),
+            // RootDir / ParentDir / CurDir / Prefix 전부 거부(traversal 차단)
+            _ => return Err(()),
+        }
+    }
+    if let Ok(canon) = p.canonicalize() {
+        let root_canon = root.canonicalize().map_err(|_| ())?;
+        if !canon.starts_with(&root_canon) {
+            return Err(());
+        }
+    }
+    Ok(p)
+}
+
+/// 확장자가 화이트리스트에 있는지(소문자 비교).
+fn ext_allowed(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| ALLOWED_EXTS.contains(&e.to_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+// ─── 토큰 인증 미들웨어 (/api/* 에만 적용) ───
+
+async fn auth(
+    State(ctx): State<Ctx>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    // 헤더(x-markmind-token) 우선, 없으면 쿼리(?token=).
+    let provided = req
+        .headers()
+        .get("x-markmind-token")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+        .or_else(|| {
+            req.uri().query().and_then(|q| {
+                url::form_urlencoded::parse(q.as_bytes())
+                    .find(|(k, _)| k == "token")
+                    .map(|(_, v)| v.into_owned())
+            })
+        });
+
+    // 상수시간 비교까진 불필요(로컬 LAN PIN) — 단순 일치.
+    if provided.as_deref() == Some(ctx.token.as_str()) {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+// ─── API 핸들러 ───
+
+#[derive(Serialize)]
+struct FileEntry {
+    /// 루트 기준 상대경로(슬래시 구분)
+    path: String,
+    name: String,
+    size: u64,
+    /// 수정 시각(epoch ms)
+    modified: u64,
+}
+
+#[derive(Serialize)]
+struct ListResp {
+    root: String,
+    files: Vec<FileEntry>,
+}
+
+/// GET /api/files — 루트 폴더의 마크다운 파일 목록(재귀, 숨김 폴더 제외).
+async fn list_files(State(ctx): State<Ctx>) -> Result<Json<ListResp>, StatusCode> {
+    let root = ctx.root.as_path();
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| {
+            // 숨김 디렉토리/파일(.git, .obsidian 등) 스킵. 루트 자신은 통과.
+            e.depth() == 0
+                || !e
+                    .file_name()
+                    .to_str()
+                    .map(|n| n.starts_with('.'))
+                    .unwrap_or(false)
+        })
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() || !ext_allowed(entry.path()) {
+            continue;
+        }
+        let Ok(rel) = entry.path().strip_prefix(root) else {
+            continue;
+        };
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let modified = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        files.push(FileEntry {
+            path: rel.to_string_lossy().replace('\\', "/"),
+            name: entry.file_name().to_string_lossy().to_string(),
+            size: meta.len(),
+            modified,
+        });
+    }
+    // 최근 수정 우선(모바일에서 방금 본 문서 찾기 쉽게).
+    files.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.path.cmp(&b.path)));
+    Ok(Json(ListResp {
+        root: ctx.root.to_string_lossy().to_string(),
+        files,
+    }))
+}
+
+#[derive(Deserialize)]
+struct PathQuery {
+    path: String,
+    // token 은 미들웨어가 처리 — 여기선 무시(쿼리에 같이 와도 무방).
+    #[serde(default)]
+    #[allow(dead_code)]
+    token: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ReadResp {
+    path: String,
+    content: String,
+}
+
+/// GET /api/file?path=rel — 파일 내용.
+async fn read_file(
+    State(ctx): State<Ctx>,
+    Query(q): Query<PathQuery>,
+) -> Result<Json<ReadResp>, StatusCode> {
+    let abs = resolve(&ctx.root, &q.path).map_err(|_| StatusCode::FORBIDDEN)?;
+    if !ext_allowed(&abs) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    let content = std::fs::read_to_string(&abs).map_err(|_| StatusCode::NOT_FOUND)?;
+    Ok(Json(ReadResp {
+        path: q.path,
+        content,
+    }))
+}
+
+#[derive(Deserialize)]
+struct SaveBody {
+    path: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct SaveResp {
+    ok: bool,
+    path: String,
+}
+
+/// PUT /api/file — 본문을 **원자적으로**(temp 작성 후 rename) in-place 저장.
+async fn write_file(
+    State(ctx): State<Ctx>,
+    Json(body): Json<SaveBody>,
+) -> Result<Json<SaveResp>, StatusCode> {
+    if body.content.len() > MAX_CONTENT_BYTES {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    let abs = resolve(&ctx.root, &body.path).map_err(|_| StatusCode::FORBIDDEN)?;
+    if !ext_allowed(&abs) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    // 부모 디렉토리는 존재해야 한다(새 폴더 생성은 하지 않음 — 단순/안전).
+    let parent = abs.parent().ok_or(StatusCode::BAD_REQUEST)?;
+    if !parent.is_dir() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    // 같은 디렉토리에 temp 작성 → rename(동일 파일시스템이라 원자적).
+    let tmp = parent.join(format!(
+        ".{}.markmind.tmp",
+        abs.file_name().and_then(|n| n.to_str()).unwrap_or("doc")
+    ));
+    std::fs::write(&tmp, body.content.as_bytes()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    std::fs::rename(&tmp, &abs).map_err(|_| {
+        let _ = std::fs::remove_file(&tmp); // rename 실패 시 temp 정리
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    Ok(Json(SaveResp {
+        ok: true,
+        path: body.path,
+    }))
+}
+
+// ─── 정적 UI (rust-embed) ───
+
+/// `/api/*` 외 모든 경로 → 임베드된 dist. 없는 경로는 index.html(SPA fallback).
+async fn static_handler(uri: Uri) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    let path = if path.is_empty() { "index.html" } else { path };
+
+    match Frontend::get(path) {
+        Some(content) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            (
+                [(header::CONTENT_TYPE, mime.as_ref().to_string())],
+                content.data.into_owned(),
+            )
+                .into_response()
+        }
+        None => match Frontend::get("index.html") {
+            Some(content) => (
+                [(header::CONTENT_TYPE, "text/html".to_string())],
+                content.data.into_owned(),
+            )
+                .into_response(),
+            None => (StatusCode::NOT_FOUND, "build not found").into_response(),
+        },
+    }
+}
+
+fn build_router(ctx: Ctx) -> Router {
+    let api = Router::new()
+        .route("/files", get(list_files))
+        .route("/file", get(read_file).put(write_file))
+        .layer(middleware::from_fn_with_state(ctx.clone(), auth))
+        .with_state(ctx.clone());
+
+    Router::new()
+        .nest("/api", api)
+        .fallback(static_handler)
+        .with_state(ctx)
+}
+
+// ─── start / stop / status ───
+
+/// 서버를 `0.0.0.0:LAN_PORT` 에 bind 하고 spawn. bind 실패(포트 사용 중 등)는
+/// 동기로 즉시 Err 반환(사용자에게 표시). 성공 시 LanInfo(LAN IP + 포트).
+pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, String> {
+    let mut guard = state.inner.lock().map_err(|_| "상태 lock 실패".to_string())?;
+    if guard.is_some() {
+        return Err("이미 연결되어 있습니다 (먼저 Disconnect)".into());
+    }
+    if token.trim().is_empty() {
+        return Err("토큰(PIN)이 비어 있습니다".into());
+    }
+    let root_path = PathBuf::from(&root);
+    if !root_path.is_dir() {
+        return Err(format!("폴더가 존재하지 않습니다: {root}"));
+    }
+    let root_canon = root_path
+        .canonicalize()
+        .map_err(|e| format!("폴더 경로 해석 실패: {e}"))?;
+
+    // 같은 망에서 아이폰이 접속할 LAN IP(표시용). 못 구하면 안내만.
+    let lan_ip = local_ip_address::local_ip()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|_| "<이 맥의 IP>".into());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], LAN_PORT));
+    // 동기 bind 로 포트 충돌을 즉시 알린다.
+    let std_listener = std::net::TcpListener::bind(addr)
+        .map_err(|e| format!("포트 {LAN_PORT} bind 실패(이미 사용 중일 수 있음): {e}"))?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("listener 설정 실패: {e}"))?;
+
+    let ctx = Ctx {
+        root: Arc::new(root_canon),
+        token: Arc::new(token),
+    };
+    let app = build_router(ctx);
+    let (tx, rx) = oneshot::channel::<()>();
+
+    tauri::async_runtime::spawn(async move {
+        let listener = match tokio::net::TcpListener::from_std(std_listener) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("[lan] listener 변환 실패: {e}");
+                return;
+            }
+        };
+        eprintln!("[lan] LAN 파일 서버 0.0.0.0:{LAN_PORT} 기동");
+        let r = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+        if let Err(e) = r {
+            eprintln!("[lan] serve 종료: {e}");
+        }
+        eprintln!("[lan] LAN 파일 서버 중지");
+    });
+
+    guard.replace(RunningServer {
+        shutdown: tx,
+        addr: lan_ip.clone(),
+        port: LAN_PORT,
+        root: root.clone(),
+    });
+
+    Ok(LanInfo {
+        running: true,
+        addr: Some(lan_ip),
+        port: Some(LAN_PORT),
+        root: Some(root),
+    })
+}
+
+/// 서버 graceful shutdown(이미 꺼져 있으면 no-op).
+pub fn stop(state: &LanState) -> Result<(), String> {
+    let mut guard = state.inner.lock().map_err(|_| "상태 lock 실패".to_string())?;
+    if let Some(srv) = guard.take() {
+        let _ = srv.shutdown.send(());
+    }
+    Ok(())
+}
+
+/// 현재 상태(running + 접속 정보).
+pub fn status(state: &LanState) -> LanInfo {
+    match state.inner.lock() {
+        Ok(g) => match &*g {
+            Some(s) => LanInfo {
+                running: true,
+                addr: Some(s.addr.clone()),
+                port: Some(s.port),
+                root: Some(s.root.clone()),
+            },
+            None => LanInfo {
+                running: false,
+                addr: None,
+                port: None,
+                root: None,
+            },
+        },
+        Err(_) => LanInfo {
+            running: false,
+            addr: None,
+            port: None,
+            root: None,
+        },
+    }
+}
+
+// ─── Tauri 커맨드 ───
+
+#[tauri::command]
+pub fn lan_start(
+    state: tauri::State<'_, LanState>,
+    root: String,
+    token: String,
+) -> Result<LanInfo, String> {
+    start(&state, root, token)
+}
+
+#[tauri::command]
+pub fn lan_stop(state: tauri::State<'_, LanState>) -> Result<(), String> {
+    stop(&state)
+}
+
+#[tauri::command]
+pub fn lan_status(state: tauri::State<'_, LanState>) -> LanInfo {
+    status(&state)
+}

--- a/src-tauri/src/lan_server.rs
+++ b/src-tauri/src/lan_server.rs
@@ -17,7 +17,6 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use axum::{
-    body::Bytes,
     extract::{Query, State},
     http::{header, StatusCode, Uri},
     middleware::{self, Next},
@@ -49,6 +48,9 @@ struct Frontend;
 /// 기동 중인 서버 핸들 — graceful shutdown 채널 + 표시용 메타.
 struct RunningServer {
     shutdown: oneshot::Sender<()>,
+    /// mDNS(Bonjour) 호스트네임(예: `My-Mac.local`). IP 와 달리 고정 — IP 가
+    /// DHCP 로 바뀌어도 같은 주소로 접속. macOS 가 기본 광고(시스템 무수정).
+    host: Option<String>,
     addr: String,
     port: u16,
     root: String,
@@ -71,9 +73,30 @@ struct Ctx {
 #[derive(Serialize, Clone)]
 pub struct LanInfo {
     pub running: bool,
+    /// mDNS 호스트네임(`*.local`) — 고정 주소(권장). 못 구하면 None.
+    pub host: Option<String>,
+    /// 현재 LAN IP — DHCP 라 바뀔 수 있음(폴백).
     pub addr: Option<String>,
     pub port: Option<u16>,
     pub root: Option<String>,
+}
+
+/// Bonjour 가 광고하는 LocalHostName(`*.local`)을 읽는다(읽기 전용 — 시스템
+/// 무수정). macOS 의 `scutil --get LocalHostName` 결과에 `.local` 을 붙인다.
+fn local_hostname() -> Option<String> {
+    let out = std::process::Command::new("scutil")
+        .args(["--get", "LocalHostName"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(format!("{name}.local"))
+    }
 }
 
 // ─── 경로 가드 ───
@@ -343,6 +366,8 @@ pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, S
     let lan_ip = local_ip_address::local_ip()
         .map(|ip| ip.to_string())
         .unwrap_or_else(|_| "<이 맥의 IP>".into());
+    // 고정 mDNS 호스트네임(있으면) — IP 가 바뀌어도 같은 주소.
+    let host = local_hostname();
 
     let addr = SocketAddr::from(([0, 0, 0, 0], LAN_PORT));
     // 동기 bind 로 포트 충돌을 즉시 알린다.
@@ -381,6 +406,7 @@ pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, S
 
     guard.replace(RunningServer {
         shutdown: tx,
+        host: host.clone(),
         addr: lan_ip.clone(),
         port: LAN_PORT,
         root: root.clone(),
@@ -388,6 +414,7 @@ pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, S
 
     Ok(LanInfo {
         running: true,
+        host,
         addr: Some(lan_ip),
         port: Some(LAN_PORT),
         root: Some(root),
@@ -409,12 +436,14 @@ pub fn status(state: &LanState) -> LanInfo {
         Ok(g) => match &*g {
             Some(s) => LanInfo {
                 running: true,
+                host: s.host.clone(),
                 addr: Some(s.addr.clone()),
                 port: Some(s.port),
                 root: Some(s.root.clone()),
             },
             None => LanInfo {
                 running: false,
+                host: None,
                 addr: None,
                 port: None,
                 root: None,
@@ -422,6 +451,7 @@ pub fn status(state: &LanState) -> LanInfo {
         },
         Err(_) => LanInfo {
             running: false,
+            host: None,
             addr: None,
             port: None,
             root: None,

--- a/src-tauri/src/lan_server.rs
+++ b/src-tauri/src/lan_server.rs
@@ -131,6 +131,28 @@ fn ext_allowed(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// 파일 수정 시각(epoch ms). 못 구하면 0.
+fn mtime_ms(meta: &std::fs::Metadata) -> u64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// 대상의 부모 디렉토리가 루트 하위인지 canonicalize 로 검증한다(P1).
+/// `resolve` 의 canonicalize 는 **존재하는 경로**에만 동작하므로, 새 파일 쓰기는
+/// 부모(항상 존재)를 따로 해소해 심볼릭 링크로 루트를 탈출하지 못하게 막는다.
+fn parent_within_root(root: &Path, abs: &Path) -> Result<(), StatusCode> {
+    let parent = abs.parent().ok_or(StatusCode::BAD_REQUEST)?;
+    let parent_canon = parent.canonicalize().map_err(|_| StatusCode::BAD_REQUEST)?;
+    if parent_canon.starts_with(root) {
+        Ok(())
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
 // ─── 토큰 인증 미들웨어 (/api/* 에만 적용) ───
 
 async fn auth(
@@ -205,17 +227,11 @@ async fn list_files(State(ctx): State<Ctx>) -> Result<Json<ListResp>, StatusCode
             Ok(m) => m,
             Err(_) => continue,
         };
-        let modified = meta
-            .modified()
-            .ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
         files.push(FileEntry {
             path: rel.to_string_lossy().replace('\\', "/"),
             name: entry.file_name().to_string_lossy().to_string(),
             size: meta.len(),
-            modified,
+            modified: mtime_ms(&meta),
         });
     }
     // 최근 수정 우선(모바일에서 방금 본 문서 찾기 쉽게).
@@ -239,6 +255,8 @@ struct PathQuery {
 struct ReadResp {
     path: String,
     content: String,
+    /// 수정 시각(epoch ms) — 저장 시 낙관적 동시성 비교(base_modified)에 사용.
+    modified: u64,
 }
 
 /// GET /api/file?path=rel — 파일 내용.
@@ -250,10 +268,23 @@ async fn read_file(
     if !ext_allowed(&abs) {
         return Err(StatusCode::FORBIDDEN);
     }
-    let content = std::fs::read_to_string(&abs).map_err(|_| StatusCode::NOT_FOUND)?;
+    let meta = std::fs::metadata(&abs).map_err(|_| StatusCode::NOT_FOUND)?;
+    // P3d: 거대 파일 메모리 보호 — write 와 같은 상한.
+    if meta.len() as usize > MAX_CONTENT_BYTES {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    // P4a: 비-UTF8 은 "없음"이 아니라 415 로 구분(원인 혼동 방지).
+    let content = match std::fs::read_to_string(&abs) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+            return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        }
+        Err(_) => return Err(StatusCode::NOT_FOUND),
+    };
     Ok(Json(ReadResp {
         path: q.path,
         content,
+        modified: mtime_ms(&meta),
     }))
 }
 
@@ -261,12 +292,18 @@ async fn read_file(
 struct SaveBody {
     path: String,
     content: String,
+    /// 읽을 때 받은 수정 시각(epoch ms). 주면 저장 직전 디스크 mtime 과 비교해
+    /// 다르면 409(외부에서 변경됨) — lost update 방지(P2). 생략/0 이면 강제 저장.
+    #[serde(default)]
+    base_modified: Option<u64>,
 }
 
 #[derive(Serialize)]
 struct SaveResp {
     ok: bool,
     path: String,
+    /// 저장 후 새 수정 시각 — 클라이언트가 다음 저장의 base 로 갱신.
+    modified: u64,
 }
 
 /// PUT /api/file — 본문을 **원자적으로**(temp 작성 후 rename) in-place 저장.
@@ -281,11 +318,26 @@ async fn write_file(
     if !ext_allowed(&abs) {
         return Err(StatusCode::FORBIDDEN);
     }
-    // 부모 디렉토리는 존재해야 한다(새 폴더 생성은 하지 않음 — 단순/안전).
+    // 부모 디렉토리는 존재해야 하고(새 폴더 생성 안 함), 루트 하위여야 한다(P1 —
+    // 새 파일은 resolve 의 canonicalize 가 스킵되므로 부모를 직접 검증해 심볼릭
+    // 링크 탈출을 막는다).
     let parent = abs.parent().ok_or(StatusCode::BAD_REQUEST)?;
     if !parent.is_dir() {
         return Err(StatusCode::BAD_REQUEST);
     }
+    parent_within_root(&ctx.root, &abs)?;
+
+    // P2: 낙관적 동시성 — base_modified 가 주어지고 대상이 존재하면 현재 mtime 과
+    // 비교해 그 사이 외부 변경(맥 데스크탑 편집 등)이 있었으면 409 로 거부.
+    if let Some(base) = body.base_modified.filter(|b| *b != 0) {
+        if let Ok(meta) = std::fs::metadata(&abs) {
+            if mtime_ms(&meta) != base {
+                return Err(StatusCode::CONFLICT);
+            }
+        }
+        // 대상이 없으면(새 파일) base 는 무의미 — 통과.
+    }
+
     // 같은 디렉토리에 temp 작성 → rename(동일 파일시스템이라 원자적).
     let tmp = parent.join(format!(
         ".{}.markmind.tmp",
@@ -296,9 +348,11 @@ async fn write_file(
         let _ = std::fs::remove_file(&tmp); // rename 실패 시 temp 정리
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
+    let modified = std::fs::metadata(&abs).map(|m| mtime_ms(&m)).unwrap_or(0);
     Ok(Json(SaveResp {
         ok: true,
         path: body.path,
+        modified,
     }))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod lan_server;
 mod mcp;
 mod print_pdf;
 mod secrets;
+mod share;
 
 use std::sync::Arc;
 
@@ -275,6 +276,8 @@ pub fn run() {
             lan_server::lan_start,
             lan_server::lan_stop,
             lan_server::lan_status,
+            // macOS AirDrop 공유 (LAN 접속 URL 을 아이폰으로)
+            share::share_url_airdrop,
             // Keychain
             converters::keychain::get_api_key,
             converters::keychain::set_api_key,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 mod converters;
 mod gdrive;
+mod lan_server;
 mod mcp;
 mod print_pdf;
 mod secrets;
@@ -244,6 +245,7 @@ pub fn run() {
         .manage(pending)
         .manage(pending_content)
         .manage(mcp_state)
+        .manage(lan_server::LanState::default())
         .on_window_event(|window, event| {
             // 포커스된 윈도우 = MCP "현재 문서". 윈도우 종료 시 목록에서 제거.
             match event {
@@ -269,6 +271,10 @@ pub fn run() {
             open_new_window,
             mcp_sync_document,
             mcp_apply_edit_result,
+            // LAN 파일 공유 서버 (아이폰 등 — Connect 시에만 0.0.0.0 bind)
+            lan_server::lan_start,
+            lan_server::lan_stop,
+            lan_server::lan_status,
             // Keychain
             converters::keychain::get_api_key,
             converters::keychain::set_api_key,

--- a/src-tauri/src/share.rs
+++ b/src-tauri/src/share.rs
@@ -39,6 +39,13 @@ pub async fn share_url_airdrop(window: WebviewWindow, url: String) -> Result<(),
                         NSSharingService::sharingServiceNamed(NSSharingServiceNameSendViaAirDrop)
                             .ok_or_else(|| "AirDrop 서비스를 사용할 수 없습니다".to_string())?;
 
+                    // P3a: 항목을 보낼 수 있는지 먼저 확인 — 불가 시 무반응 대신 안내.
+                    if !service.canPerformWithItems(Some(&items)) {
+                        return Err(
+                            "AirDrop 으로 보낼 수 없습니다 (AirDrop 이 꺼져 있거나 주변 기기가 없을 수 있습니다). 복사 버튼을 이용하세요.".to_string(),
+                        );
+                    }
+
                     // AirDrop 수신자 선택 창 표시(메인 스레드 비동기).
                     service.performWithItems(&items);
                     Ok(())

--- a/src-tauri/src/share.rs
+++ b/src-tauri/src/share.rs
@@ -1,0 +1,53 @@
+//! macOS AirDrop 공유 — LAN 접속 URL 을 `NSSharingService` 로 AirDrop 전송.
+//!
+//! 설정창의 공유 버튼이 호출. 시스템 AirDrop 수신자 선택 창이 떠 아이폰을 고르면
+//! URL 이 전달되고, 아이폰은 "Safari 로 열기" 로 토큰 포함 주소에 바로 접속한다.
+//! print_pdf.rs 와 동일하게 `with_webview`(macOS 메인 스레드 보장) 안에서 AppKit 호출.
+
+use tauri::{command, WebviewWindow};
+use tokio::sync::oneshot;
+
+#[command]
+pub async fn share_url_airdrop(window: WebviewWindow, url: String) -> Result<(), String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (window, url);
+        return Err("AirDrop 공유는 macOS 전용입니다".to_string());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let (tx, rx) = oneshot::channel::<Result<(), String>>();
+
+        window
+            .with_webview(move |_pw| {
+                // with_webview 클로저 = macOS 메인 스레드 보장(AppKit UI 요건).
+                let res: Result<(), String> = (|| unsafe {
+                    use objc2::runtime::AnyObject;
+                    use objc2_app_kit::{NSSharingService, NSSharingServiceNameSendViaAirDrop};
+                    use objc2_foundation::{NSArray, NSString, NSURL};
+
+                    let ns_url = NSString::from_str(&url);
+                    let url_obj = NSURL::URLWithString(&ns_url)
+                        .ok_or_else(|| "URL 생성 실패".to_string())?;
+                    // 공유 항목 배열 — performWithItems 는 NSArray<AnyObject> 를 받으므로
+                    // NSURL 을 AnyObject 로 업캐스트(deref: NSURL→NSObject→AnyObject).
+                    let item: &AnyObject = &url_obj;
+                    let items = NSArray::from_slice(&[item]);
+
+                    let service =
+                        NSSharingService::sharingServiceNamed(NSSharingServiceNameSendViaAirDrop)
+                            .ok_or_else(|| "AirDrop 서비스를 사용할 수 없습니다".to_string())?;
+
+                    // AirDrop 수신자 선택 창 표시(메인 스레드 비동기).
+                    service.performWithItems(&items);
+                    Ok(())
+                })();
+                let _ = tx.send(res);
+            })
+            .map_err(|e| format!("with_webview 실패: {e}"))?;
+
+        rx.await
+            .map_err(|_| "with_webview 클로저 종료".to_string())?
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -967,9 +967,9 @@ function App() {
         if (!ok) return;
       }
       try {
-        const { content: text, path } = await lanReadFile(relPath);
+        const { content: text, path, modified } = await lanReadFile(relPath);
         const name = relPath.split('/').pop() || relPath;
-        openFromRecent(path, text, name);
+        openFromRecent(path, text, name, modified);
         setLanBrowserVisible(false);
       } catch (err) {
         console.error('[App] LAN 파일 열기 실패:', err);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import { InlineDiffView } from './components/InlineDiffView';
 import { AuthCallback } from './components/AuthCallback';
 import { SettingsModal } from './components/SettingsModal';
 import { DriveBrowser } from './components/DriveBrowser';
+import { LanFileBrowser } from './components/LanFileBrowser';
+import { hasLanServer, lanReadFile } from './services/webFileSystem';
 import type { DriveFile } from './services/gdriveService';
 import { confirmAction } from './services/dialogService';
 import { useFileSystem } from './hooks/useFileSystem';
@@ -130,6 +132,8 @@ function App() {
   const [tutorialVisible, setTutorialVisible] = useState(false);
   const [settingsVisible, setSettingsVisible] = useState(false);
   const [driveBrowserMode, setDriveBrowserMode] = useState<'open' | 'save' | null>(null);
+  // LAN 서버 모드(아이폰 브라우저 등)에서 공유 폴더 파일 목록 브라우저
+  const [lanBrowserVisible, setLanBrowserVisible] = useState(false);
   const [recentPanelVisible, setRecentPanelVisible] = useState(false);
   const [searchVisible, setSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -941,6 +945,40 @@ function App() {
     [openFromRecent],
   );
 
+  // 파일 열기 — 웹 모드 + LAN 서버면 공유 폴더 브라우저, 아니면 기존 흐름
+  // (Tauri 네이티브 다이얼로그 / 브라우저 input).
+  const handleOpenFile = useCallback(() => {
+    if (!isTauri() && hasLanServer()) {
+      setLanBrowserVisible(true);
+    } else {
+      openFile();
+    }
+  }, [openFile]);
+
+  // LAN 브라우저에서 파일 선택 → 내용 읽어 로드. filePath 를 서버 상대경로로
+  // 유지(openFromRecent) → 저장이 원본을 in-place 덮어쓴다.
+  const handleLanSelect = useCallback(
+    async (relPath: string) => {
+      if (isDirty) {
+        const ok = await confirmAction(
+          '현재 문서에 저장되지 않은 변경사항이 있습니다.\n' +
+            '다른 파일을 열면 변경사항이 사라집니다. 계속할까요?',
+        );
+        if (!ok) return;
+      }
+      try {
+        const { content: text, path } = await lanReadFile(relPath);
+        const name = relPath.split('/').pop() || relPath;
+        openFromRecent(path, text, name);
+        setLanBrowserVisible(false);
+      } catch (err) {
+        console.error('[App] LAN 파일 열기 실패:', err);
+        alert('파일을 열지 못했습니다: ' + err);
+      }
+    },
+    [isDirty, openFromRecent],
+  );
+
   /** File 메뉴 submenu 에서 path 만으로 열기 — content 는 자체적으로 읽음 */
   const handleOpenRecentByPath = useCallback(
     async (path: string) => {
@@ -980,7 +1018,7 @@ function App() {
             break;
           case 'o':
             e.preventDefault();
-            openFile();
+            handleOpenFile();
             break;
           case 'n':
             e.preventDefault();
@@ -1034,7 +1072,7 @@ function App() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [
-    saveFile, saveFileAs, openFile, newFile, toggleSearch,
+    saveFile, saveFileAs, handleOpenFile, newFile, toggleSearch,
     handleFontSizeChange, resetFontSize, readingMode, recentPanelVisible,
     searchVisible, viewMode, handleToggleAI, tutorialVisible, settingsVisible,
   ]);
@@ -1167,7 +1205,7 @@ function App() {
         outlineVisible={outlineVisible}
         onViewModeChange={setViewMode}
         onNewFile={newFile}
-        onOpenFile={openFile}
+        onOpenFile={handleOpenFile}
         onSaveFile={saveFile}
         onSaveFileAs={saveFileAs}
         onExportPdf={handleExportPdf}
@@ -1440,6 +1478,13 @@ function App() {
 
       {/* 통합 Settings 모달 — STT/OCR/AI 에이전트 API 키 */}
       <SettingsModal visible={settingsVisible} onClose={() => setSettingsVisible(false)} />
+
+      {/* LAN 서버 모드(아이폰 등) — 공유 폴더 파일 브라우저 */}
+      <LanFileBrowser
+        visible={lanBrowserVisible}
+        onClose={() => setLanBrowserVisible(false)}
+        onSelect={handleLanSelect}
+      />
 
       {/* Google Drive 파일 브라우저 (Open from / Save to) */}
       <DriveBrowser

--- a/src/components/LanFileBrowser.tsx
+++ b/src/components/LanFileBrowser.tsx
@@ -1,0 +1,138 @@
+/**
+ * LAN 서버 모드 파일 브라우저 — 아이폰 브라우저 등에서 공유 폴더의 마크다운
+ * 목록을 보고 탭해서 연다. 데스크탑 앱(Tauri)에서는 사용하지 않는다(네이티브
+ * 파일 다이얼로그 사용). 선택 시 onSelect(상대경로)로 위임.
+ */
+
+import { useEffect, useState } from 'react';
+import { FileText, X, RefreshCw } from 'lucide-react';
+import { lanListFiles, type LanFile } from '../services/webFileSystem';
+
+interface LanFileBrowserProps {
+    visible: boolean;
+    onClose: () => void;
+    onSelect: (relPath: string) => void;
+}
+
+function formatTime(ms: number): string {
+    if (!ms) return '';
+    try {
+        return new Date(ms).toLocaleString();
+    } catch {
+        return '';
+    }
+}
+
+export function LanFileBrowser({ visible, onClose, onSelect }: LanFileBrowserProps) {
+    const [files, setFiles] = useState<LanFile[]>([]);
+    const [root, setRoot] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await lanListFiles();
+            setRoot(res.root);
+            setFiles(res.files);
+        } catch (err) {
+            setError(String(err));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (visible) load();
+    }, [visible]);
+
+    if (!visible) return null;
+
+    return (
+        <>
+            <div className="settings-modal-backdrop" onClick={onClose} aria-hidden />
+            <div className="settings-modal" role="dialog" aria-modal="true">
+                <div className="settings-modal-header">
+                    <span className="settings-modal-title">파일 열기</span>
+                    <div style={{ display: 'flex', gap: 4 }}>
+                        <button
+                            className="settings-modal-close"
+                            onClick={load}
+                            title="새로고침"
+                            aria-label="새로고침"
+                        >
+                            <RefreshCw size={16} />
+                        </button>
+                        <button
+                            className="settings-modal-close"
+                            onClick={onClose}
+                            title="닫기"
+                            aria-label="닫기"
+                        >
+                            <X size={18} />
+                        </button>
+                    </div>
+                </div>
+                {root && (
+                    <p className="settings-modal-note" style={{ wordBreak: 'break-all' }}>
+                        {root}
+                    </p>
+                )}
+                <div className="settings-modal-body">
+                    {loading && <p className="convert-key-note">불러오는 중…</p>}
+                    {error && <p className="drive-error">{error}</p>}
+                    {!loading && !error && files.length === 0 && (
+                        <p className="convert-key-note">이 폴더에 마크다운 파일이 없습니다.</p>
+                    )}
+                    {!loading && !error && files.length > 0 && (
+                        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+                            {files.map((f) => (
+                                <li key={f.path}>
+                                    <button
+                                        onClick={() => onSelect(f.path)}
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: 10,
+                                            width: '100%',
+                                            padding: '12px 10px',
+                                            border: 'none',
+                                            borderBottom: '1px solid var(--border-color, #e5e5e5)',
+                                            background: 'transparent',
+                                            textAlign: 'left',
+                                            cursor: 'pointer',
+                                            font: 'inherit',
+                                        }}
+                                    >
+                                        <FileText size={18} style={{ flexShrink: 0, opacity: 0.7 }} />
+                                        <span style={{ flex: 1, minWidth: 0 }}>
+                                            <span style={{ display: 'block', fontWeight: 600 }}>
+                                                {f.name}
+                                            </span>
+                                            <span
+                                                style={{
+                                                    display: 'block',
+                                                    fontSize: 12,
+                                                    opacity: 0.6,
+                                                    overflow: 'hidden',
+                                                    textOverflow: 'ellipsis',
+                                                    whiteSpace: 'nowrap',
+                                                }}
+                                            >
+                                                {f.path.includes('/')
+                                                    ? f.path.slice(0, f.path.lastIndexOf('/'))
+                                                    : ''}
+                                                {f.modified ? ` · ${formatTime(f.modified)}` : ''}
+                                            </span>
+                                        </span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+}

--- a/src/components/convert/LanShareSection.tsx
+++ b/src/components/convert/LanShareSection.tsx
@@ -36,6 +36,15 @@ export function LanShareSection() {
         lanStatus().then(setInfo).catch(() => {});
     }, []);
 
+    // P3c: 다른 윈도우에서 연결/해제해도 이 설정창이 stale 하지 않도록 주기 동기화.
+    // 작업 중(busy)에는 건너뛰어 사용자 액션 결과를 덮어쓰지 않는다.
+    useEffect(() => {
+        const id = setInterval(() => {
+            if (!busy) lanStatus().then(setInfo).catch(() => {});
+        }, 3000);
+        return () => clearInterval(id);
+    }, [busy]);
+
     const pickFolder = async () => {
         try {
             const { open } = await import('@tauri-apps/plugin-dialog');

--- a/src/components/convert/LanShareSection.tsx
+++ b/src/components/convert/LanShareSection.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Wifi, WifiOff, FolderOpen, Copy, RefreshCw, Check } from 'lucide-react';
+import { Wifi, WifiOff, FolderOpen, Copy, RefreshCw, Check, Share2 } from 'lucide-react';
 import {
     LanInfo,
     lanStart,
@@ -17,16 +17,17 @@ import {
     setSavedRoot,
     getOrCreateToken,
     regenerateToken,
-    connectUrl,
+    urlFor,
+    shareAirdrop,
 } from '../../services/lanService';
 
 export function LanShareSection() {
     const [root, setRoot] = useState('');
     const [token, setToken] = useState('');
-    const [info, setInfo] = useState<LanInfo>({ running: false, addr: null, port: null, root: null });
+    const [info, setInfo] = useState<LanInfo>({ running: false, host: null, addr: null, port: null, root: null });
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [copied, setCopied] = useState(false);
+    const [copied, setCopied] = useState<'host' | 'ip' | null>(null);
 
     useEffect(() => {
         setRoot(getSavedRoot());
@@ -72,7 +73,7 @@ export function LanShareSection() {
         setError(null);
         try {
             await lanStop();
-            setInfo({ running: false, addr: null, port: null, root: null });
+            setInfo({ running: false, host: null, addr: null, port: null, root: null });
         } catch (err) {
             setError(String(err));
         } finally {
@@ -86,15 +87,26 @@ export function LanShareSection() {
         setToken(regenerateToken());
     };
 
-    const url = connectUrl(info, token);
-    const handleCopy = async () => {
+    const port = info.port ?? 0;
+    const hostUrl = info.host && port ? urlFor(info.host, port, token) : '';
+    const ipUrl = info.addr && port ? urlFor(info.addr, port, token) : '';
+    const handleCopy = async (which: 'host' | 'ip', url: string) => {
         if (!url) return;
         try {
             await navigator.clipboard.writeText(url);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
+            setCopied(which);
+            setTimeout(() => setCopied(null), 1500);
         } catch {
             // 클립보드 불가 — 무시(주소는 화면에 표시됨)
+        }
+    };
+
+    const handleShare = async (url: string) => {
+        if (!url) return;
+        try {
+            await shareAirdrop(url);
+        } catch (err) {
+            setError(String(err));
         }
     };
 
@@ -150,18 +162,56 @@ export function LanShareSection() {
                 )}
             </div>
 
-            {/* 접속 주소 */}
-            {info.running && url && (
+            {/* 접속 주소 — 고정 .local(권장) + IP(폴백) */}
+            {info.running && (hostUrl || ipUrl) && (
                 <div className="lan-connect-info" style={{ marginTop: 8 }}>
                     <p className="convert-key-note" style={{ marginBottom: 4 }}>
                         아이폰 Safari 에서 같은 Wi-Fi 로 접속:
                     </p>
-                    <div className="convert-key-row">
-                        <input type="text" value={url} readOnly onFocus={(e) => e.target.select()} />
-                        <button onClick={handleCopy} title="주소 복사">
-                            {copied ? <Check size={14} /> : <Copy size={14} />}
-                        </button>
-                    </div>
+
+                    {hostUrl && (
+                        <>
+                            <div className="convert-key-row">
+                                <input
+                                    type="text"
+                                    value={hostUrl}
+                                    readOnly
+                                    onFocus={(e) => e.target.select()}
+                                />
+                                <button onClick={() => handleCopy('host', hostUrl)} title="주소 복사">
+                                    {copied === 'host' ? <Check size={14} /> : <Copy size={14} />}
+                                </button>
+                                <button onClick={() => handleShare(hostUrl)} title="AirDrop 으로 공유">
+                                    <Share2 size={14} />
+                                </button>
+                            </div>
+                            <p className="convert-key-note" style={{ margin: '2px 0 6px' }}>
+                                고정 주소 — IP 가 바뀌어도 그대로 (권장)
+                            </p>
+                        </>
+                    )}
+
+                    {ipUrl && (
+                        <>
+                            <div className="convert-key-row">
+                                <input
+                                    type="text"
+                                    value={ipUrl}
+                                    readOnly
+                                    onFocus={(e) => e.target.select()}
+                                />
+                                <button onClick={() => handleCopy('ip', ipUrl)} title="주소 복사">
+                                    {copied === 'ip' ? <Check size={14} /> : <Copy size={14} />}
+                                </button>
+                                <button onClick={() => handleShare(ipUrl)} title="AirDrop 으로 공유">
+                                    <Share2 size={14} />
+                                </button>
+                            </div>
+                            <p className="convert-key-note" style={{ margin: '2px 0 0' }}>
+                                IP 주소 — 위 고정 주소가 안 될 때 폴백
+                            </p>
+                        </>
+                    )}
                 </div>
             )}
 

--- a/src/components/convert/LanShareSection.tsx
+++ b/src/components/convert/LanShareSection.tsx
@@ -1,0 +1,177 @@
+/**
+ * 설정창 "아이폰 연결" 섹션 — 같은 Wi-Fi 의 기기가 지정 폴더의 마크다운을
+ * 읽고 편집하도록 LAN 서버를 Connect/Disconnect.
+ *
+ * 보안: 기본 OFF, 명시적 Connect 시에만 노출. 노출 중에는 상태를 시각적으로
+ * 표시(실수 방지). Path(노출 폴더) 하나로 샌드박싱, 토큰(PIN) 필수.
+ */
+
+import { useEffect, useState } from 'react';
+import { Wifi, WifiOff, FolderOpen, Copy, RefreshCw, Check } from 'lucide-react';
+import {
+    LanInfo,
+    lanStart,
+    lanStop,
+    lanStatus,
+    getSavedRoot,
+    setSavedRoot,
+    getOrCreateToken,
+    regenerateToken,
+    connectUrl,
+} from '../../services/lanService';
+
+export function LanShareSection() {
+    const [root, setRoot] = useState('');
+    const [token, setToken] = useState('');
+    const [info, setInfo] = useState<LanInfo>({ running: false, addr: null, port: null, root: null });
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        setRoot(getSavedRoot());
+        setToken(getOrCreateToken());
+        // 앱 재시작 후 실제 서버 상태 확인(보통 OFF로 시작).
+        lanStatus().then(setInfo).catch(() => {});
+    }, []);
+
+    const pickFolder = async () => {
+        try {
+            const { open } = await import('@tauri-apps/plugin-dialog');
+            const selected = await open({ directory: true, multiple: false });
+            if (typeof selected === 'string') {
+                setRoot(selected);
+                setSavedRoot(selected);
+            }
+        } catch (err) {
+            setError(String(err));
+        }
+    };
+
+    const handleConnect = async () => {
+        const dir = root.trim();
+        if (!dir) {
+            setError('공유할 폴더를 먼저 선택하세요.');
+            return;
+        }
+        setBusy(true);
+        setError(null);
+        try {
+            setSavedRoot(dir);
+            const result = await lanStart(dir, token);
+            setInfo(result);
+        } catch (err) {
+            setError(String(err));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleDisconnect = async () => {
+        setBusy(true);
+        setError(null);
+        try {
+            await lanStop();
+            setInfo({ running: false, addr: null, port: null, root: null });
+        } catch (err) {
+            setError(String(err));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRegenerate = () => {
+        // 연결 중에는 토큰을 바꾸면 기존 접속이 끊기므로 막는다.
+        if (info.running) return;
+        setToken(regenerateToken());
+    };
+
+    const url = connectUrl(info, token);
+    const handleCopy = async () => {
+        if (!url) return;
+        try {
+            await navigator.clipboard.writeText(url);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch {
+            // 클립보드 불가 — 무시(주소는 화면에 표시됨)
+        }
+    };
+
+    return (
+        <section className="convert-settings-section">
+            <label>
+                아이폰 연결 — LAN 파일 공유{' '}
+                {info.running ? (
+                    <span className="badge badge-ok">연결됨</span>
+                ) : (
+                    <span className="badge badge-warn">꺼짐</span>
+                )}
+            </label>
+
+            {/* 공유 폴더 */}
+            <div className="convert-key-row">
+                <input
+                    type="text"
+                    placeholder="공유할 폴더 경로 (예: ~/iCloud Drive/MarkMind)"
+                    value={root}
+                    onChange={(e) => setRoot(e.target.value)}
+                    disabled={info.running || busy}
+                />
+                <button onClick={pickFolder} disabled={info.running || busy} title="폴더 선택">
+                    <FolderOpen size={14} />
+                </button>
+            </div>
+
+            {/* 토큰(PIN) */}
+            <div className="convert-key-row" style={{ marginTop: 6 }}>
+                <input type="text" value={`PIN: ${token}`} readOnly disabled />
+                <button
+                    onClick={handleRegenerate}
+                    disabled={info.running || busy}
+                    title={info.running ? '연결 해제 후 변경 가능' : 'PIN 재생성'}
+                >
+                    <RefreshCw size={14} />
+                </button>
+            </div>
+
+            {/* Connect / Disconnect */}
+            <div className="drive-connect-row" style={{ marginTop: 8 }}>
+                {info.running ? (
+                    <button className="danger" onClick={handleDisconnect} disabled={busy}>
+                        <WifiOff size={14} />
+                        <span>연결 해제</span>
+                    </button>
+                ) : (
+                    <button className="primary" onClick={handleConnect} disabled={busy}>
+                        <Wifi size={14} />
+                        <span>{busy ? '연결 중...' : '연결 (Connect)'}</span>
+                    </button>
+                )}
+            </div>
+
+            {/* 접속 주소 */}
+            {info.running && url && (
+                <div className="lan-connect-info" style={{ marginTop: 8 }}>
+                    <p className="convert-key-note" style={{ marginBottom: 4 }}>
+                        아이폰 Safari 에서 같은 Wi-Fi 로 접속:
+                    </p>
+                    <div className="convert-key-row">
+                        <input type="text" value={url} readOnly onFocus={(e) => e.target.select()} />
+                        <button onClick={handleCopy} title="주소 복사">
+                            {copied ? <Check size={14} /> : <Copy size={14} />}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <p className="convert-key-note">
+                지정한 <strong>폴더 하나</strong>의 마크다운만 노출되며, PIN 이 있어야 접근됩니다.
+                <strong> 신뢰하는 집 Wi-Fi 에서만</strong> 사용하고, 끝나면 연결을 해제하세요.
+                카페·회사 등 공유 네트워크에서는 켜두지 마세요.
+            </p>
+
+            {error && <p className="drive-error">{error}</p>}
+        </section>
+    );
+}

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -15,6 +15,8 @@ import { getKey, hasKey, Provider, removeKey, updateCacheAfterBatch } from '../.
 import * as gdrive from '../../services/gdriveService';
 import * as secretsBatch from '../../services/secretsService';
 import { confirmAction } from '../../services/dialogService';
+import { isTauri } from '../../services/platform';
+import { LanShareSection } from './LanShareSection';
 import {
     ValidationResult,
     validateProvider,
@@ -554,6 +556,9 @@ export function SettingsView({ onDone }: SettingsViewProps) {
 
                 {driveError && <p className="drive-error">{driveError}</p>}
             </section>
+
+            {/* === 아이폰 연결 (LAN 파일 공유) — 데스크탑 앱 전용 === */}
+            {isTauri() && <LanShareSection />}
 
             {postSaveWarn && <p className="convert-key-note warn">{postSaveWarn}</p>}
 

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { isTauri } from '../services/platform';
-import { webOpenFile, webSaveFile, webConfirmUnsavedChanges } from '../services/webFileSystem';
+import { webOpenFile, webSaveFile, webConfirmUnsavedChanges, hasLanServer, lanWriteFile } from '../services/webFileSystem';
 
 interface FileState {
   content: string;
@@ -329,7 +329,19 @@ export function useFileSystem(onFileOpened?: () => void) {
   const saveFile = useCallback(async (): Promise<'saved' | 'cancelled' | 'failed'> => {
     try {
       if (!isTauri()) {
-        // Web mode
+        // LAN 서버 모드 — filePath(서버 루트 기준 상대경로)가 있으면 원본을
+        // in-place 로 덮어쓴다(다운로드 사본 아님). 아이폰 등에서 핵심 흐름.
+        if (hasLanServer() && filePathRef.current) {
+          try {
+            await lanWriteFile(filePathRef.current, contentRef.current);
+            setFileState((prev) => ({ ...prev, isDirty: false }));
+            return 'saved';
+          } catch (err) {
+            console.error('Failed to save to LAN server:', err);
+            return 'failed';
+          }
+        }
+        // Web mode (브라우저 다운로드 fallback)
         const savedName = await webSaveFile(contentRef.current, fileNameRef.current, false);
         if (savedName) {
           setFileState((prev) => ({ ...prev, fileName: savedName, isDirty: false }));

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -1,12 +1,14 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { isTauri } from '../services/platform';
-import { webOpenFile, webSaveFile, webConfirmUnsavedChanges, hasLanServer, lanWriteFile } from '../services/webFileSystem';
+import { webOpenFile, webSaveFile, webConfirmUnsavedChanges, hasLanServer, lanWriteFile, type LanWriteError } from '../services/webFileSystem';
 
 interface FileState {
   content: string;
   filePath: string | null;
   fileName: string;
   isDirty: boolean;
+  /** LAN 서버로 연 파일의 base mtime(epoch ms) — 저장 시 충돌 감지(P2). */
+  lanModified?: number;
 }
 
 
@@ -44,12 +46,14 @@ export function useFileSystem(onFileOpened?: () => void) {
   const isDirtyRef = useRef(fileState.isDirty);
   const filePathRef = useRef(fileState.filePath);
   const fileNameRef = useRef(fileState.fileName);
+  const lanModifiedRef = useRef(fileState.lanModified);
 
   useEffect(() => {
     contentRef.current = fileState.content;
     isDirtyRef.current = fileState.isDirty;
     filePathRef.current = fileState.filePath;
     fileNameRef.current = fileState.fileName;
+    lanModifiedRef.current = fileState.lanModified;
   }, [fileState]);
 
   // ─── MCP 읽기 전용 서버에 현재 문서 스냅샷 동기화 ───
@@ -331,12 +335,30 @@ export function useFileSystem(onFileOpened?: () => void) {
       if (!isTauri()) {
         // LAN 서버 모드 — filePath(서버 루트 기준 상대경로)가 있으면 원본을
         // in-place 로 덮어쓴다(다운로드 사본 아님). 아이폰 등에서 핵심 흐름.
+        // base mtime 을 보내 외부 변경(맥에서 같은 파일 편집 등) 시 409 → 사용자
+        // 확인 후에만 강제 덮어쓰기(P2 lost update 방지).
         if (hasLanServer() && filePathRef.current) {
+          const path = filePathRef.current;
           try {
-            await lanWriteFile(filePathRef.current, contentRef.current);
-            setFileState((prev) => ({ ...prev, isDirty: false }));
+            const res = await lanWriteFile(path, contentRef.current, lanModifiedRef.current);
+            setFileState((prev) => ({ ...prev, isDirty: false, lanModified: res.modified }));
             return 'saved';
           } catch (err) {
+            if ((err as LanWriteError).conflict) {
+              const ok = window.confirm(
+                '이 파일이 다른 곳에서 변경되었습니다.\n현재 편집 내용으로 덮어쓸까요? (외부 변경분이 사라집니다)',
+              );
+              if (!ok) return 'cancelled';
+              try {
+                // 강제 저장 — base 생략으로 충돌 검사 우회
+                const res2 = await lanWriteFile(path, contentRef.current);
+                setFileState((prev) => ({ ...prev, isDirty: false, lanModified: res2.modified }));
+                return 'saved';
+              } catch (err2) {
+                console.error('Failed to force-save to LAN server:', err2);
+                return 'failed';
+              }
+            }
             console.error('Failed to save to LAN server:', err);
             return 'failed';
           }
@@ -422,11 +444,15 @@ export function useFileSystem(onFileOpened?: () => void) {
 
 
 
-  // Open file directly from path and content (for recent files — Tauri only)
-  const openFromRecent = useCallback((path: string, content: string, name: string) => {
-    setFileState({ content, filePath: path, fileName: name, isDirty: false });
-    onFileOpened?.();
-  }, [onFileOpened]);
+  // Open file directly from path and content (recent files — Tauri; LAN browser).
+  // lanModified 를 주면(LAN 모드) 저장 시 충돌 감지의 base 로 보관.
+  const openFromRecent = useCallback(
+    (path: string, content: string, name: string, lanModified?: number) => {
+      setFileState({ content, filePath: path, fileName: name, isDirty: false, lanModified });
+      onFileOpened?.();
+    },
+    [onFileOpened],
+  );
 
   // 메모리(예: Google Drive 다운로드)에서 가져온 내용을 새 가상 파일로 로드.
   // filePath 는 null — 사용자가 Save 누르면 Save As 다이얼로그.

--- a/src/services/lanService.ts
+++ b/src/services/lanService.ts
@@ -1,0 +1,63 @@
+/**
+ * LAN 파일 공유 서버 제어 (데스크탑 앱 설정창 전용 — Tauri invoke).
+ *
+ * 설정창에서 Connect 하면 Rust 가 `0.0.0.0:8418` 에 bind 하고, 같은 Wi-Fi 의
+ * 기기(아이폰 브라우저)가 `http://<ip>:8418/?token=<PIN>` 으로 접속해 지정 폴더의
+ * 마크다운을 읽고 in-place 편집한다. MCP(127.0.0.1)와는 분리된 별도 서버.
+ *
+ * root(노출 폴더)·token(PIN)은 localStorage 에 보관하되, **연결 상태는 저장하지
+ * 않는다**(앱 재시작 시 항상 OFF로 시작 — 명시적 ON 원칙).
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+
+export interface LanInfo {
+    running: boolean;
+    addr: string | null;
+    port: number | null;
+    root: string | null;
+}
+
+const ROOT_KEY = 'markmind.lan.root';
+const TOKEN_KEY = 'markmind.lan.token';
+
+export function getSavedRoot(): string {
+    return localStorage.getItem(ROOT_KEY) || '';
+}
+
+export function setSavedRoot(value: string): void {
+    localStorage.setItem(ROOT_KEY, value);
+}
+
+/** PIN 토큰을 가져오거나(없으면) 생성해 저장. URL-safe 12자 hex. */
+export function getOrCreateToken(): string {
+    let t = localStorage.getItem(TOKEN_KEY);
+    if (!t) {
+        t = regenerateToken();
+    }
+    return t;
+}
+
+export function regenerateToken(): string {
+    const t = crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+    localStorage.setItem(TOKEN_KEY, t);
+    return t;
+}
+
+export async function lanStart(root: string, token: string): Promise<LanInfo> {
+    return invoke<LanInfo>('lan_start', { root, token });
+}
+
+export async function lanStop(): Promise<void> {
+    await invoke('lan_stop');
+}
+
+export async function lanStatus(): Promise<LanInfo> {
+    return invoke<LanInfo>('lan_status');
+}
+
+/** 아이폰이 접속할 전체 URL(토큰 포함). */
+export function connectUrl(info: LanInfo, token: string): string {
+    if (!info.addr || !info.port) return '';
+    return `http://${info.addr}:${info.port}/?token=${encodeURIComponent(token)}`;
+}

--- a/src/services/lanService.ts
+++ b/src/services/lanService.ts
@@ -13,6 +13,9 @@ import { invoke } from '@tauri-apps/api/core';
 
 export interface LanInfo {
     running: boolean;
+    /** mDNS 호스트네임(*.local) — IP 가 바뀌어도 고정(권장). 못 구하면 null. */
+    host: string | null;
+    /** 현재 LAN IP — DHCP 라 바뀔 수 있음(폴백). */
     addr: string | null;
     port: number | null;
     root: string | null;
@@ -56,8 +59,12 @@ export async function lanStatus(): Promise<LanInfo> {
     return invoke<LanInfo>('lan_status');
 }
 
-/** 아이폰이 접속할 전체 URL(토큰 포함). */
-export function connectUrl(info: LanInfo, token: string): string {
-    if (!info.addr || !info.port) return '';
-    return `http://${info.addr}:${info.port}/?token=${encodeURIComponent(token)}`;
+/** 호스트(또는 IP) + 포트 + 토큰으로 아이폰 접속 URL 생성. */
+export function urlFor(hostOrIp: string, port: number, token: string): string {
+    return `http://${hostOrIp}:${port}/?token=${encodeURIComponent(token)}`;
+}
+
+/** macOS AirDrop 으로 접속 URL 전송(시스템 수신자 선택 창). */
+export async function shareAirdrop(url: string): Promise<void> {
+    await invoke('share_url_airdrop', { url });
 }

--- a/src/services/webFileSystem.ts
+++ b/src/services/webFileSystem.ts
@@ -153,19 +153,41 @@ export async function lanListFiles(): Promise<{ root: string; files: LanFile[] }
     return r.json();
 }
 
-export async function lanReadFile(path: string): Promise<{ path: string; content: string }> {
+export async function lanReadFile(
+    path: string,
+): Promise<{ path: string; content: string; modified: number }> {
     const r = await lanFetch(`/api/file?path=${encodeURIComponent(path)}`);
     if (!r.ok) throw new Error(`파일을 읽지 못했습니다 (${r.status})`);
     return r.json();
 }
 
-export async function lanWriteFile(path: string, content: string): Promise<void> {
+/** 저장 충돌(외부에서 변경됨, HTTP 409)을 식별하기 위한 에러 플래그. */
+export interface LanWriteError extends Error {
+    conflict?: boolean;
+}
+
+/**
+ * in-place 저장. baseModified(읽을 때의 mtime)를 주면 서버가 그 사이 외부
+ * 변경을 감지해 409 를 던진다(lost update 방지). 강제 저장은 baseModified 생략.
+ * 반환: 저장 후 새 mtime(다음 저장의 base).
+ */
+export async function lanWriteFile(
+    path: string,
+    content: string,
+    baseModified?: number,
+): Promise<{ modified: number }> {
     const r = await lanFetch('/api/file', {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path, content }),
+        body: JSON.stringify({ path, content, base_modified: baseModified }),
     });
+    if (r.status === 409) {
+        const err: LanWriteError = new Error('파일이 외부에서 변경되었습니다');
+        err.conflict = true;
+        throw err;
+    }
     if (!r.ok) throw new Error(`저장하지 못했습니다 (${r.status})`);
+    return r.json();
 }
 
 // ─── Public API ───

--- a/src/services/webFileSystem.ts
+++ b/src/services/webFileSystem.ts
@@ -106,6 +106,68 @@ function saveWithFallback(content: string, fileName: string): string {
     return fileName;
 }
 
+// ─── LAN 서버 모드 (아이폰 브라우저 등) ───
+// MarkMind 데스크탑 앱이 Connect 로 띄운 LAN 서버에 같은 origin 으로 접속한 경우.
+// 토큰은 첫 접속 URL(?token=)에서 받아 localStorage 에 저장 후 헤더로 첨부.
+// filePath = 서버 루트 기준 상대경로 → 저장이 원본을 in-place 덮어쓴다.
+
+const LAN_TOKEN_KEY = 'markmind.lan.client.token';
+
+export interface LanFile {
+    path: string;
+    name: string;
+    size: number;
+    modified: number;
+}
+
+/** URL ?token= 우선(첫 접속 시 저장), 없으면 localStorage. */
+function getClientToken(): string | null {
+    try {
+        const fromUrl = new URL(window.location.href).searchParams.get('token');
+        if (fromUrl) {
+            localStorage.setItem(LAN_TOKEN_KEY, fromUrl);
+            return fromUrl;
+        }
+    } catch {
+        // URL 파싱 불가 — localStorage 로 폴백
+    }
+    return localStorage.getItem(LAN_TOKEN_KEY);
+}
+
+/** LAN 서버로 서빙된 컨텍스트인지(= 토큰 보유). 웹 모드에서만 의미 있음. */
+export function hasLanServer(): boolean {
+    return getClientToken() !== null;
+}
+
+async function lanFetch(path: string, init?: RequestInit): Promise<Response> {
+    const token = getClientToken();
+    return fetch(path, {
+        ...init,
+        headers: { ...(init?.headers || {}), 'x-markmind-token': token || '' },
+    });
+}
+
+export async function lanListFiles(): Promise<{ root: string; files: LanFile[] }> {
+    const r = await lanFetch('/api/files');
+    if (!r.ok) throw new Error(`목록을 불러오지 못했습니다 (${r.status})`);
+    return r.json();
+}
+
+export async function lanReadFile(path: string): Promise<{ path: string; content: string }> {
+    const r = await lanFetch(`/api/file?path=${encodeURIComponent(path)}`);
+    if (!r.ok) throw new Error(`파일을 읽지 못했습니다 (${r.status})`);
+    return r.json();
+}
+
+export async function lanWriteFile(path: string, content: string): Promise<void> {
+    const r = await lanFetch('/api/file', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path, content }),
+    });
+    if (!r.ok) throw new Error(`저장하지 못했습니다 (${r.status})`);
+}
+
 // ─── Public API ───
 
 export async function webOpenFile(): Promise<{ content: string; name: string } | null> {


### PR DESCRIPTION
## 개요
같은 Wi-Fi 의 아이폰 브라우저에서 지정 폴더의 마크다운을 읽고 **in-place 편집**하는 LAN 파일 공유 서버를 추가합니다. 설정창에서 Connect/Disconnect 로 토글하며, 기본 OFF·명시적 ON 입니다.

## 주요 기능
- **LAN 서버**: 앱 내장 axum 서버(`0.0.0.0:8418`)가 빌드된 UI(dist 임베드) + 파일 API 를 서빙 → 아이폰은 브라우저로 접속해 편집/저장. **MCP(127.0.0.1)와 분리된 별도 listener**.
- **고정 주소**: `*.local`(mDNS, 권장) + IP(폴백) 두 주소 표시. IP 가 바뀌어도 `.local` 은 고정.
- **AirDrop 공유**: 접속 URL 을 아이폰으로 AirDrop (`NSSharingService`).

## 보안 가드
- 루트 폴더 샌드박싱(`..`/심볼릭 링크 탈출 차단, 새 파일은 부모 canonicalize 검증)
- 토큰(PIN) 미들웨어 — 정적 UI 는 비인증, `/api/*` 만 인증
- 원자적 저장(temp+rename), 낙관적 동시성(mtime 비교 → 409), read/write 8MB 상한

## 검증
- tsc · cargo check · release build(v0.4.2) 통과
- 런타임(아이폰 접속·AirDrop·409 충돌)은 빌드 앱에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)