### PR TITLE
perf(mcp): generateDiff 대형 문서 크기 가드 — propose_edit UI 프리즈 방지 (#36)

### DIFF
--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { generateDiff } from './aiService';
+
+// #36 — generateDiff 의 paragraph/word LCS 는 O(m·n) DP 라 대형 입력에서 메인 스레드를
+// 막는다. 일정 규모(LCS_CELL_LIMIT = 200만 셀) 초과 시 "전체 교체"로 폴백하는 가드를 검증.
+describe('generateDiff 대형 문서 가드(#36)', () => {
+    it('일반 크기는 정밀 diff — 공통 문단을 unchanged 로 보존', () => {
+        const orig = 'keep\n\nold\n\nkeep2';
+        const mod = 'keep\n\nnew\n\nkeep2';
+        const chunks = generateDiff(orig, mod);
+        const unchanged = chunks
+            .filter((c) => c.type === 'unchanged' && c.content)
+            .map((c) => c.content);
+        expect(unchanged).toContain('keep');
+        expect(unchanged).toContain('keep2');
+        // 변경 문단은 removed/added 로 표현
+        expect(chunks.some((c) => c.type === 'removed')).toBe(true);
+        expect(chunks.some((c) => c.type === 'added')).toBe(true);
+    });
+
+    it('문단 수가 임계를 넘으면 전체 교체로 폴백 — 공통 문단도 unchanged 로 잡히지 않음', () => {
+        // 앞 1500 문단은 양쪽 동일. 정밀 diff 라면 전부 unchanged 로 보존됐을 것.
+        const common = Array.from({ length: 1500 }, (_, i) => `c${i}`);
+        const orig = [...common, 'tail-o'].join('\n\n'); // 1501 문단
+        const mod = [...common, 'tail-m'].join('\n\n'); // 1501 문단 → 1501² ≈ 225만 > 200만
+        const chunks = generateDiff(orig, mod);
+        const unchanged = chunks.filter((c) => c.type === 'unchanged' && c.content);
+        // 폴백이면 공통 문단(c0..c1499)도 unchanged 가 아니라 removed/added 로 나뉜다.
+        expect(unchanged).toHaveLength(0);
+        expect(chunks.some((c) => c.type === 'removed')).toBe(true);
+        expect(chunks.some((c) => c.type === 'added')).toBe(true);
+    });
+
+    it('줄바꿈 없는 초대형 단일 문단도 가드로 처리(word LCS 폭발 방지)', () => {
+        // 한 문단 안 토큰 수가 커서 wordDiff 의 토큰 LCS 가 폭발할 입력.
+        const orig = Array.from({ length: 3000 }, (_, i) => `wo${i}`).join(' ');
+        const mod = Array.from({ length: 3000 }, (_, i) => `wm${i}`).join(' ');
+        // 단일 문단 쌍이므로 generateDiff 진입 가드(문단 1×1)는 통과 → wordDiff 가드가 받음.
+        const chunks = generateDiff(orig, mod);
+        // 예외 없이 removed/added 가 생성되면 통과(폭발 시 행/크래시 발생).
+        expect(chunks.some((c) => c.type === 'removed')).toBe(true);
+        expect(chunks.some((c) => c.type === 'added')).toBe(true);
+    });
+});

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateDiff } from './aiService';
+import { generateDiff, applyDiff } from './aiService';
 
 // #36 — generateDiff 의 paragraph/word LCS 는 O(m·n) DP 라 대형 입력에서 메인 스레드를
 // 막는다. 일정 규모(LCS_CELL_LIMIT = 200만 셀) 초과 시 "전체 교체"로 폴백하는 가드를 검증.
