### PR TITLE
feat(gantt): 간트 차트 뷰 모드 추가 — 인라인 마커 + 자체 SVG (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2513,7 +2513,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "0.4.4"
+version = "0.5.0"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
 import { VaultGraphView } from './components/VaultGraphView';
 import { FlowchartView } from './components/FlowchartView';
+import { GanttView } from './components/GanttView';
 import { Toolbar, ViewMode } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
 import { OutlinePanel } from './components/OutlinePanel';
@@ -1251,6 +1252,11 @@ function App() {
             setViewMode('flowchart');
             setReadingMode(false);
             break;
+          case '7':
+            e.preventDefault();
+            setViewMode('gantt');
+            setReadingMode(false);
+            break;
           case '=':
           case '+':
             e.preventDefault();
@@ -1559,6 +1565,11 @@ function App() {
             <div className="pane" style={{ width: '100%' }}>
               {mcpBanner}
               <FlowchartView content={content} fileName={fileName} onChange={updateContent} />
+            </div>
+          ) : viewMode === 'gantt' ? (
+            <div className="pane" style={{ width: '100%' }}>
+              {mcpBanner}
+              <GanttView content={content} fileName={fileName} onJumpToSource={handleJumpToSource} />
             </div>
           ) : (
           <>

--- a/src/components/GanttView.css
+++ b/src/components/GanttView.css
@@ -1,0 +1,124 @@
+/* #54 간트 차트 뷰 — 자체 SVG. MindmapCanvas/FlowchartView 와 같은 CSS 변수 패턴. */
+.gantt-view {
+    flex: 1;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-primary, #ffffff);
+}
+
+.gantt-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+}
+
+.gantt-svg {
+    display: block;
+    background: var(--bg-primary, #ffffff);
+}
+
+/* 시간축 */
+.gantt-axis {
+    stroke: var(--border-primary, #d4d4d4);
+    stroke-width: 1;
+}
+.gantt-grid {
+    stroke: var(--border-primary, #ececec);
+    stroke-width: 1;
+    opacity: 0.4;
+}
+.gantt-grid--major {
+    opacity: 0.85;
+}
+.gantt-tick {
+    fill: var(--text-secondary, #888888);
+    font-size: 11px;
+}
+
+/* 섹션 헤더 */
+.gantt-section {
+    fill: var(--text-primary, #222222);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+/* 행 */
+.gantt-row-bg {
+    fill: transparent;
+}
+.gantt-row:hover .gantt-row-bg {
+    fill: var(--bg-hover, rgba(0, 0, 0, 0.04));
+}
+.gantt-task-label {
+    fill: var(--text-primary, #333333);
+    font-size: 12px;
+}
+
+/* 막대 + 진행률 */
+.gantt-bar {
+    fill-opacity: 0.28;
+}
+.gantt-bar-progress {
+    fill-opacity: 0.9;
+}
+.gantt-row:hover .gantt-bar {
+    fill-opacity: 0.4;
+}
+.gantt-bar-pct {
+    fill: var(--text-secondary, #888888);
+    font-size: 10px;
+}
+
+/* 마일스톤 다이아몬드 */
+.gantt-milestone {
+    stroke: var(--bg-primary, #ffffff);
+    stroke-width: 1.5;
+}
+
+/* 오늘 세로선 */
+.gantt-today {
+    stroke: #ef4444;
+    stroke-width: 1.5;
+    stroke-dasharray: 4 3;
+}
+.gantt-today-label {
+    fill: #ef4444;
+    font-size: 10px;
+    font-weight: 600;
+}
+
+/* 빈 상태 */
+.gantt-empty {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 40px;
+    text-align: center;
+    color: var(--text-secondary, #888888);
+}
+.gantt-empty-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary, #444444);
+}
+.gantt-empty-hint {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.7;
+    max-width: 460px;
+}
+.gantt-empty-hint code {
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: var(--bg-secondary, #f0f0f0);
+    color: var(--text-primary, #444444);
+    font-size: 12px;
+}

--- a/src/components/GanttView.tsx
+++ b/src/components/GanttView.tsx
@@ -1,0 +1,275 @@
+/**
+ * Gantt view mode (#54) — read-only, self-rendered SVG.
+ *
+ * Markdown is the SSOT: parseGantt() pulls deterministic inline markers
+ * (@start/@due/@progress) off the document tree. We render a classic gantt —
+ * a left label column (sections + task names) and a right time axis with bars,
+ * progress fill, milestone diamonds, and a "today" line. Clicking a bar jumps to
+ * its source line in the editor. No external gantt library (the other views are
+ * all self-built too); editing happens in the markdown, drag-edit is a follow-up.
+ */
+
+import { useMemo } from 'react';
+import { ChartBarStacked } from 'lucide-react';
+import { parseGantt } from '../lib/gantt-parser';
+import type { GanttTask } from '../types/gantt';
+import './GanttView.css';
+
+// ── layout constants ─────────────────────────────────────────────────────────
+const LABEL_W = 220;   // left label column width
+const HEADER_H = 40;   // time-axis header height
+const ROW_H = 32;      // task row height
+const SECTION_H = 30;  // section header row height
+const DAY_W = 30;      // px per day
+const BAR_PAD = 6;     // vertical padding inside a row for the bar
+
+const MS_PER_DAY = 86_400_000;
+
+function midnight(d: Date): Date {
+    const c = new Date(d);
+    c.setHours(0, 0, 0, 0);
+    return c;
+}
+function diffDays(a: Date, b: Date): number {
+    return Math.round((midnight(b).getTime() - midnight(a).getTime()) / MS_PER_DAY);
+}
+function addDays(base: Date, n: number): Date {
+    return new Date(base.getFullYear(), base.getMonth(), base.getDate() + n);
+}
+
+type Row =
+    | { kind: 'section'; label: string; y: number }
+    | { kind: 'task'; task: GanttTask; y: number };
+
+interface GanttViewProps {
+    content: string;
+    fileName: string;
+    onJumpToSource: (line: number) => void;
+}
+
+export function GanttView({ content, fileName, onJumpToSource }: GanttViewProps) {
+    const data = useMemo(() => parseGantt(content, fileName), [content, fileName]);
+
+    const model = useMemo(() => {
+        const { tasks, rangeStart, rangeEnd } = data;
+        if (!rangeStart || !rangeEnd || tasks.length === 0) return null;
+
+        // Pad the range by a day on each side so edge bars aren't flush to the frame.
+        const start = addDays(rangeStart, -1);
+        const end = addDays(rangeEnd, 1);
+        const totalDays = diffDays(start, end) + 1;
+
+        // Build rows: a section header (skipped for top-level '') then its tasks.
+        const rows: Row[] = [];
+        let y = 0;
+        let prevSection: string | null = null;
+        for (const task of tasks) {
+            if (task.section !== prevSection) {
+                prevSection = task.section;
+                if (task.section) {
+                    rows.push({ kind: 'section', label: task.section, y });
+                    y += SECTION_H;
+                }
+            }
+            rows.push({ kind: 'task', task, y });
+            y += ROW_H;
+        }
+
+        const chartW = LABEL_W + totalDays * DAY_W;
+        const chartH = HEADER_H + y;
+        const today = midnight(new Date());
+        const todayInRange = today.getTime() >= start.getTime() && today.getTime() <= end.getTime();
+        const todayX = todayInRange ? LABEL_W + diffDays(start, today) * DAY_W : null;
+
+        return { start, totalDays, rows, chartW, chartH, todayX, bodyH: y };
+    }, [data]);
+
+    if (!model) {
+        return (
+            <div className="gantt-view">
+                <div className="gantt-empty">
+                    <ChartBarStacked size={48} strokeWidth={1.25} />
+                    <p className="gantt-empty-title">표시할 일정이 없습니다</p>
+                    <p className="gantt-empty-hint">
+                        리스트나 헤딩에 <code>@start(2026-01-05)</code> 마커를 추가하면 간트 막대로 나타납니다.
+                        <br />
+                        <code>@due(…)</code> 로 종료일, <code>@progress(0~100)</code> 으로 진행률을 지정할 수 있고,
+                        종료일이 없으면 마일스톤으로 표시됩니다.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    const { start, totalDays, rows, chartW, chartH, todayX, bodyH } = model;
+
+    // Time-axis tick labels: daily for short ranges, weekly, then monthly.
+    const showTick = (date: Date): boolean => {
+        if (totalDays <= 21) return true;
+        if (totalDays <= 70) return date.getDay() === 1; // Mondays
+        return date.getDate() === 1;                     // first of month
+    };
+    const tickLabel = (date: Date): string =>
+        totalDays > 70 ? `${date.getMonth() + 1}월` : `${date.getMonth() + 1}/${date.getDate()}`;
+
+    return (
+        <div className="gantt-view">
+            <div className="gantt-scroll">
+                <svg
+                    className="gantt-svg"
+                    width={chartW}
+                    height={chartH}
+                    role="img"
+                    aria-label="간트 차트"
+                >
+                    {/* day grid + tick labels */}
+                    {Array.from({ length: totalDays }, (_, d) => {
+                        const date = addDays(start, d);
+                        const x = LABEL_W + d * DAY_W;
+                        const tick = showTick(date);
+                        return (
+                            <g key={d}>
+                                <line
+                                    className={tick ? 'gantt-grid gantt-grid--major' : 'gantt-grid'}
+                                    x1={x}
+                                    y1={HEADER_H}
+                                    x2={x}
+                                    y2={chartH}
+                                />
+                                {tick && (
+                                    <text className="gantt-tick" x={x + 3} y={HEADER_H - 12}>
+                                        {tickLabel(date)}
+                                    </text>
+                                )}
+                            </g>
+                        );
+                    })}
+
+                    {/* header separator + label-column divider */}
+                    <line className="gantt-axis" x1={0} y1={HEADER_H} x2={chartW} y2={HEADER_H} />
+                    <line className="gantt-axis" x1={LABEL_W} y1={0} x2={LABEL_W} y2={chartH} />
+
+                    {/* rows */}
+                    {rows.map((row, i) => {
+                        const ry = HEADER_H + row.y;
+                        if (row.kind === 'section') {
+                            return (
+                                <text key={i} className="gantt-section" x={10} y={ry + SECTION_H / 2 + 4}>
+                                    {row.label}
+                                </text>
+                            );
+                        }
+                        const t = row.task;
+                        const bx = LABEL_W + diffDays(start, t.start) * DAY_W;
+                        const cy = ry + ROW_H / 2;
+                        const labelText =
+                            t.label.length > 26 ? `${t.label.slice(0, 25)}…` : t.label;
+
+                        return (
+                            <g
+                                key={i}
+                                className="gantt-row"
+                                onClick={() => t.mdLine && onJumpToSource(t.mdLine)}
+                                style={{ cursor: t.mdLine ? 'pointer' : 'default' }}
+                            >
+                                <title>
+                                    {`${t.label}\n${ymd(t.start)}${t.isMilestone ? ' (마일스톤)' : ` → ${ymd(t.end)}`}` +
+                                        `${t.isMilestone ? '' : `\n진행률 ${t.progress}%`}`}
+                                </title>
+                                {/* row hover background spanning the chart */}
+                                <rect
+                                    className="gantt-row-bg"
+                                    x={0}
+                                    y={ry}
+                                    width={chartW}
+                                    height={ROW_H}
+                                />
+                                <text className="gantt-task-label" x={20} y={cy + 4}>
+                                    {labelText}
+                                </text>
+
+                                {t.isMilestone ? (
+                                    // diamond centred on the start day
+                                    <path
+                                        className="gantt-milestone"
+                                        d={diamond(bx + DAY_W / 2, cy, 8)}
+                                        fill={t.color}
+                                    />
+                                ) : (
+                                    <>
+                                        {(() => {
+                                            const days = diffDays(t.start, t.end) + 1;
+                                            const bw = Math.max(DAY_W * days, 6);
+                                            const by = ry + BAR_PAD;
+                                            const bh = ROW_H - BAR_PAD * 2;
+                                            const fillW = Math.round((bw * t.progress) / 100);
+                                            return (
+                                                <>
+                                                    <rect
+                                                        className="gantt-bar"
+                                                        x={bx}
+                                                        y={by}
+                                                        width={bw}
+                                                        height={bh}
+                                                        rx={4}
+                                                        fill={t.color}
+                                                    />
+                                                    {fillW > 0 && (
+                                                        <rect
+                                                            className="gantt-bar-progress"
+                                                            x={bx}
+                                                            y={by}
+                                                            width={fillW}
+                                                            height={bh}
+                                                            rx={4}
+                                                            fill={t.color}
+                                                        />
+                                                    )}
+                                                    {t.progress > 0 && (
+                                                        <text
+                                                            className="gantt-bar-pct"
+                                                            x={bx + bw + 6}
+                                                            y={cy + 4}
+                                                        >
+                                                            {t.progress}%
+                                                        </text>
+                                                    )}
+                                                </>
+                                            );
+                                        })()}
+                                    </>
+                                )}
+                            </g>
+                        );
+                    })}
+
+                    {/* today line (drawn last so it sits on top) */}
+                    {todayX !== null && (
+                        <g>
+                            <line
+                                className="gantt-today"
+                                x1={todayX}
+                                y1={HEADER_H}
+                                x2={todayX}
+                                y2={HEADER_H + bodyH}
+                            />
+                            <text className="gantt-today-label" x={todayX + 4} y={HEADER_H + 12}>
+                                오늘
+                            </text>
+                        </g>
+                    )}
+                </svg>
+            </div>
+        </div>
+    );
+}
+
+/** A diamond path centred at (cx, cy) with the given half-size. */
+function diamond(cx: number, cy: number, r: number): string {
+    return `M ${cx} ${cy - r} L ${cx + r} ${cy} L ${cx} ${cy + r} L ${cx - r} ${cy} Z`;
+}
+
+function ymd(d: Date): string {
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}

--- a/src/components/MindmapCanvas.tsx
+++ b/src/components/MindmapCanvas.tsx
@@ -25,6 +25,7 @@ import {
 } from '@xyflow/react';
 import { Plus, Pencil, Trash2, FileSymlink, SquareArrowOutUpRight } from 'lucide-react';
 import type { MindmapNode } from '../types/mindmap';
+import { PALETTE } from '../lib/d3-layout';
 import '@xyflow/react/dist/style.css';
 import './MindmapCanvas.css';
 
@@ -54,8 +55,6 @@ export interface MindmapNodeData {
     onOpenLink?: () => void;
     [key: string]: unknown;
 }
-
-const PALETTE = ['#6366f1', '#0ea5e9', '#10b981', '#f59e0b', '#ef4444', '#ec4899', '#8b5cf6', '#14b8a6'];
 
 /** One-line plain-text preview of a node's description (full text on hover). */
 function descPreview(s: string): string {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,13 +6,13 @@ import {
     Search, ChevronRight, Sparkles, Check, X,
     Mic, ScanText, Settings,
     FileCode, FileText, AlignVerticalSpaceAround,
-    Network, Share2, Workflow,
+    Network, Share2, VectorSquare, ChartBarStacked,
 } from 'lucide-react';
 import * as gdriveService from '../services/gdriveService';
 import type { RecentFile } from '../hooks/useRecentFiles';
 import { BackgroundPicker } from './BackgroundPicker';
 
-export type ViewMode = 'split' | 'editor' | 'preview' | 'mindmap' | 'graph' | 'flowchart';
+export type ViewMode = 'split' | 'editor' | 'preview' | 'mindmap' | 'graph' | 'flowchart' | 'gantt';
 
 function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; isDirty: boolean; onRename: (name: string) => void }) {
     const [editing, setEditing] = useState(false);
@@ -341,14 +341,21 @@ export function Toolbar({
                     onClick={() => onViewModeChange('graph')}
                     title="Vault Graph (⌘5)"
                 >
-                    <Network size={16} strokeWidth={1.5} />
+                    <VectorSquare size={16} strokeWidth={1.5} />
                 </button>
                 <button
                     className={`toolbar-btn${viewMode === 'flowchart' ? ' active' : ''}`}
                     onClick={() => onViewModeChange('flowchart')}
                     title="Flowchart (⌘6)"
                 >
-                    <Workflow size={16} strokeWidth={1.5} />
+                    <Network size={16} strokeWidth={1.5} />
+                </button>
+                <button
+                    className={`toolbar-btn${viewMode === 'gantt' ? ' active' : ''}`}
+                    onClick={() => onViewModeChange('gantt')}
+                    title="Gantt (⌘7)"
+                >
+                    <ChartBarStacked size={16} strokeWidth={1.5} />
                 </button>
 
                 <div className="toolbar-divider" />

--- a/src/lib/d3-layout.ts
+++ b/src/lib/d3-layout.ts
@@ -28,6 +28,10 @@ const VERTICAL_GAP = 26;    // gap between sibling rows
 const CENTER_X = 0;
 const CENTER_Y = 0;
 
+/** Shared branch colour palette — used by the mindmap canvas and the gantt view
+ *  so derived visualizations stay visually consistent. Index with `i % length`. */
+export const PALETTE = ['#6366f1', '#0ea5e9', '#10b981', '#f59e0b', '#ef4444', '#ec4899', '#8b5cf6', '#14b8a6'];
+
 const SLOT_W = MAX_W + HORIZONTAL_GAP;
 const SLOT_H = MAX_H + VERTICAL_GAP;
 

--- a/src/lib/gantt-parser.test.ts
+++ b/src/lib/gantt-parser.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { parseGantt } from './gantt-parser';
+
+/** Helper: local-midnight date as YYYY-MM-DD (avoids UTC drift in assertions). */
+function ymd(d: Date): string {
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+describe('parseGantt', () => {
+    it('parses start/due/progress markers into a task', () => {
+        const md = `# Plan
+## 프로젝트 일정
+- [ ] 구현 @start(2026-01-21) @due(2026-02-10) @progress(40)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks).toHaveLength(1);
+        const t = tasks[0];
+        expect(t.label).toBe('구현');
+        expect(t.section).toBe('프로젝트 일정');
+        expect(ymd(t.start)).toBe('2026-01-21');
+        expect(ymd(t.end)).toBe('2026-02-10');
+        expect(t.isMilestone).toBe(false);
+        expect(t.progress).toBe(40);
+    });
+
+    it('treats a task with start but no due/end as a milestone', () => {
+        const md = `# Plan
+- [ ] 출시 마일스톤 @start(2026-02-11)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].isMilestone).toBe(true);
+        expect(ymd(tasks[0].start)).toBe('2026-02-11');
+        expect(ymd(tasks[0].end)).toBe('2026-02-11');
+    });
+
+    it('accepts @end as an alias for @due', () => {
+        const md = `# Plan
+- [ ] A @start(2026-01-01) @end(2026-01-05)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks[0].isMilestone).toBe(false);
+        expect(ymd(tasks[0].end)).toBe('2026-01-05');
+    });
+
+    it('prefers @progress over the checkbox state', () => {
+        const md = `# Plan
+- [x] done-but-70 @start(2026-01-01) @due(2026-01-02) @progress(70)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks[0].progress).toBe(70);
+    });
+
+    it('falls back to checkbox: [x]=100, [ ]=0', () => {
+        const md = `# Plan
+- [x] 설계 @start(2026-01-13) @due(2026-01-20)
+- [ ] 구현 @start(2026-01-21) @due(2026-02-10)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks.find((t) => t.label === '설계')?.progress).toBe(100);
+        expect(tasks.find((t) => t.label === '구현')?.progress).toBe(0);
+    });
+
+    it('clamps progress to 0..100', () => {
+        const md = `# Plan
+- [ ] A @start(2026-01-01) @due(2026-01-02) @progress(250)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks[0].progress).toBe(100);
+    });
+
+    it('returns no tasks when there are no markers', () => {
+        const md = `# Plan
+## Goals
+- ship v1
+- get users
+`;
+        const { tasks, rangeStart, rangeEnd } = parseGantt(md);
+        expect(tasks).toHaveLength(0);
+        expect(rangeStart).toBeNull();
+        expect(rangeEnd).toBeNull();
+    });
+
+    it('ignores a node with an invalid start date (not a task)', () => {
+        const md = `# Plan
+- [ ] bad @start(2026-13-40) @due(2026-02-10)
+- [ ] good @start(2026-01-01) @due(2026-01-05)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].label).toBe('good');
+    });
+
+    it('ignores an invalid due (treated as a milestone)', () => {
+        const md = `# Plan
+- [ ] A @start(2026-01-01) @due(2026-02-30)
+`;
+        const { tasks } = parseGantt(md);
+        expect(tasks[0].isMilestone).toBe(true);
+    });
+
+    it('clamps a due earlier than start up to the start day', () => {
+        const md = `# Plan
+- [ ] A @start(2026-01-10) @due(2026-01-05)
+`;
+        const { tasks } = parseGantt(md);
+        expect(ymd(tasks[0].end)).toBe('2026-01-10');
+    });
+
+    it('groups tasks by their parent heading and assigns one colour per section', () => {
+        const md = `# Plan
+## 분석
+- [ ] 요구사항 @start(2026-01-05) @due(2026-01-12)
+## 개발
+- [ ] 구현 @start(2026-01-21) @due(2026-02-10)
+- [ ] 테스트 @start(2026-02-11) @due(2026-02-15)
+`;
+        const { tasks } = parseGantt(md);
+        const bySection = (s: string) => tasks.filter((t) => t.section === s);
+        expect(bySection('분석')).toHaveLength(1);
+        expect(bySection('개발')).toHaveLength(2);
+        // tasks in the same section share a colour; different sections differ.
+        expect(bySection('개발')[0].color).toBe(bySection('개발')[1].color);
+        expect(bySection('분석')[0].color).not.toBe(bySection('개발')[0].color);
+    });
+
+    it('preserves mdLine in full-document coordinates (incl. frontmatter)', () => {
+        const md = `---
+title: x
+---
+# Plan
+- [ ] A @start(2026-01-01) @due(2026-01-02)
+`;
+        const { tasks } = parseGantt(md);
+        // frontmatter (3 lines) + "# Plan" (line 4) + task on line 5.
+        expect(tasks[0].mdLine).toBe(5);
+    });
+
+    it('computes the overall date range across all tasks', () => {
+        const md = `# Plan
+- [ ] A @start(2026-01-10) @due(2026-01-20)
+- [ ] B @start(2026-01-05) @due(2026-01-12)
+- [ ] C @start(2026-02-01)
+`;
+        const { rangeStart, rangeEnd } = parseGantt(md);
+        expect(ymd(rangeStart!)).toBe('2026-01-05');
+        expect(ymd(rangeEnd!)).toBe('2026-02-01');
+    });
+});

--- a/src/lib/gantt-parser.ts
+++ b/src/lib/gantt-parser.ts
@@ -1,0 +1,112 @@
+/**
+ * Gantt parser (#54) — deterministic, no LLM.
+ *
+ * Reuses documentToTree() so we get the section hierarchy and source lines
+ * (`mdLine`, full-document coordinates incl. frontmatter) for free. We then walk
+ * the tree and pull inline markers off each node's label:
+ *
+ *     @start(YYYY-MM-DD)   required — a node without a valid start is not a task
+ *     @due(YYYY-MM-DD)     end of the bar. @end(...) is an accepted alias.
+ *     @progress(0..100)    completion. Falls back to checkbox [x]=100 / [ ]=0, else 0.
+ *
+ * A task with a start but no due/end is a milestone (rendered as a diamond).
+ * The nearest ancestor (heading or list parent) label becomes the section/group,
+ * and each section gets a stable palette colour. Dates are parsed at LOCAL
+ * midnight (`new Date(y, m-1, d)`) to dodge the UTC off-by-one trap.
+ */
+
+import { documentToTree } from './markdownTree';
+import { PALETTE } from './d3-layout';
+import type { MindmapNode } from '../types/mindmap';
+import type { GanttTask, GanttData } from '../types/gantt';
+
+const START_RE = /@start\(\s*(\d{4})-(\d{1,2})-(\d{1,2})\s*\)/i;
+const DUE_RE = /@(?:due|end)\(\s*(\d{4})-(\d{1,2})-(\d{1,2})\s*\)/i;
+const PROGRESS_RE = /@progress\(\s*(\d{1,3})\s*\)/i;
+const CHECKBOX_RE = /^\[([ xX])\]\s*/;
+const MARKER_RE = /@\w+\([^)]*\)/g;
+
+/** Parse `YYYY-MM-DD` at local midnight. Returns null for impossible dates
+ *  (e.g. month 13, day 32) so bad markers are silently ignored. */
+function parseLocalDate(y: number, m: number, d: number): Date | null {
+    if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+    const date = new Date(y, m - 1, d);
+    // Reject overflow (e.g. Feb 30 → Mar 2): the round-trip must match.
+    if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) return null;
+    return date;
+}
+
+/** Strip all `@marker(...)` tokens and a leading checkbox from a label. */
+function cleanLabel(label: string): string {
+    return label.replace(CHECKBOX_RE, '').replace(MARKER_RE, '').replace(/\s+/g, ' ').trim();
+}
+
+/** Parse a full markdown document into gantt tasks. `fileName` (without extension)
+ *  is used only as the tree root label and never appears as a section. */
+export function parseGantt(fullMd: string, fileName?: string): GanttData {
+    const stem = (fileName ?? '').replace(/\.(md|markdown|mdx|txt)$/i, '').trim() || undefined;
+    const { tree } = documentToTree(fullMd, stem);
+
+    const tasks: GanttTask[] = [];
+    const sectionColor = new Map<string, string>();
+
+    const colorFor = (section: string): string => {
+        let c = sectionColor.get(section);
+        if (c === undefined) {
+            c = PALETTE[sectionColor.size % PALETTE.length];
+            sectionColor.set(section, c);
+        }
+        return c;
+    };
+
+    const visit = (node: MindmapNode, section: string): void => {
+        const startMatch = node.label.match(START_RE);
+        if (startMatch) {
+            const start = parseLocalDate(+startMatch[1], +startMatch[2], +startMatch[3]);
+            if (start) {
+                const dueMatch = node.label.match(DUE_RE);
+                const due = dueMatch ? parseLocalDate(+dueMatch[1], +dueMatch[2], +dueMatch[3]) : null;
+                const isMilestone = due === null;
+                // End is inclusive and never before start (guards bad due < start).
+                const end = isMilestone ? start : (due!.getTime() < start.getTime() ? start : due!);
+
+                let progress: number;
+                const progMatch = node.label.match(PROGRESS_RE);
+                if (progMatch) {
+                    progress = Math.min(100, Math.max(0, parseInt(progMatch[1], 10)));
+                } else {
+                    const box = node.label.match(CHECKBOX_RE);
+                    progress = box ? (box[1].toLowerCase() === 'x' ? 100 : 0) : 0;
+                }
+
+                tasks.push({
+                    id: node.id,
+                    label: cleanLabel(node.label),
+                    section,
+                    start,
+                    end,
+                    isMilestone,
+                    progress,
+                    mdLine: node.mdLine,
+                    color: colorFor(section),
+                });
+            }
+        }
+        // This node's clean label is the section for its children.
+        const childSection = cleanLabel(node.label) || section;
+        for (const child of node.children) visit(child, childSection);
+    };
+
+    // Root is the document title (H1) — its children's section is '' (top-level),
+    // not the title, so a bare task list isn't grouped under the file name.
+    for (const child of tree.children) visit(child, '');
+
+    let rangeStart: Date | null = null;
+    let rangeEnd: Date | null = null;
+    for (const t of tasks) {
+        if (rangeStart === null || t.start.getTime() < rangeStart.getTime()) rangeStart = t.start;
+        if (rangeEnd === null || t.end.getTime() > rangeEnd.getTime()) rangeEnd = t.end;
+    }
+
+    return { tasks, rangeStart, rangeEnd };
+}

--- a/src/types/gantt.ts
+++ b/src/types/gantt.ts
@@ -1,0 +1,43 @@
+/**
+ * Gantt data model (#54).
+ *
+ * Markdown stays the single source of truth: tasks are derived from deterministic
+ * inline markers on heading/list nodes —
+ *
+ *     - [ ] 구현 @start(2026-01-21) @due(2026-02-10) @progress(40)
+ *     - [ ] 출시 마일스톤 @start(2026-02-11)        ← no due/end ⇒ milestone
+ *
+ * The parser (see ../lib/gantt-parser.ts) reuses documentToTree() so each task
+ * carries its source line (`mdLine`) for jump-to-source and inherits its parent
+ * heading/list label as its section (group). Dates are parsed at local midnight
+ * to avoid the UTC off-by-one trap.
+ */
+
+export interface GanttTask {
+    /** Stable id (derived from the source tree node id). */
+    id: string;
+    /** Task label with the `@…(…)` markers stripped. */
+    label: string;
+    /** Group/section label (nearest ancestor heading or list parent). '' when top-level. */
+    section: string;
+    /** Inclusive start day at local midnight. */
+    start: Date;
+    /** Inclusive end day at local midnight. Equals `start` for milestones. */
+    end: Date;
+    /** A milestone has a start but no due/end marker (rendered as a diamond). */
+    isMilestone: boolean;
+    /** Completion 0–100. From `@progress(n)`, else checkbox ([x]=100 / [ ]=0), else 0. */
+    progress: number;
+    /** 1-based source line in the FULL document (for onJumpToSource). */
+    mdLine?: number;
+    /** Palette colour for this task's section (consistent per section). */
+    color: string;
+}
+
+export interface GanttData {
+    tasks: GanttTask[];
+    /** Earliest task start across all tasks (local midnight). null when empty. */
+    rangeStart: Date | null;
+    /** Latest task end across all tasks (local midnight). null when empty. */
+    rangeEnd: Date | null;
+}


### PR DESCRIPTION
## 요약
마크다운 SSOT를 유지하며 인라인 마커(`@start`/`@due`/`@progress`)를 결정론적으로 파싱해 자체 SVG 간트 차트로 그리는 `gantt` 뷰(⌘7)를 추가합니다. 외부 라이브러리 없이 기존 자산(`documentToTree`·`PALETTE`·`handleJumpToSource`)을 재사용했습니다. Closes #54.

## 변경
- **신규**: `src/types/gantt.ts`, `src/lib/gantt-parser.ts`(+테스트 13), `src/components/GanttView.tsx`/`.css`
- **수정**: `Toolbar.tsx`(⌘7 버튼), `App.tsx`(단축키·뷰 분기), `d3-layout.ts`(PALETTE export), `MindmapCanvas.tsx`(import 전환)
- **아이콘 정리**: 간트=ChartBarStacked, Vault=VectorSquare, Flowchart=Network
- **버전**: 0.4.4 → 0.5.0

## 검증
- `npm run build`(tsc strict) 통과
- 테스트 97개 전부 통과(간트 파서 13개 신규)
- 앱 실행 검증은 머지 후 로컬에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)