### PR TITLE
feat(ai): 사용자 메모리(#15-1) — 내 정보를 system prompt 에 주입

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod mcp;
 mod print_pdf;
 mod secrets;
 mod share;
+mod user_memory;
 mod vault;
 
 use std::sync::Arc;
@@ -316,6 +317,9 @@ pub fn run() {
             // Vault (옵시디언형 문서 그래프 — 폴더 스캔 + create-on-click)
             vault::scan_vault,
             vault::create_file_at,
+            // 사용자 메모리(#15) — AI system prompt 주입용 "내 정보"
+            user_memory::read_user_memory,
+            user_memory::write_user_memory,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/user_memory.rs
+++ b/src-tauri/src/user_memory.rs
@@ -1,0 +1,34 @@
+//! 사용자 메모리(#15) — "내 정보" plaintext 를 appDataDir/memory.md 에 보관.
+//!
+//! 사용자가 Settings 에서 적는 자기 정보(예: "한국어 사용자, B2B SaaS, 존댓말 선호")를
+//! AI 호출 시 system prompt 에 주입해 톤·용어·배경을 반영한다. 평문 파일이라 사용자가
+//! 외부 에디터로 직접 열어 편집할 수도 있다.
+
+use tauri::Manager;
+
+/// appDataDir/memory.md 경로. (macOS: ~/Library/Application Support/<bundle>/memory.md)
+fn memory_path(app: &tauri::AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(dir.join("memory.md"))
+}
+
+/// memory.md 읽기. 파일이 없으면(첫 실행) 빈 문자열을 돌려준다.
+#[tauri::command]
+pub fn read_user_memory(app: tauri::AppHandle) -> Result<String, String> {
+    let path = memory_path(&app)?;
+    match std::fs::read_to_string(&path) {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// memory.md 쓰기. appDataDir 가 없으면 생성한다.
+#[tauri::command]
+pub fn write_user_memory(app: tauri::AppHandle, content: String) -> Result<(), String> {
+    let path = memory_path(&app)?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&path, content).map_err(|e| e.to_string())
+}

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -17,6 +17,7 @@ import * as secretsBatch from '../../services/secretsService';
 import { confirmAction } from '../../services/dialogService';
 import { isTauri } from '../../services/platform';
 import { LanShareSection } from './LanShareSection';
+import { loadUserMemory, saveUserMemory, USER_MEMORY_MAX_CHARS } from '../../services/userMemory';
 import {
     ValidationResult,
     validateProvider,
@@ -125,6 +126,11 @@ export function SettingsView({ onDone }: SettingsViewProps) {
     const [driveBusy, setDriveBusy] = useState(false);
     const [driveError, setDriveError] = useState<string | null>(null);
 
+    // 사용자 메모리(#15) — AI system prompt 주입용 "내 정보"
+    const [userMemory, setUserMemory] = useState('');
+    const [memoryOrig, setMemoryOrig] = useState('');
+    const [memorySaving, setMemorySaving] = useState(false);
+
     useEffect(() => {
         setValues({
             gemini: getKey('gemini') || '',
@@ -154,8 +160,26 @@ export function SettingsView({ onDone }: SettingsViewProps) {
             const dp = (await secretsBatch.getDiarPython()) || '';
             setDiarPython(dp);
             setDiarPythonOrig(dp);
+            const mem = await loadUserMemory();
+            setUserMemory(mem);
+            setMemoryOrig(mem);
         })();
     }, []);
+
+    // 사용자 메모리(#15) 저장 — API 키 저장과 독립.
+    const handleSaveMemory = async () => {
+        setMemorySaving(true);
+        try {
+            await saveUserMemory(userMemory);
+            setMemoryOrig(userMemory);
+        } catch (e) {
+            await confirmAction(
+                `내 정보 저장에 실패했습니다: ${e instanceof Error ? e.message : String(e)}`,
+            );
+        } finally {
+            setMemorySaving(false);
+        }
+    };
 
     // ─── 입력 빠른 초기화 (휴지통) ───
     const handleClearKeyInput = async (provider: Provider) => {
@@ -397,6 +421,33 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     </section>
                 );
             })}
+
+            {/* === 내 정보 (AI 컨텍스트, #15) === */}
+            <section className="convert-settings-section">
+                <label>
+                    내 정보 (AI 컨텍스트){' '}
+                    {memoryOrig && <span className="badge badge-ok">설정됨</span>}
+                </label>
+                <textarea
+                    className="convert-memory-input"
+                    placeholder="예: 한국어 사용자, B2B SaaS 분야, 존댓말 선호. 자주 쓰는 용어·약어 등"
+                    value={userMemory}
+                    rows={4}
+                    maxLength={USER_MEMORY_MAX_CHARS}
+                    onChange={(e) => setUserMemory(e.target.value)}
+                />
+                <p className="convert-key-note">
+                    AI(문법·번역·개선·구조화) 호출 시 참고 정보로 전달됩니다. {userMemory.length}/
+                    {USER_MEMORY_MAX_CHARS}자
+                </p>
+                <button
+                    className="primary"
+                    onClick={handleSaveMemory}
+                    disabled={memorySaving || userMemory === memoryOrig}
+                >
+                    {memorySaving ? '저장 중…' : '내 정보 저장'}
+                </button>
+            </section>
 
             {/* === 로컬 화자분리 (pyannote, 무료/오프라인) === */}
             <section className="convert-settings-section">

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -441,7 +441,7 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     {USER_MEMORY_MAX_CHARS}자
                 </p>
                 <button
-                    className="primary"
+                    className="convert-btn primary"
                     onClick={handleSaveMemory}
                     disabled={memorySaving || userMemory === memoryOrig}
                 >

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -553,6 +553,25 @@
     font: inherit;
     font-size: 13px;
 }
+/* 내 정보(#15) textarea — convert-key-row input 과 동일 톤 + textarea 특성 */
+.convert-memory-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 72px;
+}
+.convert-memory-input:focus {
+    outline: none;
+    border-color: var(--text-secondary);
+}
 .convert-key-row button {
     padding: 0 10px;
     background: var(--bg-secondary);

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -572,6 +572,11 @@
     outline: none;
     border-color: var(--text-secondary);
 }
+/* 내 정보 저장 버튼(.convert-btn.primary)이 flex-column 섹션에서 full-width 로
+   늘어나지 않게 — align-items:stretch 기본 무시(#15 P2-3) */
+.convert-settings-section > button.primary {
+    align-self: flex-start;
+}
 .convert-key-row button {
     padding: 0 10px;
     background: var(--bg-secondary);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { initSecureStorage } from "./services/secureStorage";
+import { loadUserMemory } from "./services/userMemory";
 
 // Keychain init + legacy localStorage 마이그레이션. 실패해도 앱 시작 진행.
 initSecureStorage().finally(() => {
+    // #15 사용자 메모리 캐시 preload — render 를 막지 않게 fire-and-forget(실패해도 빈 값).
+    void loadUserMemory();
     ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         <React.StrictMode>
             <App />

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from '@google/genai';
 import { AIRequest, AIResponse, DiffChunk, DiffSeg, getModelForMode } from '../types/ai';
 import { getKey, hasKey, setKey, removeKey } from './secureStorage';
+import { getCachedUserMemory } from './userMemory';
 
 // ─── API Key Management ───────────────────────────────────
 // 저장소: Tauri 환경 → macOS Keychain (Rust keyring), 웹 → localStorage.
@@ -25,6 +26,21 @@ export function hasApiKey(): boolean {
 // ─── System Prompts ───────────────────────────────────────
 
 function getSystemPrompt(request: AIRequest): string {
+    return getBaseSystemPrompt(request) + buildUserMemoryBlock();
+}
+
+/** 사용자 메모리(#15)를 system prompt 끝에 "참고 컨텍스트" 로 덧붙인다.
+    출력 형식 규칙(수정 텍스트만 출력 등)은 각 모드 prompt 가 이미 강제하므로,
+    여기선 톤·어조·용어·배경 이해에 쓸 정보만 제공한다. */
+function buildUserMemoryBlock(): string {
+    const memory = getCachedUserMemory().trim();
+    if (!memory) return '';
+    return `\n\n## 사용자 컨텍스트 (참고용)
+다음은 사용자가 제공한 정보입니다. 톤·어조·용어·배경 이해에 반영하되, 위의 출력 형식 규칙은 그대로 지키세요.
+${memory}`;
+}
+
+function getBaseSystemPrompt(request: AIRequest): string {
     const base = `You are an expert document editor. You work with Markdown documents.
 CRITICAL RULES:
 - Return ONLY the modified text. No explanations, no code blocks, no prefixes.

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -26,13 +26,15 @@ export function hasApiKey(): boolean {
 // ─── System Prompts ───────────────────────────────────────
 
 function getSystemPrompt(request: AIRequest): string {
-    return getBaseSystemPrompt(request) + buildUserMemoryBlock();
+    return getBaseSystemPrompt(request) + buildUserMemoryBlock(request.mode);
 }
 
 /** 사용자 메모리(#15)를 system prompt 끝에 "참고 컨텍스트" 로 덧붙인다.
-    출력 형식 규칙(수정 텍스트만 출력 등)은 각 모드 prompt 가 이미 강제하므로,
-    여기선 톤·어조·용어·배경 이해에 쓸 정보만 제공한다. */
-function buildUserMemoryBlock(): string {
+    grammar/translate 는 '최소 변경 / 원문 톤 유지' 모드라, 메모리(톤·배경 지시)를
+    주입하면 과편집·톤 변형을 유발할 수 있어 제외한다(#15 P3-1). improve/structurize
+    등만 주입하며, 출력 형식 규칙은 각 모드 prompt 가 이미 강제한다. */
+function buildUserMemoryBlock(mode: AIRequest['mode']): string {
+    if (mode === 'grammar' || mode === 'translate') return '';
     const memory = getCachedUserMemory().trim();
     if (!memory) return '';
     return `\n\n## 사용자 컨텍스트 (참고용)

--- a/src/services/userMemory.ts
+++ b/src/services/userMemory.ts
@@ -33,7 +33,9 @@ export async function loadUserMemory(): Promise<string> {
 
 /** Settings 에서 저장. 상한으로 자른 뒤 디스크에 쓰고 캐시도 즉시 갱신. */
 export async function saveUserMemory(content: string): Promise<void> {
-    const trimmed = content.slice(0, USER_MEMORY_MAX_CHARS);
+    // code-point 단위 절단 — slice(code unit)는 이모지 등 서로게이트 쌍 중간을 잘라
+    // lone surrogate 를 남기고, invoke 직렬화(serde_json)가 이를 거부한다(#15 P3-7).
+    const trimmed = Array.from(content).slice(0, USER_MEMORY_MAX_CHARS).join('');
     if (isTauri) {
         await invoke('write_user_memory', { content: trimmed });
     }

--- a/src/services/userMemory.ts
+++ b/src/services/userMemory.ts
@@ -1,0 +1,41 @@
+/**
+ * 사용자 메모리(#15) — "내 정보" 를 appDataDir/memory.md 에 보관(Rust command 경유).
+ *
+ * AI 호출 시 getSystemPrompt 가 캐시된 값을 system prompt 에 주입한다. getSystemPrompt 는
+ * 동기 함수라 매번 파일을 읽을 수 없으므로 모듈 캐시를 두고, 앱 시작 시 loadUserMemory()
+ * 로 채운다. Settings 저장 시 캐시도 즉시 갱신해 다음 호출에 바로 반영된다.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+const isTauri =
+    typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+/** system prompt 주입 + UI 입력 폭주를 막는 상한(토큰 비용 보호). */
+export const USER_MEMORY_MAX_CHARS = 4000;
+
+let cached = '';
+
+/** getSystemPrompt 등 동기 경로에서 쓰는 캐시 접근자. */
+export function getCachedUserMemory(): string {
+    return cached;
+}
+
+/** 앱 시작 시(또는 Settings 진입 시) memory.md 를 읽어 캐시를 채운다. 실패해도 빈 값. */
+export async function loadUserMemory(): Promise<string> {
+    if (!isTauri) return cached; // web 빌드: 기능 비활성(빈 메모리)
+    try {
+        cached = (await invoke<string>('read_user_memory')) ?? '';
+    } catch {
+        cached = '';
+    }
+    return cached;
+}
+
+/** Settings 에서 저장. 상한으로 자른 뒤 디스크에 쓰고 캐시도 즉시 갱신. */
+export async function saveUserMemory(content: string): Promise<void> {
+    const trimmed = content.slice(0, USER_MEMORY_MAX_CHARS);
+    if (isTauri) {
+        await invoke('write_user_memory', { content: trimmed });
+    }
+    cached = trimmed;
+}


### PR DESCRIPTION
## 요약
Settings '내 정보'(예: 한국어 사용자, B2B SaaS, 존댓말 선호)를 `appDataDir/memory.md` 에 저장하고, 모든 AI 모드의 system prompt 에 '사용자 컨텍스트'로 주입.

## 구현
- **Rust**: `read_user_memory`/`write_user_memory` command (`appDataDir/memory.md`, `create_dir_all` 로 첫 실행 대응) — fs mkdir 권한 회피 위해 frontend plugin-fs 대신 Rust 경유(secrets/vault 패턴 일관).
- `src/services/userMemory.ts`: 모듈 캐시 + load/save(`getSystemPrompt` 동기 접근용), web 빌드는 graceful 빈 메모리.
- `aiService.getSystemPrompt`: `getBaseSystemPrompt` + `buildUserMemoryBlock` 분리.
- `main.tsx` preload, SettingsView '내 정보' 섹션 + CSS.

## 적대적 제로베이스 리뷰(2026-06-15) 후속 수정 포함
- **P2-3**: '내 정보 저장' 버튼 무스타일 → `convert-btn primary` + `align-self:flex-start`(이전엔 매칭 CSS 없어 OS 기본 버튼 + full-width).
- **P3-7**: 이모지/서로게이트 쌍 중간 절단 → `Array.from().slice().join('')`(code-point safe, invoke 직렬화 거부 방지).
- **P3-1**: grammar/translate('최소 변경/원문 톤 유지') 모드는 메모리 주입 제외 — 과편집·톤 변형 방지. improve/structurize 등만 주입.

## 검증
cargo check + tsc 통과. 저장→주입 런타임 확인은 dev 권장.

## 범위 / 후속
#15 의 1순위(사용자 메모리)만 구현. 폴더 참조/대화이력/인용은 후속.
남은 P3(리뷰 발견, 후속): 멀티윈도우 캐시 stale, preload race, web 미영속 표시, Rust 측 크기 상한, `isTauri` canonical 통일.

Refs #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)