@@ -40,5 +40,16 @@ describe('generateDiff 대형 문서 가드(#36)', () => {
         // 예외 없이 removed/added 가 생성되면 통과(폭발 시 행/크래시 발생).
         expect(chunks.some((c) => c.type === 'removed')).toBe(true);
         expect(chunks.some((c) => c.type === 'added')).toBe(true);
+    });
+
+    it('대형 문서 폴백을 applyDiff 하면 원본/수정본이 정확히 복원(separator 가짜 빈 줄 없음, #36 P2-1)', () => {
+        const common = Array.from({ length: 1500 }, (_, i) => `c${i}`);
+        const orig = [...common, 'tail-o'].join('\n\n'); // 1501 문단
+        const mod = [...common, 'tail-m'].join('\n\n'); // 1501² > 200만 → 폴백
+        const chunks = generateDiff(orig, mod);
+        // accept-all → 수정본 정확 복원 (선두 가짜 빈 줄 없음)
+        expect(applyDiff(chunks.map((c) => ({ ...c, accepted: true })))).toBe(mod);
+        // reject-all → 원본 정확 복원 (후미 가짜 빈 줄 없음)
+        expect(applyDiff(chunks.map((c) => ({ ...c, accepted: false })))).toBe(orig);
     });
 });

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -80,9 +80,21 @@ function getLanguageName(lang: string): string {
 
 // ─── Diff Generation ──────────────────────────────────────
 
+/** computeLCS 의 O(m·n) DP 가 메인 스레드를 막지 않도록 하는 셀 수 상한(#36).
+    문단/토큰 곱이 이 값을 넘으면 정밀 LCS 대신 통짜 교체로 폴백한다.
+    (m+1)(n+1) number 행렬 ≈ 16MB·수백만 연산 수준 — 일반 문서는 한참 아래. */
+const LCS_CELL_LIMIT = 2_000_000;
+
 export function generateDiff(original: string, modified: string): DiffChunk[] {
     const origParas = splitIntoParagraphs(original);
     const modParas = splitIntoParagraphs(modified);
+
+    // 대형 문서 가드(#36): paragraph-level LCS 가 폭발할 규모면 정밀 diff 를 건너뛰고
+    // "전체 교체" 미리보기로 폴백 — propose_edit 리스너가 메인 스레드에서 동기 호출하므로
+    // 여기서 막지 않으면 수천 문단 문서에서 UI 가 프리즈된다.
+    if (origParas.length * modParas.length > LCS_CELL_LIMIT) {
+        return wholeReplacementChunks(original, modified);
+    }
 
     // Build paragraph-level operations
     type ParaOp = { type: 'unchanged'; text: string }
@@ -176,6 +188,21 @@ export function generateDiff(original: string, modified: string): DiffChunk[] {
     return chunks;
 }
 
+/** 대형 문서 폴백(#36): 정밀 diff 없이 원본 전체→수정본 전체 교체로 표현.
+    라인 단위 chunk 라 computeLCS 의 O(m·n) 비용이 없다(split 은 O(n)). */
+function wholeReplacementChunks(original: string, modified: string): DiffChunk[] {
+    const chunks: DiffChunk[] = [];
+    let id = 0;
+    for (const line of original.split('\n')) {
+        chunks.push({ id: id++, type: 'removed', content: line });
+    }
+    chunks.push({ id: id++, type: 'unchanged', content: '' });
+    for (const line of modified.split('\n')) {
+        chunks.push({ id: id++, type: 'added', content: line });
+    }
+    return chunks;
+}
+
 /** 단어/공백/구두점 토큰화 (한글·영문·숫자는 묶고 구두점은 1글자씩 →
     따옴표 하나 변경도 그 토큰만 잡힘). */
 function tokenize(s: string): string[] {
@@ -186,6 +213,14 @@ function tokenize(s: string): string[] {
 function wordDiff(orig: string, mod: string): { origParts: DiffSeg[]; modParts: DiffSeg[] } {
     const a = tokenize(orig);
     const b = tokenize(mod);
+    // 거대 문단 쌍 가드(#36): 토큰 LCS 가 폭발할 규모면(예: 줄바꿈 없는 초대형 단락)
+    // 단어 단위 강조를 포기하고 문단 전체를 통짜 removed/added 세그먼트로 둔다.
+    if (a.length * b.length > LCS_CELL_LIMIT) {
+        return {
+            origParts: [{ text: orig, type: 'removed' }],
+            modParts: [{ text: mod, type: 'added' }],
+        };
+    }
     const lcs = computeLCS(a, b);
     return {
         origParts: buildSegs(a, lcs, 'removed'),

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -196,7 +196,10 @@ function wholeReplacementChunks(original: string, modified: string): DiffChunk[]
     for (const line of original.split('\n')) {
         chunks.push({ id: id++, type: 'removed', content: line });
     }
-    chunks.push({ id: id++, type: 'unchanged', content: '' });
+    // separator(빈 unchanged)는 넣지 않는다 — applyDiff 가 unchanged 를 accepted 무관
+    // 무조건 출력에 포함하므로, separator 가 있으면 accept-all 시 선두 빈 줄 /
+    // reject-all 시 후미 빈 줄이 라운드트립에 주입된다(#36 P2-1). removed→added 는
+    // type 색으로 구분되고, separator 가 없어야 countMcpChanges 도 1곳으로 정확하다.
     for (const line of modified.split('\n')) {
         chunks.push({ id: id++, type: 'added', content: line });
     }


### PR DESCRIPTION
## 문제
`generateDiff` 의 paragraph/word LCS(O(m·n) DP)가 메인 스레드에서 돌아 수천 문단(또는 거대 단일 문단) 문서의 `propose_edit` 시 UI 가 프리즈.

## 해법
`LCS_CELL_LIMIT`(200만 셀) 초과 시 정밀 diff 대신 "전체 교체" 폴백:
- `generateDiff`: 문단 수 곱 초과 → 라인 단위 전체 교체(O(n))
- `wordDiff`: 토큰 수 곱 초과 → 통짜 removed/added 세그먼트

일반 크기 문서는 기존 정밀 word-level diff 그대로 유지. Web Worker 오프로드 대비 단순하면서 프리즈를 근본 차단.

## 검증
`tsc` + vitest 회귀 테스트 3개(정밀 diff 보존 / 폴백 발동 / 초대형 단일 문단) 통과. 런타임 실측은 dev 권장.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)