### PR TITLE
feat(ai): 구독 OAuth 연동 + 전역 AI 모델 설정 + 설정 UI 개편

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
@@ -35,6 +35,7 @@
         "dagre": "^0.8.5",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.576.0",
+        "pptxgenjs": "^4.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
@@ -3518,6 +3519,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -4222,6 +4229,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -4234,6 +4247,33 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4306,6 +4346,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4369,6 +4415,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4388,6 +4446,15 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/linkify-it": {
@@ -5523,6 +5590,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5644,6 +5717,39 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -5850,6 +5956,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -5907,6 +6022,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/rehype-highlight": {
       "version": "7.0.2",
@@ -6118,6 +6254,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6190,6 +6332,21 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -6591,6 +6748,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dagre": "^0.8.5",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.576.0",
+    "pptxgenjs": "^4.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -189,6 +189,26 @@ pub async fn ai_generate_claude(
     result.map(|r| r.text).map_err(err_to_string)
 }
 
+// ─── 범용 ChatGPT(Codex 구독) 텍스트 생성 (React AI 모드) ────────────────────
+//
+// 본인 Codex CLI 로그인 토큰을 재사용해 ChatGPT 구독으로 호출(비공개 Responses API).
+// 미검증 경로 — API 키 fallback 은 호출부(프론트)에서 모델 전환으로 처리한다.
+#[tauri::command]
+pub async fn ai_generate_codex(system: Option<String>, prompt: String) -> Result<String, String> {
+    use super::llm::openai_codex;
+    let tokens = crate::subscription_auth::read_codex_tokens()?;
+    openai_codex::generate_text(
+        &tokens.access_token,
+        tokens.account_id.as_deref(),
+        super::MODEL_CODEX,
+        system.as_deref(),
+        &prompt,
+    )
+    .await
+    .map(|r| r.text)
+    .map_err(err_to_string)
+}
+
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────
 
 #[cfg(test)]

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -108,10 +108,15 @@ pub async fn generate_slides_llm(
                 max_output_tokens: Some(SLIDES_MAX_TOKENS),
                 system: Some(SLIDES_SYSTEM.to_string()),
             };
-            llm::anthropic::generate_text(&key, super::MODEL_NOTES_CLAUDE, &prompt, Some(opts))
-                .await
-                .map_err(err_to_string)?
-                .text
+            llm::anthropic::generate_text(
+                llm::anthropic::ClaudeAuth::ApiKey(&key),
+                super::MODEL_NOTES_CLAUDE,
+                &prompt,
+                Some(opts),
+            )
+            .await
+            .map_err(err_to_string)?
+            .text
         }
         super::NotesProvider::Gemini => {
             let key = get_key(Provider::Gemini)
@@ -131,6 +136,57 @@ pub async fn generate_slides_llm(
     };
 
     Ok(text)
+}
+
+// ─── 범용 Claude 텍스트 생성 (문법/번역/문서개선/구조화 — React AI 모드) ─────
+//
+// system + prompt 는 프론트(aiService)가 모드별로 구성해 전달하고, 백엔드는 인증
+// (구독 OAuth or API 키) + 호출만 담당한다. 구독 토큰은 Rust(keychain/refresh)에만
+// 있으므로 Claude 경로는 반드시 이 command 를 거친다. 반환은 변환된 텍스트(diff 는 프론트).
+#[tauri::command]
+pub async fn ai_generate_claude(
+    system: Option<String>,
+    prompt: String,
+    claude_auth: crate::subscription_auth::ClaudeAuthMode,
+    max_tokens: Option<u32>,
+) -> Result<String, String> {
+    use super::keychain::{get_key, Provider};
+    use super::llm::anthropic::{self, ClaudeAuth, ClaudeOptions};
+    use crate::subscription_auth::ClaudeAuthMode;
+
+    let opts = ClaudeOptions {
+        max_output_tokens: Some(max_tokens.unwrap_or(16000)),
+        system,
+    };
+
+    let result = match claude_auth {
+        ClaudeAuthMode::Subscription => {
+            let token = crate::subscription_auth::claude_access_token().await?;
+            anthropic::generate_text(
+                ClaudeAuth::Subscription(&token),
+                super::MODEL_NOTES_CLAUDE,
+                &prompt,
+                Some(opts),
+            )
+            .await
+        }
+        ClaudeAuthMode::ApiKey => {
+            let key = get_key(Provider::Claude)
+                .map_err(err_to_string)?
+                .ok_or_else(|| {
+                    "Claude API 키가 없습니다. Settings 에서 등록하거나 구독 로그인을 사용하세요."
+                        .to_string()
+                })?;
+            anthropic::generate_text(
+                ClaudeAuth::ApiKey(&key),
+                super::MODEL_NOTES_CLAUDE,
+                &prompt,
+                Some(opts),
+            )
+            .await
+        }
+    };
+    result.map(|r| r.text).map_err(err_to_string)
 }
 
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -149,11 +149,13 @@ pub async fn ai_generate_claude(
     prompt: String,
     claude_auth: crate::subscription_auth::ClaudeAuthMode,
     max_tokens: Option<u32>,
+    model: Option<String>,
 ) -> Result<String, String> {
     use super::keychain::{get_key, Provider};
     use super::llm::anthropic::{self, ClaudeAuth, ClaudeOptions};
     use crate::subscription_auth::ClaudeAuthMode;
 
+    let model_id = model.as_deref().unwrap_or(super::MODEL_NOTES_CLAUDE);
     let opts = ClaudeOptions {
         max_output_tokens: Some(max_tokens.unwrap_or(16000)),
         system,
@@ -162,13 +164,8 @@ pub async fn ai_generate_claude(
     let result = match claude_auth {
         ClaudeAuthMode::Subscription => {
             let token = crate::subscription_auth::claude_access_token().await?;
-            anthropic::generate_text(
-                ClaudeAuth::Subscription(&token),
-                super::MODEL_NOTES_CLAUDE,
-                &prompt,
-                Some(opts),
-            )
-            .await
+            anthropic::generate_text(ClaudeAuth::Subscription(&token), model_id, &prompt, Some(opts))
+                .await
         }
         ClaudeAuthMode::ApiKey => {
             let key = get_key(Provider::Claude)
@@ -177,13 +174,7 @@ pub async fn ai_generate_claude(
                     "Claude API 키가 없습니다. Settings 에서 등록하거나 구독 로그인을 사용하세요."
                         .to_string()
                 })?;
-            anthropic::generate_text(
-                ClaudeAuth::ApiKey(&key),
-                super::MODEL_NOTES_CLAUDE,
-                &prompt,
-                Some(opts),
-            )
-            .await
+            anthropic::generate_text(ClaudeAuth::ApiKey(&key), model_id, &prompt, Some(opts)).await
         }
     };
     result.map(|r| r.text).map_err(err_to_string)
@@ -194,19 +185,44 @@ pub async fn ai_generate_claude(
 // 본인 Codex CLI 로그인 토큰을 재사용해 ChatGPT 구독으로 호출(비공개 Responses API).
 // 미검증 경로 — API 키 fallback 은 호출부(프론트)에서 모델 전환으로 처리한다.
 #[tauri::command]
-pub async fn ai_generate_codex(system: Option<String>, prompt: String) -> Result<String, String> {
+pub async fn ai_generate_codex(
+    system: Option<String>,
+    prompt: String,
+    model: Option<String>,
+) -> Result<String, String> {
     use super::llm::openai_codex;
     let tokens = crate::subscription_auth::read_codex_tokens()?;
+    let model_id = model.as_deref().unwrap_or(super::MODEL_CODEX);
     openai_codex::generate_text(
         &tokens.access_token,
         tokens.account_id.as_deref(),
-        super::MODEL_CODEX,
+        model_id,
         system.as_deref(),
         &prompt,
     )
     .await
     .map(|r| r.text)
     .map_err(err_to_string)
+}
+
+// ─── OpenAI API 키 텍스트 생성 (구독 codex 와 별개 경로) ─────────────────────
+//
+// 표준 chat completions(api.openai.com). React AI 모드가 OpenAI + API 키 선택 시 사용.
+#[tauri::command]
+pub async fn ai_generate_openai(
+    system: Option<String>,
+    prompt: String,
+    model: String,
+) -> Result<String, String> {
+    use super::keychain::{get_key, Provider};
+    use super::llm::openai_api;
+    let key = get_key(Provider::Openai)
+        .map_err(err_to_string)?
+        .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+    openai_api::generate_text(&key, &model, system.as_deref(), &prompt)
+        .await
+        .map(|r| r.text)
+        .map_err(err_to_string)
 }
 
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -72,6 +72,67 @@ pub fn get_conversions_dir() -> String {
     super::conversions_dir().to_string_lossy().into_owned()
 }
 
+// ─── PPTX 스마트 레이아웃 (이슈 #6) ─────────────────────────────
+//
+// 마크다운을 슬라이드용으로 "재구성"해 과밀 슬라이드를 막는다(규칙 기반의 약점
+// 보완). 기존 converters 의 키체인 + LLM 클라이언트를 그대로 재사용한다.
+// 반환은 프론트가 파싱하는 단순 슬라이드 JSON 문자열:
+//   { "slides": [ { "title", "layout":"title|content", "bullets":[...], "notes"? } ] }
+
+// 출력 토큰 상한 — 큰 덱(50장+)도 잘리지 않도록 넉넉히. 생성한 만큼만 과금.
+const SLIDES_MAX_TOKENS: u32 = 32000;
+
+const SLIDES_SYSTEM: &str = "You are a presentation designer. Convert the given Markdown document into a concise slide deck. Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[{\"title\":string,\"layout\":\"title\"|\"content\",\"bullets\":string[],\"notes\":string?}]}. Rules: the first slide is layout \"title\" (deck title + optional one-line subtitle as a single bullet); other slides are \"content\"; keep each bullet short (<= ~12 words); at most ~6 bullets per slide; split dense content across multiple slides to avoid overcrowding; omit the \"notes\" field unless it adds real speaker value (keeps output compact); preserve the document's language; do not invent facts.";
+
+#[tauri::command]
+pub async fn generate_slides_llm(
+    markdown: String,
+    provider: super::NotesProvider,
+) -> Result<String, String> {
+    use super::keychain::{get_key, Provider};
+    use super::llm;
+
+    let prompt = format!(
+        "Convert this Markdown document into slides as specified.\n\n<markdown>\n{}\n</markdown>",
+        markdown
+    );
+
+    let text = match provider {
+        super::NotesProvider::Claude => {
+            let key = get_key(Provider::Claude)
+                .map_err(err_to_string)?
+                .ok_or_else(|| "CLAUDE_API_KEY 가 없습니다. Settings 에서 등록하세요.".to_string())?;
+            // 큰 문서(20장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
+            // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
+            let opts = llm::anthropic::ClaudeOptions {
+                max_output_tokens: Some(SLIDES_MAX_TOKENS),
+                system: Some(SLIDES_SYSTEM.to_string()),
+            };
+            llm::anthropic::generate_text(&key, super::MODEL_NOTES_CLAUDE, &prompt, Some(opts))
+                .await
+                .map_err(err_to_string)?
+                .text
+        }
+        super::NotesProvider::Gemini => {
+            let key = get_key(Provider::Gemini)
+                .map_err(err_to_string)?
+                .ok_or_else(|| "GEMINI_API_KEY 가 없습니다. Settings 에서 등록하세요.".to_string())?;
+            // Gemini 는 system 파라미터를 따로 안 받으므로 프롬프트 앞에 지시문 결합.
+            let full = format!("{}\n\n{}", SLIDES_SYSTEM, prompt);
+            let cfg = llm::gemini::GenerationConfig {
+                max_output_tokens: Some(SLIDES_MAX_TOKENS),
+                temperature: Some(0.3),
+            };
+            llm::gemini::generate_text(&key, super::MODEL_NOTES_GEMINI, &full, Vec::new(), Some(cfg))
+                .await
+                .map_err(err_to_string)?
+                .text
+        }
+    };
+
+    Ok(text)
+}
+
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────
 
 #[cfg(test)]

--- a/src-tauri/src/converters/error.rs
+++ b/src-tauri/src/converters/error.rs
@@ -14,6 +14,9 @@ pub enum ConverterError {
     #[error("Claude API 오류: {0}")]
     Claude(String),
 
+    #[error("ChatGPT(Codex) API 오류: {0}")]
+    Codex(String),
+
     #[error("네트워크 연결이 불안정합니다. 잠시 후 다시 시도해주세요. ({0})")]
     Network(String),
 

--- a/src-tauri/src/converters/llm/anthropic.rs
+++ b/src-tauri/src/converters/llm/anthropic.rs
@@ -14,10 +14,22 @@ const API_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 16000;
 const MAX_RETRIES: u32 = 3;
 
+/// 구독(OAuth) 모드 헤더 — Claude Code 가 보내는 beta 플래그 쌍.
+const OAUTH_BETA: &str = "claude-code-20250219,oauth-2025-04-20";
+/// 구독(OAuth) 모드에서 non-Haiku 모델이 요구하는 system 블록 0 의 정확한 리터럴.
+/// 누락 시 HTTP 400 — 실제 지시는 블록 1 이후로 append 한다. (Haiku 는 면제이나 무해)
+const CLAUDE_CODE_IDENTITY: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
+
 #[derive(Default)]
 pub struct ClaudeOptions {
     pub max_output_tokens: Option<u32>,
     pub system: Option<String>,
+}
+
+/// 인증 방식 — API 키(공식) 또는 구독 OAuth(로컬 Claude Code 토큰 재사용).
+pub enum ClaudeAuth<'a> {
+    ApiKey(&'a str),
+    Subscription(&'a str),
 }
 
 #[derive(Serialize)]
@@ -25,8 +37,23 @@ struct MessageRequest<'a> {
     model: &'a str,
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<&'a str>,
+    system: Option<SystemField<'a>>,
     messages: Vec<UserMessage<'a>>,
+}
+
+/// system 필드는 단일 텍스트(API 키 모드) 또는 블록 배열(OAuth spoof) 둘 다 직렬화 가능.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum SystemField<'a> {
+    Text(&'a str),
+    Blocks(Vec<SystemBlock<'a>>),
+}
+
+#[derive(Serialize)]
+struct SystemBlock<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    text: &'a str,
 }
 
 #[derive(Serialize)]
@@ -68,7 +95,7 @@ struct AnthropicErrorBody {
 }
 
 pub async fn generate_text(
-    api_key: &str,
+    auth: ClaudeAuth<'_>,
     model: &str,
     prompt: &str,
     options: Option<ClaudeOptions>,
@@ -76,10 +103,28 @@ pub async fn generate_text(
     let opts = options.unwrap_or_default();
     let max_tokens = opts.max_output_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
 
+    // OAuth(구독) 모드는 system 블록 0 에 Claude Code identity 를 강제(non-Haiku 400 회피)하고
+    // 실제 지시는 블록 1 이후로 둔다. API 키 모드는 기존대로 단일 텍스트.
+    let system: Option<SystemField> = match &auth {
+        ClaudeAuth::Subscription(_) => {
+            let mut blocks = vec![SystemBlock {
+                kind: "text",
+                text: CLAUDE_CODE_IDENTITY,
+            }];
+            if let Some(s) = opts.system.as_deref() {
+                if !s.trim().is_empty() {
+                    blocks.push(SystemBlock { kind: "text", text: s });
+                }
+            }
+            Some(SystemField::Blocks(blocks))
+        }
+        ClaudeAuth::ApiKey(_) => opts.system.as_deref().map(SystemField::Text),
+    };
+
     let body = MessageRequest {
         model,
         max_tokens,
-        system: opts.system.as_deref(),
+        system,
         messages: vec![UserMessage {
             role: "user",
             content: prompt,
@@ -92,14 +137,17 @@ pub async fn generate_text(
 
     let mut last_err: Option<ConverterError> = None;
     for attempt in 1..=MAX_RETRIES {
-        let resp = client
+        let mut rb = client
             .post(API_URL)
-            .header("x-api-key", api_key)
             .header("anthropic-version", API_VERSION)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await;
+            .header("content-type", "application/json");
+        rb = match &auth {
+            ClaudeAuth::ApiKey(k) => rb.header("x-api-key", *k),
+            ClaudeAuth::Subscription(t) => rb
+                .header("authorization", format!("Bearer {}", t))
+                .header("anthropic-beta", OAUTH_BETA),
+        };
+        let resp = rb.json(&body).send().await;
 
         match resp {
             Ok(r) => {
@@ -161,7 +209,7 @@ pub async fn generate_text(
 
 fn classify_error(status: u16, body_msg: &str) -> ConverterError {
     match status {
-        401 | 403 => ConverterError::Claude("CLAUDE_API_KEY 가 잘못되었습니다. Settings 에서 확인하세요.".into()),
+        401 | 403 => ConverterError::Claude("Claude 인증 실패 — API 키 또는 구독 로그인을 확인하세요.".into()),
         429 => ConverterError::RateLimit,
         503 | 529 => ConverterError::Overloaded,
         _ => ConverterError::Claude(format!("HTTP {} — {}", status, body_msg)),

--- a/src-tauri/src/converters/llm/mod.rs
+++ b/src-tauri/src/converters/llm/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod anthropic;
 pub mod gemini;
+pub mod openai_api;
 pub mod openai_codex;

--- a/src-tauri/src/converters/llm/mod.rs
+++ b/src-tauri/src/converters/llm/mod.rs
@@ -1,4 +1,5 @@
-//! LLM 클라이언트 모듈 — Gemini + Anthropic Claude.
+//! LLM 클라이언트 모듈 — Gemini + Anthropic Claude + ChatGPT(Codex 구독).
 
 pub mod anthropic;
 pub mod gemini;
+pub mod openai_codex;

--- a/src-tauri/src/converters/llm/openai_api.rs
+++ b/src-tauri/src/converters/llm/openai_api.rs
@@ -1,0 +1,122 @@
+//! OpenAI API 키 클라이언트 — 표준 chat completions(공식). 구독(codex) 경로와 별개.
+//!
+//! GPT-5 계열은 `max_completion_tokens` 사용(`max_tokens` 아님). temperature 등은
+//! 기본값으로 두어 reasoning 모델 호환성을 확보한다(일부 GPT-5 모델이 temperature 제약).
+
+use crate::converters::error::{ConverterError, ConverterResult};
+use crate::converters::{GenerateResult, UsageInfo};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+const API_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<ChatMessage<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_completion_tokens: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct ChatMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+    #[serde(default)]
+    usage: Option<Usage>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: RespMessage,
+}
+
+#[derive(Deserialize)]
+struct RespMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Usage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+pub async fn generate_text(
+    api_key: &str,
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+) -> ConverterResult<GenerateResult> {
+    let mut messages = Vec::new();
+    if let Some(s) = system {
+        if !s.is_empty() {
+            messages.push(ChatMessage { role: "system", content: s });
+        }
+    }
+    messages.push(ChatMessage { role: "user", content: prompt });
+
+    let body = ChatRequest {
+        model,
+        messages,
+        max_completion_tokens: Some(16000),
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(180))
+        .build()
+        .map_err(|e| ConverterError::Network(e.to_string()))?;
+
+    let resp = client
+        .post(API_URL)
+        .header("authorization", format!("Bearer {}", api_key))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| ConverterError::Network(e.to_string()))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        let snippet: String = raw.chars().take(400).collect();
+        return Err(ConverterError::Codex(format!(
+            "OpenAI HTTP {} — {}",
+            status.as_u16(),
+            snippet
+        )));
+    }
+
+    let parsed: ChatResponse = resp
+        .json()
+        .await
+        .map_err(|e| ConverterError::Codex(format!("OpenAI 응답 파싱 실패: {e}")))?;
+    let text = parsed
+        .choices
+        .into_iter()
+        .next()
+        .and_then(|c| c.message.content)
+        .unwrap_or_default();
+    let usage = parsed.usage.unwrap_or(Usage {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+    });
+
+    Ok(GenerateResult {
+        text,
+        usage: UsageInfo {
+            model: model.to_string(),
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+            cost_usd: 0.0,
+        },
+    })
+}

--- a/src-tauri/src/converters/llm/openai_codex.rs
+++ b/src-tauri/src/converters/llm/openai_codex.rs
@@ -1,0 +1,156 @@
+//! ChatGPT(Codex 구독) 클라이언트 — 본인 Codex CLI 로그인 토큰 재사용.
+//!
+//! 비공개 경로: `POST chatgpt.com/backend-api/codex/responses` (Responses API + SSE).
+//! 공식 문서화되지 않아 헤더·바디·응답 형식이 codex 버전마다 바뀔 수 있다(미검증).
+//! 진단 로그(status, 빈 출력 시 SSE 앞부분)를 남겨 형식 불일치를 빠르게 잡는다.
+//! 토큰 값은 절대 로깅하지 않는다.
+
+use crate::converters::error::{ConverterError, ConverterResult};
+use crate::converters::{GenerateResult, UsageInfo};
+use std::time::Duration;
+
+const CODEX_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+pub async fn generate_text(
+    access_token: &str,
+    account_id: Option<&str>,
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+) -> ConverterResult<GenerateResult> {
+    let body = serde_json::json!({
+        "model": model,
+        "instructions": system.unwrap_or(""),
+        "input": [{ "role": "user", "content": prompt }],
+        "stream": true,
+        "store": false,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(180))
+        .build()
+        .map_err(|e| ConverterError::Network(e.to_string()))?;
+    let session_id = uuid::Uuid::new_v4().to_string();
+
+    let mut rb = client
+        .post(CODEX_URL)
+        .header("authorization", format!("Bearer {}", access_token))
+        .header("content-type", "application/json")
+        .header("accept", "text/event-stream")
+        .header("originator", "codex_cli_rs")
+        .header("openai-beta", "responses=experimental")
+        .header("session_id", &session_id);
+    if let Some(acc) = account_id {
+        rb = rb.header("chatgpt-account-id", acc);
+    }
+
+    let resp = rb
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| ConverterError::Network(e.to_string()))?;
+    let status = resp.status();
+
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        let snippet: String = raw.chars().take(500).collect();
+        eprintln!("[codex] 에러 본문: {}", snippet);
+        return Err(ConverterError::Codex(format!("HTTP {} — {}", status.as_u16(), snippet)));
+    }
+
+    let sse = resp
+        .text()
+        .await
+        .map_err(|e| ConverterError::Network(e.to_string()))?;
+    let text = parse_sse_output(&sse);
+
+    if text.trim().is_empty() {
+        // 형식 불일치 진단 — 앞부분만(모델 출력 구조, 토큰/민감정보 없음).
+        let head: String = sse.chars().take(500).collect();
+        eprintln!("[codex] 빈 출력 — SSE 앞부분: {}", head);
+        return Err(ConverterError::Codex(
+            "응답에서 텍스트를 추출하지 못했습니다(형식 불일치). 로그를 확인하세요.".into(),
+        ));
+    }
+
+    Ok(GenerateResult {
+        text,
+        // 구독 호출은 토큰/비용 정보가 표준 형식으로 오지 않으므로 0 으로 둔다.
+        usage: UsageInfo {
+            model: model.to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cost_usd: 0.0,
+        },
+    })
+}
+
+/// Responses API SSE 파싱 — `data: {json}` 라인에서 출력 텍스트를 누적.
+/// delta 스트림(`response.output_text.delta`)을 우선 쓰고, 비면 완료 이벤트의
+/// 중첩 output 구조에서 fallback 추출한다(형식 변형 관용 흡수).
+fn parse_sse_output(sse: &str) -> String {
+    let mut out = String::new();
+    for line in sse.lines() {
+        let line = line.trim();
+        let Some(data) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let data = data.trim();
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(data) else {
+            continue;
+        };
+        let t = v.get("type").and_then(|x| x.as_str()).unwrap_or("");
+        match t {
+            "response.output_text.delta" => {
+                if let Some(d) = v.get("delta").and_then(|x| x.as_str()) {
+                    out.push_str(d);
+                }
+            }
+            "response.completed" | "response.output_item.done" => {
+                if out.is_empty() {
+                    if let Some(txt) = extract_completed_text(&v) {
+                        out.push_str(&txt);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// 완료 이벤트의 중첩 구조에서 output_text 텍스트를 긁어온다.
+/// `response.output[].content[].text` 와 `item.content[].text` 두 변형을 탐색.
+fn extract_completed_text(v: &serde_json::Value) -> Option<String> {
+    let mut acc = String::new();
+    if let Some(arr) = v
+        .get("response")
+        .and_then(|r| r.get("output"))
+        .and_then(|o| o.as_array())
+    {
+        for item in arr {
+            if let Some(content) = item.get("content").and_then(|c| c.as_array()) {
+                for c in content {
+                    if let Some(txt) = c.get("text").and_then(|t| t.as_str()) {
+                        acc.push_str(txt);
+                    }
+                }
+            }
+        }
+    }
+    if let Some(content) = v.get("item").and_then(|i| i.get("content")).and_then(|c| c.as_array()) {
+        for c in content {
+            if let Some(txt) = c.get("text").and_then(|t| t.as_str()) {
+                acc.push_str(txt);
+            }
+        }
+    }
+    if acc.is_empty() {
+        None
+    } else {
+        Some(acc)
+    }
+}

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -37,8 +37,11 @@ pub const MODEL_OCR_ENHANCE: &str = "gemini-3-pro-image-preview";
 pub const MODEL_AUDIO: &str = "gemini-3.1-flash-lite";
 pub const MODEL_NOTES_GEMINI: &str = "gemini-3.1-pro-preview";
 pub const MODEL_NOTES_CLAUDE: &str = "claude-sonnet-4-6";
-#[allow(dead_code)] // OpenAI 호출 아직 미구현 — 미래 사용용 default
+#[allow(dead_code)] // OpenAI API 키 호출은 아직 미구현 — 미래 사용용 default
 pub const MODEL_OPENAI_DEFAULT: &str = "gpt-5.4-mini-2026-03-17";
+/// ChatGPT(Codex 구독) backend 호출 모델. `~/.codex/models_cache.json` 의 실제 id 기반
+/// (gpt-5.4 / gpt-5.4-mini / gpt-5.5). 최신 gpt-5.5 사용.
+pub const MODEL_CODEX: &str = "gpt-5.5";
 
 /// 단가 — USD per 1M tokens
 pub fn pricing(model: &str) -> Option<(f64, f64)> {

--- a/src-tauri/src/converters/notes_pipeline.rs
+++ b/src-tauri/src/converters/notes_pipeline.rs
@@ -8,7 +8,7 @@ use super::templates::{
     build_evidence_markdown, get_template, strip_frontmatter, EvidenceMeta,
 };
 use super::{
-    conversions_dir, CostSummary, DetailLevel, EvidenceType, NotesProvider, MODEL_NOTES_CLAUDE,
+    conversions_dir, CostSummary, DetailLevel, EvidenceType, MODEL_CODEX, MODEL_NOTES_CLAUDE,
     MODEL_NOTES_GEMINI,
 };
 use serde::{Deserialize, Serialize};
@@ -23,11 +23,13 @@ pub struct NotesJobOptions {
     pub source: String,
     #[serde(default)]
     pub detail: DetailLevel,
+    /// 전역 AI 모델 설정 — 회사 / 인증 / 모델 ID.
     #[serde(default)]
-    pub provider: NotesProvider,
-    /// Claude provider 사용 시 인증 소스 (API 키 / 구독 OAuth). Gemini 에는 무관.
-    #[serde(rename = "claudeAuth", default)]
-    pub claude_auth: crate::subscription_auth::ClaudeAuthMode,
+    pub company: crate::subscription_auth::AICompany,
+    #[serde(default)]
+    pub auth: crate::subscription_auth::ClaudeAuthMode,
+    #[serde(default)]
+    pub model: Option<String>,
     #[serde(rename = "outputDir", skip_serializing_if = "Option::is_none")]
     pub output_dir: Option<String>,
 }
@@ -67,10 +69,15 @@ pub async fn run(
     } else {
         "사용자 정의"
     };
+    let company_label = match opts.company {
+        crate::subscription_auth::AICompany::Gemini => "Gemini",
+        crate::subscription_auth::AICompany::Claude => "Claude",
+        crate::subscription_auth::AICompany::Openai => "ChatGPT",
+    };
     emitter.emit(
         format!(
             "✅ 템플릿: {} · 상세도: {} · 모델: {}",
-            template.info.name, opts.detail, opts.provider
+            template.info.name, opts.detail, company_label
         ),
         Some(source_label.to_string()),
     );
@@ -82,68 +89,25 @@ pub async fn run(
         detail = opts.detail.instruction(),
     );
 
-    let (model, generate_result) = match opts.provider {
-        NotesProvider::Claude => {
-            use crate::subscription_auth::ClaudeAuthMode;
-            let auth_label = match opts.claude_auth {
-                ClaudeAuthMode::Subscription => "구독 로그인",
-                ClaudeAuthMode::ApiKey => "API 키",
-            };
-            emitter.emit(
-                "🧠 미팅 노트 생성 중...",
-                Some(format!(
-                    "{} · {} · max {} tok",
-                    MODEL_NOTES_CLAUDE, auth_label, MAX_OUTPUT_TOKENS
-                )),
-            );
-            let start = std::time::Instant::now();
-            let claude_opts = anthropic::ClaudeOptions {
-                max_output_tokens: Some(MAX_OUTPUT_TOKENS),
-                system: None,
-            };
-            // 인증 소스 분기. 토큰/키는 호출 동안 살아있어야 하므로 각 분기에서 보관 후 빌려준다.
-            let result = match opts.claude_auth {
-                ClaudeAuthMode::Subscription => {
-                    let token = crate::subscription_auth::claude_access_token()
-                        .await
-                        .map_err(ConverterError::Claude)?;
-                    anthropic::generate_text(
-                        anthropic::ClaudeAuth::Subscription(&token),
-                        MODEL_NOTES_CLAUDE,
-                        &prompt,
-                        Some(claude_opts),
-                    )
-                    .await?
-                }
-                ClaudeAuthMode::ApiKey => {
-                    let api_key = get_key(Provider::Claude)?
-                        .ok_or(ConverterError::MissingApiKey("Claude"))?;
-                    anthropic::generate_text(
-                        anthropic::ClaudeAuth::ApiKey(&api_key),
-                        MODEL_NOTES_CLAUDE,
-                        &prompt,
-                        Some(claude_opts),
-                    )
-                    .await?
-                }
-            };
-            emitter.emit(
-                format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
-                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
-            );
-            (MODEL_NOTES_CLAUDE, result)
-        }
-        NotesProvider::Gemini => {
+    use crate::subscription_auth::{AICompany, ClaudeAuthMode};
+    let auth_label = match opts.auth {
+        ClaudeAuthMode::Subscription => "구독",
+        ClaudeAuthMode::ApiKey => "API 키",
+    };
+
+    let generate_result = match opts.company {
+        AICompany::Gemini => {
             let api_key = get_key(Provider::Gemini)?
                 .ok_or(ConverterError::MissingApiKey("Gemini"))?;
+            let model = opts.model.as_deref().unwrap_or(MODEL_NOTES_GEMINI);
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
-                Some(format!("{} · max {} tok", MODEL_NOTES_GEMINI, MAX_OUTPUT_TOKENS)),
+                Some(format!("{} · max {} tok", model, MAX_OUTPUT_TOKENS)),
             );
             let start = std::time::Instant::now();
             let result = gemini::generate_text(
                 &api_key,
-                MODEL_NOTES_GEMINI,
+                model,
                 &prompt,
                 vec![],
                 Some(gemini::GenerationConfig {
@@ -156,7 +120,85 @@ pub async fn run(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
                 Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
             );
-            (MODEL_NOTES_GEMINI, result)
+            result
+        }
+        AICompany::Claude => {
+            let model = opts
+                .model
+                .clone()
+                .unwrap_or_else(|| MODEL_NOTES_CLAUDE.to_string());
+            emitter.emit(
+                "🧠 미팅 노트 생성 중...",
+                Some(format!("{} · {} · max {} tok", model, auth_label, MAX_OUTPUT_TOKENS)),
+            );
+            let start = std::time::Instant::now();
+            let claude_opts = anthropic::ClaudeOptions {
+                max_output_tokens: Some(MAX_OUTPUT_TOKENS),
+                system: None,
+            };
+            let result = match opts.auth {
+                ClaudeAuthMode::Subscription => {
+                    let token = crate::subscription_auth::claude_access_token()
+                        .await
+                        .map_err(ConverterError::Claude)?;
+                    anthropic::generate_text(
+                        anthropic::ClaudeAuth::Subscription(&token),
+                        &model,
+                        &prompt,
+                        Some(claude_opts),
+                    )
+                    .await?
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let api_key = get_key(Provider::Claude)?
+                        .ok_or(ConverterError::MissingApiKey("Claude"))?;
+                    anthropic::generate_text(
+                        anthropic::ClaudeAuth::ApiKey(&api_key),
+                        &model,
+                        &prompt,
+                        Some(claude_opts),
+                    )
+                    .await?
+                }
+            };
+            emitter.emit(
+                format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
+                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
+            );
+            result
+        }
+        AICompany::Openai => {
+            use super::llm::{openai_api, openai_codex};
+            let model = opts.model.clone().unwrap_or_else(|| MODEL_CODEX.to_string());
+            emitter.emit(
+                "🧠 미팅 노트 생성 중...",
+                Some(format!("{} · {} · ChatGPT", model, auth_label)),
+            );
+            let start = std::time::Instant::now();
+            let result = match opts.auth {
+                ClaudeAuthMode::Subscription => {
+                    let tokens =
+                        crate::subscription_auth::read_codex_tokens().map_err(ConverterError::Codex)?;
+                    openai_codex::generate_text(
+                        &tokens.access_token,
+                        tokens.account_id.as_deref(),
+                        &model,
+                        None,
+                        &prompt,
+                    )
+                    .await?
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let api_key = get_key(Provider::Openai)?
+                        .ok_or(ConverterError::MissingApiKey("OpenAI"))?;
+                    openai_api::generate_text(&api_key, &model, None, &prompt).await?
+                }
+            };
+            emitter.emit(
+                format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
+                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
+            );
+            result
         }
     };
 
@@ -181,7 +223,6 @@ pub async fn run(
     std::fs::write(&target_path, &markdown)?;
     // doc-converter 와 동일: 저장 step 은 표시 안 함 (결과 카드의 경로로 충분)
 
-    let _ = model; // 단일 호출이라 cost는 generate_result.usage 그대로
 
     Ok(NotesJobResult {
         markdown_path: target_path.to_string_lossy().into_owned(),

--- a/src-tauri/src/converters/notes_pipeline.rs
+++ b/src-tauri/src/converters/notes_pipeline.rs
@@ -25,6 +25,9 @@ pub struct NotesJobOptions {
     pub detail: DetailLevel,
     #[serde(default)]
     pub provider: NotesProvider,
+    /// Claude provider 사용 시 인증 소스 (API 키 / 구독 OAuth). Gemini 에는 무관.
+    #[serde(rename = "claudeAuth", default)]
+    pub claude_auth: crate::subscription_auth::ClaudeAuthMode,
     #[serde(rename = "outputDir", skip_serializing_if = "Option::is_none")]
     pub output_dir: Option<String>,
 }
@@ -81,23 +84,49 @@ pub async fn run(
 
     let (model, generate_result) = match opts.provider {
         NotesProvider::Claude => {
-            let api_key = get_key(Provider::Claude)?
-                .ok_or(ConverterError::MissingApiKey("Claude"))?;
+            use crate::subscription_auth::ClaudeAuthMode;
+            let auth_label = match opts.claude_auth {
+                ClaudeAuthMode::Subscription => "구독 로그인",
+                ClaudeAuthMode::ApiKey => "API 키",
+            };
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
-                Some(format!("{} · max {} tok", MODEL_NOTES_CLAUDE, MAX_OUTPUT_TOKENS)),
+                Some(format!(
+                    "{} · {} · max {} tok",
+                    MODEL_NOTES_CLAUDE, auth_label, MAX_OUTPUT_TOKENS
+                )),
             );
             let start = std::time::Instant::now();
-            let result = anthropic::generate_text(
-                &api_key,
-                MODEL_NOTES_CLAUDE,
-                &prompt,
-                Some(anthropic::ClaudeOptions {
-                    max_output_tokens: Some(MAX_OUTPUT_TOKENS),
-                    system: None,
-                }),
-            )
-            .await?;
+            let claude_opts = anthropic::ClaudeOptions {
+                max_output_tokens: Some(MAX_OUTPUT_TOKENS),
+                system: None,
+            };
+            // 인증 소스 분기. 토큰/키는 호출 동안 살아있어야 하므로 각 분기에서 보관 후 빌려준다.
+            let result = match opts.claude_auth {
+                ClaudeAuthMode::Subscription => {
+                    let token = crate::subscription_auth::claude_access_token()
+                        .await
+                        .map_err(ConverterError::Claude)?;
+                    anthropic::generate_text(
+                        anthropic::ClaudeAuth::Subscription(&token),
+                        MODEL_NOTES_CLAUDE,
+                        &prompt,
+                        Some(claude_opts),
+                    )
+                    .await?
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let api_key = get_key(Provider::Claude)?
+                        .ok_or(ConverterError::MissingApiKey("Claude"))?;
+                    anthropic::generate_text(
+                        anthropic::ClaudeAuth::ApiKey(&api_key),
+                        MODEL_NOTES_CLAUDE,
+                        &prompt,
+                        Some(claude_opts),
+                    )
+                    .await?
+                }
+            };
             emitter.emit(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
                 Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),

--- a/src-tauri/src/export_pptx.rs
+++ b/src-tauri/src/export_pptx.rs
@@ -1,0 +1,13 @@
+// PPTX 내보내기 — 이슈 #6
+//
+// 프론트(PptxGenJS, WKWebView)에서 만든 .pptx ArrayBuffer 를 받아 사용자가 고른
+// 경로에 저장한다. WKWebView 의 blob:// 다운로드 버그(WebKit #216918) 우회 —
+// 저장 다이얼로그는 프론트 tauri-plugin-dialog 의 save() 가 처리하고, 여기선
+// bytes 를 fs::write 만 한다(print_pdf::export_pdf 와 동일한 역할 분담).
+
+use tauri::command;
+
+#[command]
+pub async fn save_pptx(path: String, data: Vec<u8>) -> Result<(), String> {
+    std::fs::write(&path, &data).map_err(|e| format!("PPTX 저장 실패: {e}"))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -319,6 +319,7 @@ pub fn run() {
             converters::commands::get_conversions_dir,
             converters::commands::generate_slides_llm,
             converters::commands::ai_generate_claude,
+            converters::commands::ai_generate_codex,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod converters;
+mod export_pptx;
 mod gdrive;
 mod lan_server;
 mod mcp;
@@ -313,6 +314,7 @@ pub fn run() {
             converters::commands::run_ocr_job,
             converters::commands::run_notes_job,
             converters::commands::get_conversions_dir,
+            converters::commands::generate_slides_llm,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,
@@ -330,6 +332,8 @@ pub fn run() {
             gdrive::commands::gdrive_update,
             // PDF export — macOS NSPrintInfo 명시 + WKWebView native print
             print_pdf::export_pdf,
+            // PPTX export — 프론트 PptxGenJS ArrayBuffer → fs::write (이슈 #6)
+            export_pptx::save_pptx,
             // Vault (옵시디언형 문서 그래프 — 폴더 스캔 + create-on-click)
             vault::scan_vault,
             vault::create_file_at,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,6 +320,7 @@ pub fn run() {
             converters::commands::generate_slides_llm,
             converters::commands::ai_generate_claude,
             converters::commands::ai_generate_codex,
+            converters::commands::ai_generate_openai,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod mcp;
 mod print_pdf;
 mod secrets;
 mod share;
+mod subscription_auth;
 mod user_memory;
 mod vault;
 
@@ -306,6 +307,8 @@ pub fn run() {
             // 통합 vault batch (저장 다이얼로그 1회로 묶기)
             secrets::secrets_set_user_inputs,
             secrets::get_diar_python,
+            // 구독 OAuth (Claude Code / Codex CLI 토큰 재사용) — 로그인 감지
+            subscription_auth::detect_subscription_logins,
             // Templates
             converters::templates::list_meeting_templates,
             converters::templates::open_user_templates_folder,
@@ -315,6 +318,7 @@ pub fn run() {
             converters::commands::run_notes_job,
             converters::commands::get_conversions_dir,
             converters::commands::generate_slides_llm,
+            converters::commands::ai_generate_claude,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -15,6 +15,7 @@
 //! - Claude: keychain 토큰 읽기 + 만료 시 refresh + 유효 access token 반환 (호출에 사용).
 //! - Codex: 로그인 여부 감지만 (실제 호출은 후속 Phase).
 
+use base64::Engine;
 use keyring::Entry;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -26,6 +27,16 @@ pub enum ClaudeAuthMode {
     #[default]
     ApiKey,
     Subscription,
+}
+
+/// AI 회사(company) — 전역 모델 설정. JS `aiModelConfig.AICompany` 와 값 일치.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AICompany {
+    #[default]
+    Gemini,
+    Claude,
+    Openai,
 }
 
 // ─── Claude Code (Anthropic) ────────────────────────────────────────────────
@@ -50,6 +61,9 @@ struct ClaudeOauth {
     /// unix epoch milliseconds.
     #[serde(rename = "expiresAt", default, skip_serializing_if = "Option::is_none")]
     expires_at: Option<u64>,
+    /// 구독 종류 — "max" / "pro" 등 (플랜 표시용, write-back 보존).
+    #[serde(rename = "subscriptionType", default, skip_serializing_if = "Option::is_none")]
+    subscription_type: Option<String>,
     #[serde(flatten)]
     extra: serde_json::Map<String, serde_json::Value>,
 }
@@ -225,17 +239,77 @@ pub fn codex_logged_in() -> bool {
 
 // ─── Tauri command ──────────────────────────────────────────────────────────
 
-/// 구독 로그인 감지 결과 (UI 배지용 — 토큰 값은 절대 포함하지 않음).
+/// 첫 글자만 대문자화 ("max" → "Max", "plus" → "Plus").
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(f) => f.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Claude 플랜 라벨 — keychain 의 subscriptionType ("max" → "Max"). 없으면 None.
+fn claude_plan_label(creds: &ClaudeCreds) -> Option<String> {
+    creds
+        .claude_ai_oauth
+        .subscription_type
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(capitalize)
+}
+
+/// JWT(헤더.페이로드.서명) 의 payload(base64url) 를 JSON 으로 디코드.
+fn decode_jwt_payload(jwt: &str) -> Option<serde_json::Value> {
+    let payload = jwt.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Codex 플랜 라벨 — id_token JWT 의 chatgpt_plan_type ("plus" → "Plus"). 없으면 None.
+fn codex_plan_label() -> Option<String> {
+    let path = codex_auth_path()?;
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let id_token = v.get("tokens")?.get("id_token")?.as_str()?;
+    let payload = decode_jwt_payload(id_token)?;
+    let plan = payload
+        .get("https://api.openai.com/auth")?
+        .get("chatgpt_plan_type")?
+        .as_str()?;
+    if plan.is_empty() {
+        None
+    } else {
+        Some(capitalize(plan))
+    }
+}
+
+/// 구독 로그인 감지 결과 (UI 배지용 — 토큰 값은 절대 포함하지 않음, 플랜명만).
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubscriptionStatus {
     pub claude: bool,
     pub codex: bool,
+    /// Claude 플랜명 ("Max" 등). 미연결/미상이면 None.
+    pub claude_plan: Option<String>,
+    /// ChatGPT 플랜명 ("Plus" 등). 미연결/미상이면 None.
+    pub codex_plan: Option<String>,
 }
 
 #[tauri::command]
 pub fn detect_subscription_logins() -> SubscriptionStatus {
+    let claude_creds = read_claude_creds();
+    let claude = claude_creds
+        .as_ref()
+        .map(|c| !c.claude_ai_oauth.access_token.is_empty())
+        .unwrap_or(false);
+    let claude_plan = claude_creds.as_ref().and_then(claude_plan_label);
+    let codex = codex_logged_in();
     SubscriptionStatus {
-        claude: claude_logged_in(),
-        codex: codex_logged_in(),
+        claude,
+        codex,
+        claude_plan: if claude { claude_plan } else { None },
+        codex_plan: if codex { codex_plan_label() } else { None },
     }
 }

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -171,6 +171,39 @@ fn codex_auth_path() -> Option<std::path::PathBuf> {
     Some(std::path::Path::new(&home).join(".codex").join("auth.json"))
 }
 
+/// Codex 호출에 필요한 토큰 (값은 메모리에서만).
+pub struct CodexTokens {
+    pub access_token: String,
+    pub account_id: Option<String>,
+}
+
+/// `~/.codex/auth.json` 에서 access_token + account_id 를 읽는다.
+/// (만료 refresh 는 미구현 — 만료 시 `codex` 재로그인 안내. 후속 Phase 에서 추가.)
+pub fn read_codex_tokens() -> Result<CodexTokens, String> {
+    let path = codex_auth_path().ok_or_else(|| "HOME 환경변수를 찾을 수 없습니다.".to_string())?;
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|_| "Codex 로그인을 찾을 수 없습니다. 터미널에서 `codex` 로 로그인하세요.".to_string())?;
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).map_err(|e| format!("auth.json 파싱 실패: {e}"))?;
+    let tokens = v
+        .get("tokens")
+        .ok_or_else(|| "auth.json 에 tokens 가 없습니다.".to_string())?;
+    let access_token = tokens
+        .get("access_token")
+        .and_then(|a| a.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "access_token 이 없습니다. `codex` 재로그인이 필요합니다.".to_string())?
+        .to_string();
+    let account_id = tokens
+        .get("account_id")
+        .and_then(|a| a.as_str())
+        .map(String::from);
+    Ok(CodexTokens {
+        access_token,
+        account_id,
+    })
+}
+
 /// Codex 로그인 존재 여부 (`~/.codex/auth.json` 의 `tokens.access_token` 유무).
 pub fn codex_logged_in() -> bool {
     let Some(path) = codex_auth_path() else {

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -1,0 +1,208 @@
+//! 구독 OAuth 토큰 재사용 — 사용자가 로컬에 로그인해 둔 Claude Code / Codex CLI 의
+//! OAuth 토큰을 읽어 **본인 구독**으로 LLM 을 호출하기 위한 모듈.
+//!
+//! ## 전제 / 범위
+//! - **본인 머신·본인 구독 한정.** Claude Code / Codex CLI 를 직접 실행하는 것과 같은 범주
+//!   (앱이 타인에게 claude.ai/ChatGPT 로그인을 *제공*하는 것은 약관 위반 — 그건 하지 않는다).
+//! - 호출 경로(헤더/엔드포인트)는 공식 문서화된 것이 아니라 CLI 동작을 따른 것이라
+//!   공급사가 임의로 바꾸면 깨질 수 있다. 따라서 호출부는 **API 키 fallback 을 항상 함께** 둔다.
+//!
+//! ## 보안
+//! - 토큰 값은 메모리에서만 다루고 **로그·파일·IPC 응답에 절대 노출하지 않는다**
+//!   (`detect_*` 는 로그인 여부 bool 만 반환).
+//!
+//! 현재 구현(Phase 1+2):
+//! - Claude: keychain 토큰 읽기 + 만료 시 refresh + 유효 access token 반환 (호출에 사용).
+//! - Codex: 로그인 여부 감지만 (실제 호출은 후속 Phase).
+
+use keyring::Entry;
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Claude 호출 인증 소스 — UI 토글값. `#[serde(default)]` 로 기존 호출은 API 키 유지.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaudeAuthMode {
+    #[default]
+    ApiKey,
+    Subscription,
+}
+
+// ─── Claude Code (Anthropic) ────────────────────────────────────────────────
+
+/// Claude Code 가 OAuth 토큰을 저장하는 macOS Keychain service 이름.
+/// account 는 현재 사용자명($USER).
+const CLAUDE_KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
+/// Claude Code CLI 의 공개 OAuth client_id (refresh grant 에 필요).
+const CLAUDE_OAUTH_CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const CLAUDE_TOKEN_URL: &str = "https://console.anthropic.com/v1/oauth/token";
+/// access token 만료 임박 시 미리 refresh 하는 버퍼 (5분, ms).
+const REFRESH_SKEW_MS: u64 = 5 * 60 * 1000;
+
+/// keychain JSON 의 `claudeAiOauth` 객체. 알려진 필드 외(scopes/subscriptionType 등)는
+/// `extra` 로 캡처해 write-back 시 **그대로 보존**한다.
+#[derive(Serialize, Deserialize, Clone)]
+struct ClaudeOauth {
+    #[serde(rename = "accessToken")]
+    access_token: String,
+    #[serde(rename = "refreshToken", default, skip_serializing_if = "Option::is_none")]
+    refresh_token: Option<String>,
+    /// unix epoch milliseconds.
+    #[serde(rename = "expiresAt", default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ClaudeCreds {
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: ClaudeOauth,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct RefreshResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    /// seconds until expiry.
+    #[serde(default)]
+    expires_in: u64,
+}
+
+fn current_user() -> String {
+    std::env::var("USER").unwrap_or_default()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn claude_entry() -> Result<Entry, String> {
+    Entry::new(CLAUDE_KEYCHAIN_SERVICE, &current_user()).map_err(|e| e.to_string())
+}
+
+fn read_claude_creds() -> Option<ClaudeCreds> {
+    let raw = claude_entry().ok()?.get_password().ok()?;
+    serde_json::from_str::<ClaudeCreds>(&raw).ok()
+}
+
+fn write_claude_creds(creds: &ClaudeCreds) -> Result<(), String> {
+    let json = serde_json::to_string(creds).map_err(|e| e.to_string())?;
+    claude_entry()?.set_password(&json).map_err(|e| e.to_string())
+}
+
+/// Claude Code 로그인 존재 여부 (토큰 값은 노출하지 않음).
+pub fn claude_logged_in() -> bool {
+    read_claude_creds()
+        .map(|c| !c.claude_ai_oauth.access_token.is_empty())
+        .unwrap_or(false)
+}
+
+/// 유효한 Claude 구독 access token 반환. 만료 임박이면 refresh 후 keychain write-back.
+///
+/// write-back 실패(권한 프롬프트 거부 등)는 치명적이지 않다 — 이번 호출용 토큰은 그대로 반환.
+pub async fn claude_access_token() -> Result<String, String> {
+    let mut creds = read_claude_creds().ok_or_else(|| {
+        "Claude Code 로그인을 찾을 수 없습니다. 터미널에서 `claude` 로 로그인하세요.".to_string()
+    })?;
+
+    let needs_refresh = match creds.claude_ai_oauth.expires_at {
+        Some(exp) => now_ms().saturating_add(REFRESH_SKEW_MS) >= exp,
+        None => false, // 만료 정보가 없으면 일단 보유 토큰으로 시도
+    };
+    if !needs_refresh {
+        return Ok(creds.claude_ai_oauth.access_token.clone());
+    }
+
+    let refresh_token = creds
+        .claude_ai_oauth
+        .refresh_token
+        .clone()
+        .ok_or_else(|| "refresh token 이 없습니다. 터미널에서 `claude` 재로그인하세요.".to_string())?;
+
+    let refreshed = refresh_claude_token(&refresh_token).await?;
+
+    creds.claude_ai_oauth.access_token = refreshed.access_token.clone();
+    if refreshed.refresh_token.is_some() {
+        creds.claude_ai_oauth.refresh_token = refreshed.refresh_token;
+    }
+    if refreshed.expires_in > 0 {
+        creds.claude_ai_oauth.expires_at = Some(now_ms() + refreshed.expires_in * 1000);
+    }
+    let _ = write_claude_creds(&creds); // best-effort
+
+    Ok(refreshed.access_token)
+}
+
+async fn refresh_claude_token(refresh_token: &str) -> Result<RefreshResponse, String> {
+    let body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": CLAUDE_OAUTH_CLIENT_ID,
+    });
+    let resp = reqwest::Client::new()
+        .post(CLAUDE_TOKEN_URL)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Claude 토큰 갱신 요청 실패: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "Claude 토큰 갱신 실패 (HTTP {}). `claude` 재로그인이 필요할 수 있습니다.",
+            resp.status().as_u16()
+        ));
+    }
+    resp.json::<RefreshResponse>()
+        .await
+        .map_err(|e| format!("Claude 토큰 갱신 응답 파싱 실패: {e}"))
+}
+
+// ─── Codex (ChatGPT) — 현재는 감지만 ─────────────────────────────────────────
+
+fn codex_auth_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(std::path::Path::new(&home).join(".codex").join("auth.json"))
+}
+
+/// Codex 로그인 존재 여부 (`~/.codex/auth.json` 의 `tokens.access_token` 유무).
+pub fn codex_logged_in() -> bool {
+    let Some(path) = codex_auth_path() else {
+        return false;
+    };
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&raw)
+        .ok()
+        .and_then(|v| {
+            v.get("tokens")
+                .and_then(|t| t.get("access_token"))
+                .and_then(|a| a.as_str())
+                .map(|s| !s.is_empty())
+        })
+        .unwrap_or(false)
+}
+
+// ─── Tauri command ──────────────────────────────────────────────────────────
+
+/// 구독 로그인 감지 결과 (UI 배지용 — 토큰 값은 절대 포함하지 않음).
+#[derive(Serialize)]
+pub struct SubscriptionStatus {
+    pub claude: bool,
+    pub codex: bool,
+}
+
+#[tauri::command]
+pub fn detect_subscription_logins() -> SubscriptionStatus {
+    SubscriptionStatus {
+        claude: claude_logged_in(),
+        codex: codex_logged_in(),
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -3413,3 +3413,31 @@ code.hljs {
   font-size: 17px;
   font-weight: 600;
 }
+
+/* PPTX 내보내기 진행 오버레이 (이슈 #6 — LLM 슬라이드 생성은 수초~수십초 소요) */
+.pptx-busy-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(1.5px);
+  animation: fadeIn 120ms ease-out;
+}
+.pptx-busy-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 22px;
+  border-radius: 12px;
+  background: var(--bg-elevated, #ffffff);
+  color: var(--text-primary, #1a1a2e);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+  font-size: 14px;
+  font-weight: 500;
+}
+.pptx-busy-card .spinning {
+  color: #2f6fed;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import { useConverter } from './hooks/useConverter';
 import { isTauri } from './services/platform';
 import { getCallbackPath } from './services/knowaiAuth';
 import { TUTORIAL_CONTENT } from './constants/tutorial';
-import { Link, Unlink, Mic, ScanText, BookOpen, X as IconX, Sparkles } from 'lucide-react';
+import { Link, Unlink, Mic, ScanText, BookOpen, X as IconX, Sparkles, Loader2 } from 'lucide-react';
 import { ConvertSidebar } from './components/sidebar/ConvertSidebar';
 import { AudioTab } from './components/convert/AudioTab';
 import { OcrTab } from './components/convert/OcrTab';
@@ -242,6 +242,80 @@ function App() {
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [handleExportPdf]);
+
+  // PPTX export (이슈 #6) — 규칙 기반 + LLM 스마트 레이아웃.
+  // 프론트 PptxGenJS 로 ArrayBuffer 생성 → Rust save_pptx 로 저장(WKWebView blob 버그 우회).
+  const [pptxAiProviders, setPptxAiProviders] = useState<{ claude: boolean; gemini: boolean }>({
+    claude: false,
+    gemini: false,
+  });
+  // PPTX 내보내기 진행 표시(특히 AI 레이아웃은 LLM 호출로 수초~수십초 소요).
+  const [pptxBusy, setPptxBusy] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isTauri()) return;
+    (async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const [claude, gemini] = await Promise.all([
+          invoke<boolean>('has_api_key', { provider: 'claude' }),
+          invoke<boolean>('has_api_key', { provider: 'gemini' }),
+        ]);
+        setPptxAiProviders({ claude, gemini });
+      } catch {
+        /* 키 조회 실패 시 AI 옵션 비활성 유지 */
+      }
+    })();
+  }, [settingsVisible]);
+
+  // PPTX 내보내기 — LLM 스마트 레이아웃 단일 경로(디폴트). 규칙 기반은 LLM 응답을
+  // 전혀 해석 못한 catastrophic 실패 시의 안전망으로만 내부 사용한다.
+  const handleExportPptx = useCallback(async () => {
+    if (!pptxAiProviders.claude && !pptxAiProviders.gemini) {
+      alert('PPTX 내보내기는 AI 레이아웃을 사용합니다. Settings 에서 Claude 또는 Gemini API 키를 등록하세요.');
+      return;
+    }
+    const baseName = (fileName || 'Untitled').replace(/\.(md|markdown|mdx|txt)$/i, '');
+    try {
+      const [{ save }, { invoke }, { markdownToSlides, slidesFromLlmJson }, { buildPptx }] =
+        await Promise.all([
+          import('@tauri-apps/plugin-dialog'),
+          import('@tauri-apps/api/core'),
+          import('./lib/markdownToSlides'),
+          import('./lib/buildPptx'),
+        ]);
+      const path = await save({
+        defaultPath: `${baseName}.pptx`,
+        filters: [{ name: 'PowerPoint', extensions: ['pptx'] }],
+        title: 'PPTX로 내보내기',
+      });
+      if (!path) return; // 사용자 취소
+
+      const provider = pptxAiProviders.claude ? 'claude' : 'gemini';
+      setPptxBusy(`AI 슬라이드 생성 중… (${provider === 'claude' ? 'Claude' : 'Gemini'})`);
+
+      const raw = await invoke<string>('generate_slides_llm', { markdown: content, provider });
+      let slides = slidesFromLlmJson(raw);
+      console.log(
+        `[export_pptx] AI(${provider}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장`,
+      );
+      if (!slides || slides.length === 0) {
+        // 조용한 폴백 금지 — 사용자에게 알리고 원문 로깅(메모리: silent fallback 함정)
+        console.warn('[export_pptx] AI 응답 파싱 실패, 규칙 기반 안전망으로 폴백. 원문:', raw);
+        alert('AI 응답을 해석하지 못해 기본 레이아웃으로 저장합니다.\n(개발자 콘솔에 원문이 로깅되었습니다)');
+        slides = markdownToSlides(content);
+      }
+
+      setPptxBusy('PPTX 파일 생성 중…');
+      const baseDir = filePath ? filePath.replace(/\/[^/]*$/, '') : undefined;
+      const buf = await buildPptx(slides, { title: baseName, baseDir });
+      await invoke('save_pptx', { path, data: Array.from(new Uint8Array(buf)) });
+    } catch (err) {
+      console.error('[export_pptx] failed:', err);
+      alert(`PPTX 내보내기에 실패했습니다.\n${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setPptxBusy(null);
+    }
+  }, [fileName, filePath, content, pptxAiProviders]);
 
   // AI
   const ai = useAI();
@@ -1449,6 +1523,8 @@ function App() {
         onSaveFile={saveFile}
         onSaveFileAs={saveFileAs}
         onExportPdf={handleExportPdf}
+        onExportPptx={handleExportPptx}
+        aiLayoutAvailable={pptxAiProviders.claude || pptxAiProviders.gemini}
         onShowTutorial={() => setTutorialVisible(true)}
         onShowSettings={() => setSettingsVisible(true)}
         onOpenFromDrive={() => setDriveBrowserMode('open')}
@@ -1733,6 +1809,15 @@ function App() {
       </div>
 
       <StatusBar content={content} filePath={filePath} />
+
+      {pptxBusy && (
+        <div className="pptx-busy-overlay" role="status" aria-live="polite">
+          <div className="pptx-busy-card">
+            <Loader2 size={20} className="spinning" />
+            <span>{pptxBusy}</span>
+          </div>
+        </div>
+      )}
 
       <RecentFilesPanel
         files={recentFiles}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,9 @@ import { createPortal } from 'react-dom';
 import { AIMode, DiffChunk } from './types/ai';
 import { Editor, EditorHandle } from './components/Editor';
 import { McpProposalView } from './components/McpProposalView';
-import { generateDiff } from './services/aiService';
+import { generateDiff, isAuthError } from './services/aiService';
+import { getAIModelSelection } from './services/aiModelConfig';
+import { setValidationStatus } from './services/apiValidation';
 import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
 import { VaultGraphView } from './components/VaultGraphView';
@@ -694,16 +696,22 @@ function App() {
       ai.setIsLoading(true);
       try {
         // 회의록 백엔드는 gemini/claude 만 지원 → 그 외(openai/pyannoteai)는 Claude 폴백
-        const provider = ai.selectedModel === 'gemini' ? 'gemini' : 'claude';
+        const sel = getAIModelSelection();
         const result = await converter.runNotes({
           transcript: runContent,
           template: ai.notesTemplate,
           source: fileName || 'document.md',
-          provider,
-          claudeAuth: provider === 'claude' ? ai.claudeAuthMode : undefined,
+          company: sel.company,
+          auth: sel.auth,
+          model: sel.model,
         });
         if (result) ai.setNotesResult(result);
       } catch (err) {
+        // 실제 사용 중 인증 실패면 설정 검증 상태 갱신(정상→확인 필요). API 키 인증일 때만.
+        const failSel = getAIModelSelection();
+        if (failSel.auth === 'api_key' && isAuthError(err)) {
+          setValidationStatus(failSel.company, 'invalid');
+        }
         ai.setError(err instanceof Error ? err.message : '회의록 생성 실패');
       } finally {
         ai.setIsLoading(false);
@@ -1766,10 +1774,6 @@ function App() {
           streamingText={ai.streamingText}
           apiKeySet={ai.apiKeySet}
           content={content}
-          selectedModel={ai.selectedModel}
-          onSelectedModelChange={ai.setSelectedModel}
-          claudeAuthMode={ai.claudeAuthMode}
-          onClaudeAuthChange={ai.setClaudeAuthMode}
           onModeChange={ai.setMode}
           onLanguageChange={ai.setLanguage}
           notesTemplate={ai.notesTemplate}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -700,6 +700,7 @@ function App() {
           template: ai.notesTemplate,
           source: fileName || 'document.md',
           provider,
+          claudeAuth: provider === 'claude' ? ai.claudeAuthMode : undefined,
         });
         if (result) ai.setNotesResult(result);
       } catch (err) {
@@ -1767,6 +1768,8 @@ function App() {
           content={content}
           selectedModel={ai.selectedModel}
           onSelectedModelChange={ai.setSelectedModel}
+          claudeAuthMode={ai.claudeAuthMode}
+          onClaudeAuthChange={ai.setClaudeAuthMode}
           onModeChange={ai.setMode}
           onLanguageChange={ai.setLanguage}
           notesTemplate={ai.notesTemplate}

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -6,11 +6,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { AIMode, TranslateLanguage } from '../types/ai';
 import { Sparkles, Send, Loader2, AlertCircle } from 'lucide-react';
-import type { ClaudeAuthMode, NotesJobResult, TemplateInfo } from '../types/converter';
-import { hasKey, type Provider } from '../services/secureStorage';
-import { detectSubscriptionLogins } from '../services/subscriptionService';
+import type { NotesJobResult, TemplateInfo } from '../types/converter';
 import { ModeSelector } from './ai/ModeSelector';
-import { LlmSelector } from './ai/LlmSelector';
 import { NotesOptions } from './ai/NotesOptions';
 import { NotesResultCard } from './ai/NotesResultCard';
 import './AIPanel.css';
@@ -24,10 +21,6 @@ interface AIPanelProps {
     streamingText: string;
     apiKeySet: boolean;
     content: string;
-    selectedModel: Provider;
-    onSelectedModelChange: (p: Provider) => void;
-    claudeAuthMode: ClaudeAuthMode;
-    onClaudeAuthChange: (m: ClaudeAuthMode) => void;
     notesTemplate: string;
     notesResult: NotesJobResult | null;
     loadTemplates: () => Promise<TemplateInfo[]>;
@@ -48,10 +41,6 @@ export function AIPanel({
     streamingText,
     apiKeySet,
     content,
-    selectedModel,
-    onSelectedModelChange,
-    claudeAuthMode,
-    onClaudeAuthChange,
     notesTemplate,
     notesResult,
     loadTemplates,
@@ -64,27 +53,6 @@ export function AIPanel({
 }: AIPanelProps) {
     const [prompt, setPrompt] = useState('');
     const promptRef = useRef<HTMLTextAreaElement>(null);
-
-    // 구독(Claude Code / Codex) 로그인 감지 — mount 1회.
-    const [subClaude, setSubClaude] = useState(false);
-    const [subCodex, setSubCodex] = useState(false);
-    useEffect(() => {
-        let cancelled = false;
-        detectSubscriptionLogins().then((s) => {
-            if (cancelled) return;
-            setSubClaude(s.claude);
-            setSubCodex(s.codex);
-            // Claude API 키가 없고 구독만 있으면 인증 소스를 구독으로 자동 설정.
-            if (s.claude && !hasKey('claude') && claudeAuthMode !== 'subscription') {
-                onClaudeAuthChange('subscription');
-            }
-        });
-        return () => {
-            cancelled = true;
-        };
-        // mount 1회만 — 콜백/상태 변화로 재실행하지 않음.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     useEffect(() => {
         if (mode === 'improve' && promptRef.current) {
@@ -133,30 +101,6 @@ export function AIPanel({
                 </div>
             ) : (
                 <>
-                    <LlmSelector
-                        selected={selectedModel}
-                        onChange={onSelectedModelChange}
-                        claudeSubscription={subClaude}
-                        codexSubscription={subCodex}
-                    />
-
-                    {selectedModel === 'claude' && (
-                        <div className="ai-llm-select" title="Claude 호출 인증 소스">
-                            <label>Claude 인증</label>
-                            <select
-                                value={claudeAuthMode}
-                                onChange={(e) => onClaudeAuthChange(e.target.value as ClaudeAuthMode)}
-                            >
-                                <option value="api_key" disabled={!hasKey('claude')}>
-                                    API 키{!hasKey('claude') ? ' (없음)' : ''}
-                                </option>
-                                <option value="subscription" disabled={!subClaude}>
-                                    구독 로그인{!subClaude ? ' (미감지)' : ''}
-                                </option>
-                            </select>
-                        </div>
-                    )}
-
                     <ModeSelector mode={mode} onChange={onModeChange} />
 
                     {mode === 'translate' && (

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -6,8 +6,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { AIMode, TranslateLanguage } from '../types/ai';
 import { Sparkles, Send, Loader2, AlertCircle } from 'lucide-react';
-import type { NotesJobResult, TemplateInfo } from '../types/converter';
-import type { Provider } from '../services/secureStorage';
+import type { ClaudeAuthMode, NotesJobResult, TemplateInfo } from '../types/converter';
+import { hasKey, type Provider } from '../services/secureStorage';
+import { detectSubscriptionLogins } from '../services/subscriptionService';
 import { ModeSelector } from './ai/ModeSelector';
 import { LlmSelector } from './ai/LlmSelector';
 import { NotesOptions } from './ai/NotesOptions';
@@ -25,6 +26,8 @@ interface AIPanelProps {
     content: string;
     selectedModel: Provider;
     onSelectedModelChange: (p: Provider) => void;
+    claudeAuthMode: ClaudeAuthMode;
+    onClaudeAuthChange: (m: ClaudeAuthMode) => void;
     notesTemplate: string;
     notesResult: NotesJobResult | null;
     loadTemplates: () => Promise<TemplateInfo[]>;
@@ -47,6 +50,8 @@ export function AIPanel({
     content,
     selectedModel,
     onSelectedModelChange,
+    claudeAuthMode,
+    onClaudeAuthChange,
     notesTemplate,
     notesResult,
     loadTemplates,
@@ -59,6 +64,25 @@ export function AIPanel({
 }: AIPanelProps) {
     const [prompt, setPrompt] = useState('');
     const promptRef = useRef<HTMLTextAreaElement>(null);
+
+    // 구독(Claude Code / Codex) 로그인 감지 — mount 1회.
+    const [subClaude, setSubClaude] = useState(false);
+    useEffect(() => {
+        let cancelled = false;
+        detectSubscriptionLogins().then((s) => {
+            if (cancelled) return;
+            setSubClaude(s.claude);
+            // Claude API 키가 없고 구독만 있으면 인증 소스를 구독으로 자동 설정.
+            if (s.claude && !hasKey('claude') && claudeAuthMode !== 'subscription') {
+                onClaudeAuthChange('subscription');
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+        // mount 1회만 — 콜백/상태 변화로 재실행하지 않음.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     useEffect(() => {
         if (mode === 'improve' && promptRef.current) {
@@ -107,7 +131,28 @@ export function AIPanel({
                 </div>
             ) : (
                 <>
-                    <LlmSelector mode={mode} selected={selectedModel} onChange={onSelectedModelChange} />
+                    <LlmSelector
+                        selected={selectedModel}
+                        onChange={onSelectedModelChange}
+                        claudeSubscription={subClaude}
+                    />
+
+                    {selectedModel === 'claude' && (
+                        <div className="ai-llm-select" title="Claude 호출 인증 소스">
+                            <label>Claude 인증</label>
+                            <select
+                                value={claudeAuthMode}
+                                onChange={(e) => onClaudeAuthChange(e.target.value as ClaudeAuthMode)}
+                            >
+                                <option value="api_key" disabled={!hasKey('claude')}>
+                                    API 키{!hasKey('claude') ? ' (없음)' : ''}
+                                </option>
+                                <option value="subscription" disabled={!subClaude}>
+                                    구독 로그인{!subClaude ? ' (미감지)' : ''}
+                                </option>
+                            </select>
+                        </div>
+                    )}
 
                     <ModeSelector mode={mode} onChange={onModeChange} />
 

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -67,11 +67,13 @@ export function AIPanel({
 
     // 구독(Claude Code / Codex) 로그인 감지 — mount 1회.
     const [subClaude, setSubClaude] = useState(false);
+    const [subCodex, setSubCodex] = useState(false);
     useEffect(() => {
         let cancelled = false;
         detectSubscriptionLogins().then((s) => {
             if (cancelled) return;
             setSubClaude(s.claude);
+            setSubCodex(s.codex);
             // Claude API 키가 없고 구독만 있으면 인증 소스를 구독으로 자동 설정.
             if (s.claude && !hasKey('claude') && claudeAuthMode !== 'subscription') {
                 onClaudeAuthChange('subscription');
@@ -135,6 +137,7 @@ export function AIPanel({
                         selected={selectedModel}
                         onChange={onSelectedModelChange}
                         claudeSubscription={subClaude}
+                        codexSubscription={subCodex}
                     />
 
                     {selectedModel === 'claude' && (

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -29,7 +29,6 @@ export function SettingsModal({ visible, onClose }: SettingsModalProps) {
                         <X size={18} />
                     </button>
                 </div>
-                <p className="settings-modal-note">입력한 정보는 본인 컴퓨터에만 저장됩니다.</p>
                 <div className="settings-modal-body">
                     <SettingsView onDone={onClose} />
                 </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import {
     Mic, ScanText, Settings,
     FileCode, FileText, AlignVerticalSpaceAround,
     Network, Share2, VectorSquare, ChartBarStacked,
+    Presentation,
 } from 'lucide-react';
 import * as gdriveService from '../services/gdriveService';
 import type { RecentFile } from '../hooks/useRecentFiles';
@@ -98,6 +99,8 @@ interface ToolbarProps {
     onSaveFile: () => void;
     onSaveFileAs: () => void;
     onExportPdf: () => void;
+    onExportPptx: () => void;
+    aiLayoutAvailable: boolean;
     onShowTutorial: () => void;
     onFontSizeChange: (delta: number) => void;
     onFontSizeReset: () => void;
@@ -134,6 +137,8 @@ export function Toolbar({
     onSaveFile,
     onSaveFileAs,
     onExportPdf,
+    onExportPptx,
+    aiLayoutAvailable,
     onShowTutorial,
     onFontSizeChange,
     onFontSizeReset,
@@ -235,6 +240,15 @@ export function Toolbar({
                                 <FileDown size={14} strokeWidth={1.5} />
                                 <span>Export as PDF…</span>
                                 <span className="dropdown-shortcut">⌘P</span>
+                            </button>
+                            <button
+                                className="dropdown-item"
+                                onClick={() => handleMenuItem(onExportPptx)}
+                                disabled={!aiLayoutAvailable}
+                                title={!aiLayoutAvailable ? 'Settings 에서 Claude 또는 Gemini API 키 등록 필요' : ''}
+                            >
+                                <Presentation size={14} strokeWidth={1.5} />
+                                <span>Export as PPTX…</span>
                             </button>
                             {driveAvailable && (
                                 <>

--- a/src/components/ai/LlmSelector.tsx
+++ b/src/components/ai/LlmSelector.tsx
@@ -1,40 +1,35 @@
 /**
- * 공통 LLM 모델 selector — AIPanel 상단. 회의록 모드에서만 활성.
+ * 공통 LLM 모델 selector — AIPanel 상단. 모든 AI 모드(문법/번역/개선/구조화/회의록)에서 활성.
  */
 
-import { AIMode } from '../../types/ai';
 import type { Provider } from '../../services/secureStorage';
 import { hasKey } from '../../services/secureStorage';
 
 interface LlmSelectorProps {
-    mode: AIMode;
     selected: Provider;
     onChange: (p: Provider) => void;
+    /** Claude Code 구독 로그인 감지 여부 — API 키가 없어도 Claude 선택을 허용. */
+    claudeSubscription?: boolean;
 }
 
-export function LlmSelector({ mode, selected, onChange }: LlmSelectorProps) {
+export function LlmSelector({ selected, onChange, claudeSubscription }: LlmSelectorProps) {
     const geminiAvailable = hasKey('gemini');
-    const claudeAvailable = hasKey('claude');
-    const openaiAvailable = hasKey('openai');
-    const enabled = mode === 'meeting-notes';
+    const claudeKey = hasKey('claude');
+    // 구독(Claude Code) 로그인이 있으면 API 키 없이도 Claude 사용 가능.
+    const claudeAvailable = claudeKey || !!claudeSubscription;
     return (
-        <div
-            className="ai-llm-select"
-            title={enabled ? '회의록 생성에 사용할 LLM 선택' : '문법/번역/문서 개선은 항상 Gemini 사용'}
-        >
-            <select
-                value={selected}
-                onChange={(e) => onChange(e.target.value as Provider)}
-                disabled={!enabled}
-            >
+        <div className="ai-llm-select" title="AI 작업에 사용할 LLM 선택">
+            <select value={selected} onChange={(e) => onChange(e.target.value as Provider)}>
                 <option value="gemini" disabled={!geminiAvailable}>
                     Gemini 3.1 Pro{!geminiAvailable && ' (키 필요)'}
                 </option>
                 <option value="claude" disabled={!claudeAvailable}>
-                    Claude Sonnet 4.6{!claudeAvailable && ' (키 필요)'}
+                    Claude Sonnet 4.6
+                    {!claudeAvailable ? ' (키/구독 필요)' : !claudeKey ? ' (구독)' : ''}
                 </option>
-                <option value="openai" disabled={!openaiAvailable}>
-                    OpenAI{!openaiAvailable && ' (키 필요)'}
+                {/* OpenAI 호출 경로 미구현(Codex 구독 연동은 다음 Phase) — 선택 비활성. */}
+                <option value="openai" disabled>
+                    OpenAI (준비 중)
                 </option>
             </select>
         </div>

--- a/src/components/ai/LlmSelector.tsx
+++ b/src/components/ai/LlmSelector.tsx
@@ -10,13 +10,17 @@ interface LlmSelectorProps {
     onChange: (p: Provider) => void;
     /** Claude Code 구독 로그인 감지 여부 — API 키가 없어도 Claude 선택을 허용. */
     claudeSubscription?: boolean;
+    /** Codex(ChatGPT) 구독 로그인 감지 여부 — 구독으로만 호출(API 키 경로 없음). */
+    codexSubscription?: boolean;
 }
 
-export function LlmSelector({ selected, onChange, claudeSubscription }: LlmSelectorProps) {
+export function LlmSelector({ selected, onChange, claudeSubscription, codexSubscription }: LlmSelectorProps) {
     const geminiAvailable = hasKey('gemini');
     const claudeKey = hasKey('claude');
     // 구독(Claude Code) 로그인이 있으면 API 키 없이도 Claude 사용 가능.
     const claudeAvailable = claudeKey || !!claudeSubscription;
+    // ChatGPT 는 Codex 구독 로그인으로만 호출(API 키 경로 미구현).
+    const codexAvailable = !!codexSubscription;
     return (
         <div className="ai-llm-select" title="AI 작업에 사용할 LLM 선택">
             <select value={selected} onChange={(e) => onChange(e.target.value as Provider)}>
@@ -27,9 +31,8 @@ export function LlmSelector({ selected, onChange, claudeSubscription }: LlmSelec
                     Claude Sonnet 4.6
                     {!claudeAvailable ? ' (키/구독 필요)' : !claudeKey ? ' (구독)' : ''}
                 </option>
-                {/* OpenAI 호출 경로 미구현(Codex 구독 연동은 다음 Phase) — 선택 비활성. */}
-                <option value="openai" disabled>
-                    OpenAI (준비 중)
+                <option value="openai" disabled={!codexAvailable}>
+                    ChatGPT (구독){!codexAvailable ? ' (구독 필요)' : ''}
                 </option>
             </select>
         </div>

--- a/src/components/convert/AIModelPicker.tsx
+++ b/src/components/convert/AIModelPicker.tsx
@@ -1,0 +1,105 @@
+/**
+ * 전역 AI 모델 선택 — 회사 → 인증 → 모델 단계형.
+ * 카탈로그(aiModelConfig)를 그대로 읽어 렌더하므로 회사가 늘면 자동 확장된다.
+ * 인증 단계는 회사가 2가지 이상 인증을 지원할 때만 노출(Gemini 는 API 고정 → 숨김).
+ */
+
+import { useEffect, useState } from 'react';
+import {
+    AI_CATALOG,
+    AICompany,
+    AIAuthMode,
+    AIModelSelection,
+    getAIModelSelection,
+    setAIModelSelection,
+    selectCompany,
+    selectAuth,
+    normalizeSelection,
+} from '../../services/aiModelConfig';
+import { detectSubscriptionLogins, SubscriptionStatus } from '../../services/subscriptionService';
+
+export function AIModelPicker() {
+    const [sel, setSel] = useState<AIModelSelection>(getAIModelSelection());
+    const [sub, setSub] = useState<SubscriptionStatus>({ claude: false, codex: false });
+
+    useEffect(() => {
+        detectSubscriptionLogins().then(setSub);
+    }, []);
+
+    const apply = (next: Partial<AIModelSelection>) => {
+        const n = normalizeSelection({ ...sel, ...next });
+        setSel(n);
+        setAIModelSelection(n);
+    };
+
+    const def = AI_CATALOG[sel.company];
+    const models = def.models[sel.auth] ?? [];
+
+    // 구독 인증 가용성 — 해당 회사의 CLI 로그인이 감지돼야 활성.
+    const subAvailable = (company: AICompany): boolean =>
+        company === 'claude' ? sub.claude : company === 'openai' ? sub.codex : false;
+    const authEnabled = (auth: AIAuthMode): boolean =>
+        auth === 'api_key' ? true : subAvailable(sel.company);
+
+    const authLabel = (auth: AIAuthMode): string => (auth === 'api_key' ? 'API 키' : '구독');
+
+    return (
+        <section className="convert-settings-section">
+            <label>AI 모델</label>
+
+            {/* 회사 */}
+            <div className="ai-model-row">
+                <span className="ai-model-key">회사</span>
+                <div className="ai-seg">
+                    {(Object.keys(AI_CATALOG) as AICompany[]).map((key) => (
+                        <button
+                            key={key}
+                            type="button"
+                            className={`ai-seg-btn${sel.company === key ? ' active' : ''}`}
+                            onClick={() => apply(selectCompany(key))}
+                        >
+                            {AI_CATALOG[key].label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* 인증 — 둘 이상 지원하는 회사에서만 노출 */}
+            {def.auths.length > 1 && (
+                <div className="ai-model-row">
+                    <span className="ai-model-key">인증</span>
+                    <div className="ai-seg">
+                        {def.auths.map((auth) => (
+                            <button
+                                key={auth}
+                                type="button"
+                                className={`ai-seg-btn${sel.auth === auth ? ' active' : ''}`}
+                                disabled={!authEnabled(auth)}
+                                onClick={() => apply(selectAuth(sel.company, auth))}
+                            >
+                                {authLabel(auth)}
+                                {auth === 'subscription' && !subAvailable(sel.company) ? ' (미연결)' : ''}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* 모델 */}
+            <div className="ai-model-row">
+                <span className="ai-model-key">모델</span>
+                <select value={sel.model} onChange={(e) => apply({ model: e.target.value })}>
+                    {models.map((m) => (
+                        <option key={m.id} value={m.id}>
+                            {m.label}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <p className="convert-key-note">
+                모든 AI 작업(문법·번역·개선·구조화·회의록)에 이 모델이 사용됩니다.
+            </p>
+        </section>
+    );
+}

--- a/src/components/convert/LanShareSection.tsx
+++ b/src/components/convert/LanShareSection.tsx
@@ -122,11 +122,11 @@ export function LanShareSection() {
     return (
         <section className="convert-settings-section">
             <label>
-                아이폰 연결 — LAN 파일 공유{' '}
+                아이폰 연결{' '}
                 {info.running ? (
                     <span className="badge badge-ok">연결됨</span>
                 ) : (
-                    <span className="badge badge-warn">꺼짐</span>
+                    <span className="badge badge-warn">연결 안됨</span>
                 )}
             </label>
 
@@ -166,7 +166,7 @@ export function LanShareSection() {
                 ) : (
                     <button className="primary" onClick={handleConnect} disabled={busy}>
                         <Wifi size={14} />
-                        <span>{busy ? '연결 중...' : '연결 (Connect)'}</span>
+                        <span>{busy ? '연결 중...' : '연결하기'}</span>
                     </button>
                 )}
             </div>
@@ -225,9 +225,8 @@ export function LanShareSection() {
             )}
 
             <p className="convert-key-note">
-                지정한 <strong>폴더 하나</strong>의 마크다운만 노출되며, PIN 이 있어야 접근됩니다.
-                <strong> 신뢰하는 집 Wi-Fi 에서만</strong> 사용하고, 끝나면 연결을 해제하세요.
-                카페·회사 등 공유 네트워크에서는 켜두지 마세요.
+                신뢰할 수 있는 네트워크에서만 사용하세요. 공용 또는 공유 네트워크에서는 보안상
+                위험이 있을 수 있습니다.
             </p>
 
             {error && <p className="drive-error">{error}</p>}

--- a/src/components/convert/NotesTab.tsx
+++ b/src/components/convert/NotesTab.tsx
@@ -6,8 +6,13 @@
 
 import { useEffect, useState } from 'react';
 import { Upload, Play, RotateCcw } from 'lucide-react';
-import { DetailLevel, NotesJobResult, NotesProvider, TemplateInfo } from '../../types/converter';
+import { ClaudeAuthMode, DetailLevel, NotesJobResult, NotesProvider, TemplateInfo } from '../../types/converter';
 import { useConverter } from '../../hooks/useConverter';
+import {
+    detectSubscriptionLogins,
+    getClaudeAuthMode,
+    setClaudeAuthMode,
+} from '../../services/subscriptionService';
 import { ProgressPanel } from './ProgressPanel';
 import { ResultCard } from './ResultCard';
 import { pickTextFile } from './pickFile';
@@ -29,8 +34,31 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
     const [template, setTemplate] = useState('general');
     const [detail, setDetail] = useState<DetailLevel>('standard');
     const [provider, setProvider] = useState<NotesProvider>('claude');
+    const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthMode>(getClaudeAuthMode());
+    const [claudeLoggedIn, setClaudeLoggedIn] = useState(false);
     const [templates, setTemplates] = useState<TemplateInfo[]>([]);
     const [result, setResult] = useState<NotesJobResult | null>(null);
+
+    // 구독(Claude Code) 로그인 감지 — mount 1회.
+    useEffect(() => {
+        let cancelled = false;
+        detectSubscriptionLogins().then((s) => {
+            if (cancelled) return;
+            setClaudeLoggedIn(s.claude);
+            // 저장된 기본값이 구독인데 로그인이 사라졌으면 API 키로 안전 복귀.
+            if (!s.claude && getClaudeAuthMode() === 'subscription') {
+                setClaudeAuth('api_key');
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const updateClaudeAuth = (mode: ClaudeAuthMode) => {
+        setClaudeAuth(mode);
+        setClaudeAuthMode(mode);
+    };
 
     useEffect(() => {
         let cancelled = false;
@@ -97,6 +125,7 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
             source,
             detail,
             provider,
+            claudeAuth: provider === 'claude' ? claudeAuth : undefined,
         });
         if (r) setResult(r);
     };
@@ -178,6 +207,40 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
                         </label>
                     </div>
                 </div>
+
+                {provider === 'claude' && (
+                    <div className="convert-option-field">
+                        <label>Claude 인증</label>
+                        <div className="convert-provider-row">
+                            <label
+                                className={`convert-provider${claudeAuth === 'api_key' ? ' active' : ''}`}
+                            >
+                                <input
+                                    type="radio"
+                                    checked={claudeAuth === 'api_key'}
+                                    onChange={() => updateClaudeAuth('api_key')}
+                                />
+                                API 키
+                            </label>
+                            <label
+                                className={`convert-provider${claudeAuth === 'subscription' ? ' active' : ''}${!claudeLoggedIn ? ' disabled' : ''}`}
+                            >
+                                <input
+                                    type="radio"
+                                    checked={claudeAuth === 'subscription'}
+                                    disabled={!claudeLoggedIn}
+                                    onChange={() => updateClaudeAuth('subscription')}
+                                />
+                                구독 로그인
+                            </label>
+                        </div>
+                        {!claudeLoggedIn && (
+                            <p className="convert-key-note">
+                                구독으로 쓰려면 터미널에서 <code>claude</code> 로그인이 필요합니다.
+                            </p>
+                        )}
+                    </div>
+                )}
             </div>
 
             <div className="convert-actions">

--- a/src/components/convert/NotesTab.tsx
+++ b/src/components/convert/NotesTab.tsx
@@ -6,13 +6,9 @@
 
 import { useEffect, useState } from 'react';
 import { Upload, Play, RotateCcw } from 'lucide-react';
-import { ClaudeAuthMode, DetailLevel, NotesJobResult, NotesProvider, TemplateInfo } from '../../types/converter';
+import { DetailLevel, NotesJobResult, TemplateInfo } from '../../types/converter';
 import { useConverter } from '../../hooks/useConverter';
-import {
-    detectSubscriptionLogins,
-    getClaudeAuthMode,
-    setClaudeAuthMode,
-} from '../../services/subscriptionService';
+import { getAIModelSelection } from '../../services/aiModelConfig';
 import { ProgressPanel } from './ProgressPanel';
 import { ResultCard } from './ResultCard';
 import { pickTextFile } from './pickFile';
@@ -33,32 +29,8 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
     const [source, setSource] = useState('paste.md');
     const [template, setTemplate] = useState('general');
     const [detail, setDetail] = useState<DetailLevel>('standard');
-    const [provider, setProvider] = useState<NotesProvider>('claude');
-    const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthMode>(getClaudeAuthMode());
-    const [claudeLoggedIn, setClaudeLoggedIn] = useState(false);
     const [templates, setTemplates] = useState<TemplateInfo[]>([]);
     const [result, setResult] = useState<NotesJobResult | null>(null);
-
-    // 구독(Claude Code) 로그인 감지 — mount 1회.
-    useEffect(() => {
-        let cancelled = false;
-        detectSubscriptionLogins().then((s) => {
-            if (cancelled) return;
-            setClaudeLoggedIn(s.claude);
-            // 저장된 기본값이 구독인데 로그인이 사라졌으면 API 키로 안전 복귀.
-            if (!s.claude && getClaudeAuthMode() === 'subscription') {
-                setClaudeAuth('api_key');
-            }
-        });
-        return () => {
-            cancelled = true;
-        };
-    }, []);
-
-    const updateClaudeAuth = (mode: ClaudeAuthMode) => {
-        setClaudeAuth(mode);
-        setClaudeAuthMode(mode);
-    };
 
     useEffect(() => {
         let cancelled = false;
@@ -119,13 +91,15 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
     const handleRun = async () => {
         if (transcript.trim().length < MIN_CHARS) return;
         setResult(null);
+        const sel = getAIModelSelection();
         const r = await converter.runNotes({
             transcript,
             template,
             source,
             detail,
-            provider,
-            claudeAuth: provider === 'claude' ? claudeAuth : undefined,
+            company: sel.company,
+            auth: sel.auth,
+            model: sel.model,
         });
         if (r) setResult(r);
     };
@@ -187,60 +161,11 @@ export function NotesTab({ converter, droppedFile, onConsumeDropped, onOpenResul
                 </div>
 
                 <div className="convert-option-field">
-                    <label>LLM 모델</label>
-                    <div className="convert-provider-row">
-                        <label className={`convert-provider${provider === 'claude' ? ' active' : ''}`}>
-                            <input
-                                type="radio"
-                                checked={provider === 'claude'}
-                                onChange={() => setProvider('claude')}
-                            />
-                            Claude Sonnet 4.6
-                        </label>
-                        <label className={`convert-provider${provider === 'gemini' ? ' active' : ''}`}>
-                            <input
-                                type="radio"
-                                checked={provider === 'gemini'}
-                                onChange={() => setProvider('gemini')}
-                            />
-                            Gemini 3.1 Pro
-                        </label>
-                    </div>
+                    <label>모델</label>
+                    <p className="convert-key-note" style={{ margin: 0 }}>
+                        설정 &gt; 기본 설정의 AI 모델을 사용합니다.
+                    </p>
                 </div>
-
-                {provider === 'claude' && (
-                    <div className="convert-option-field">
-                        <label>Claude 인증</label>
-                        <div className="convert-provider-row">
-                            <label
-                                className={`convert-provider${claudeAuth === 'api_key' ? ' active' : ''}`}
-                            >
-                                <input
-                                    type="radio"
-                                    checked={claudeAuth === 'api_key'}
-                                    onChange={() => updateClaudeAuth('api_key')}
-                                />
-                                API 키
-                            </label>
-                            <label
-                                className={`convert-provider${claudeAuth === 'subscription' ? ' active' : ''}${!claudeLoggedIn ? ' disabled' : ''}`}
-                            >
-                                <input
-                                    type="radio"
-                                    checked={claudeAuth === 'subscription'}
-                                    disabled={!claudeLoggedIn}
-                                    onChange={() => updateClaudeAuth('subscription')}
-                                />
-                                구독 로그인
-                            </label>
-                        </div>
-                        {!claudeLoggedIn && (
-                            <p className="convert-key-note">
-                                구독으로 쓰려면 터미널에서 <code>claude</code> 로그인이 필요합니다.
-                            </p>
-                        )}
-                    </div>
-                )}
             </div>
 
             <div className="convert-actions">

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useState } from 'react';
 import { Eye, EyeOff, Trash2, Cloud, CloudOff } from 'lucide-react';
 import { getKey, hasKey, Provider, removeKey, updateCacheAfterBatch } from '../../services/secureStorage';
+import { detectSubscriptionLogins, SubscriptionStatus } from '../../services/subscriptionService';
 import * as gdrive from '../../services/gdriveService';
 import * as secretsBatch from '../../services/secretsService';
 import { confirmAction } from '../../services/dialogService';
@@ -131,6 +132,9 @@ export function SettingsView({ onDone }: SettingsViewProps) {
     const [memoryOrig, setMemoryOrig] = useState('');
     const [memorySaving, setMemorySaving] = useState(false);
 
+    // 구독 연동 — 로컬 Claude Code / Codex CLI 로그인 감지 현황
+    const [subStatus, setSubStatus] = useState<SubscriptionStatus>({ claude: false, codex: false });
+
     useEffect(() => {
         setValues({
             gemini: getKey('gemini') || '',
@@ -163,6 +167,7 @@ export function SettingsView({ onDone }: SettingsViewProps) {
             const mem = await loadUserMemory();
             setUserMemory(mem);
             setMemoryOrig(mem);
+            setSubStatus(await detectSubscriptionLogins());
         })();
     }, []);
 
@@ -423,6 +428,28 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     </section>
                 );
             })}
+
+            {/* === 구독 연동 (Claude / ChatGPT — 로컬 CLI 토큰 재사용) === */}
+            <section className="convert-settings-section">
+                <label>구독 연동 (Claude · ChatGPT)</label>
+                <p className="convert-key-note">
+                    <strong>Claude Code</strong>{' '}
+                    <span className={subStatus.claude ? 'badge badge-ok' : 'badge badge-warn'}>
+                        {subStatus.claude ? '로그인 감지됨' : '미감지'}
+                    </span>
+                    {'   ·   '}
+                    <strong>ChatGPT (Codex)</strong>{' '}
+                    <span className={subStatus.codex ? 'badge badge-ok' : 'badge badge-warn'}>
+                        {subStatus.codex ? '로그인 감지됨' : '미감지'}
+                    </span>
+                </p>
+                <p className="convert-key-note">
+                    터미널에서 <code>claude</code> 로 로그인하면 API 키 없이 본인 구독으로 회의록을 생성할 수
+                    있습니다 (회의록 탭에서 Claude 선택 → <strong>구독 로그인</strong>). ChatGPT(Codex) 호출
+                    연동은 다음 단계에서 추가됩니다. 본인 머신·본인 구독 전용이며, 비공식 경로라 작동이
+                    보장되지 않습니다.
+                </p>
+            </section>
 
             {/* === 내 정보 (AI 컨텍스트, #15) === */}
             <section className="convert-settings-section">

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -18,6 +18,7 @@ import * as secretsBatch from '../../services/secretsService';
 import { confirmAction } from '../../services/dialogService';
 import { isTauri } from '../../services/platform';
 import { LanShareSection } from './LanShareSection';
+import { AIModelPicker } from './AIModelPicker';
 import { loadUserMemory, saveUserMemory, USER_MEMORY_MAX_CHARS } from '../../services/userMemory';
 import {
     ValidationResult,
@@ -43,14 +44,14 @@ interface KeySpec {
 const KEY_SPECS: KeySpec[] = [
     {
         provider: 'gemini',
-        label: 'Google Gemini API 키',
+        label: 'Gemini API 키',
         placeholder: 'AIza...',
         issueUrl: 'https://aistudio.google.com/apikey',
         issueLabel: 'aistudio.google.com/apikey',
     },
     {
         provider: 'claude',
-        label: 'Anthropic Claude API 키',
+        label: 'Claude API 키',
         placeholder: 'sk-ant-...',
         issueUrl: 'https://console.anthropic.com/settings/keys',
         issueLabel: 'console.anthropic.com/settings/keys',
@@ -64,12 +65,16 @@ const KEY_SPECS: KeySpec[] = [
     },
     {
         provider: 'pyannoteai',
-        label: 'pyannote.ai API 키 (화자 분리)',
+        label: 'pyannote.ai API 키',
         placeholder: 'sk_...',
         issueUrl: 'https://dashboard.pyannote.ai',
         issueLabel: 'dashboard.pyannote.ai',
     },
 ];
+
+type SettingsTab = 'basic' | 'ai' | 'extra';
+/** AI 설정 탭에 노출할 API 키 (나머지 키는 추가 기능 탭). */
+const AI_PROVIDERS: Provider[] = ['gemini', 'claude', 'openai'];
 
 function maskClientId(id: string): string {
     if (id.length <= 12) return id;
@@ -130,10 +135,12 @@ export function SettingsView({ onDone }: SettingsViewProps) {
     // 사용자 메모리(#15) — AI system prompt 주입용 "내 정보"
     const [userMemory, setUserMemory] = useState('');
     const [memoryOrig, setMemoryOrig] = useState('');
-    const [memorySaving, setMemorySaving] = useState(false);
 
     // 구독 연동 — 로컬 Claude Code / Codex CLI 로그인 감지 현황
     const [subStatus, setSubStatus] = useState<SubscriptionStatus>({ claude: false, codex: false });
+
+    // 설정 탭 (기본 / AI / 추가 기능). AI 가 가장 자주 쓰이므로 기본 진입 탭.
+    const [activeTab, setActiveTab] = useState<SettingsTab>('ai');
 
     useEffect(() => {
         setValues({
@@ -170,22 +177,6 @@ export function SettingsView({ onDone }: SettingsViewProps) {
             setSubStatus(await detectSubscriptionLogins());
         })();
     }, []);
-
-    // 사용자 메모리(#15) 저장 — API 키 저장과 독립.
-    const handleSaveMemory = async () => {
-        setMemorySaving(true);
-        try {
-            await saveUserMemory(userMemory);
-            setMemoryOrig(userMemory);
-        } catch (e) {
-            await confirmAction(
-                `내 정보 저장에 실패했습니다: ${e instanceof Error ? e.message : String(e)}`,
-                { title: '저장 실패', kind: 'error' },
-            );
-        } finally {
-            setMemorySaving(false);
-        }
-    };
 
     // ─── 입력 빠른 초기화 (휴지통) ───
     const handleClearKeyInput = async (provider: Provider) => {
@@ -324,6 +315,12 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                 }
             }
 
+            // 나의 정보(옵션) — 변경 시 함께 저장(키 변경 여부와 독립).
+            if (userMemory.trim() !== memoryOrig.trim()) {
+                await saveUserMemory(userMemory);
+                setMemoryOrig(userMemory);
+            }
+
             // 3) 변경된 키 검증 — 네트워크 ping (Keychain 미접근)
             for (const p of changedKeys) {
                 setValidation((v) => ({ ...v, [p]: null }));
@@ -384,129 +381,163 @@ export function SettingsView({ onDone }: SettingsViewProps) {
         }
     };
 
-    return (
-        <div className="convert-settings">
-            {KEY_SPECS.map((spec) => {
-                const badge = statusBadge(stored[spec.provider], validation[spec.provider]);
-                return (
-                    <section key={spec.provider} className="convert-settings-section">
-                        <label>
-                            {spec.label} {badge && <span className={badge.cls}>{badge.text}</span>}
-                        </label>
-                        <div className="convert-key-row">
-                            <input
-                                type={show[spec.provider] ? 'text' : 'password'}
-                                placeholder={spec.placeholder}
-                                value={values[spec.provider]}
-                                onChange={(e) =>
-                                    setValues((v) => ({ ...v, [spec.provider]: e.target.value }))
-                                }
-                            />
-                            <button
-                                onClick={() =>
-                                    setShow((s) => ({ ...s, [spec.provider]: !s[spec.provider] }))
-                                }
-                                title="표시/숨김"
-                            >
-                                {show[spec.provider] ? <EyeOff size={14} /> : <Eye size={14} />}
-                            </button>
-                            <button
-                                onClick={() => handleClearKeyInput(spec.provider)}
-                                className="danger"
-                                disabled={!stored[spec.provider]}
-                                title="삭제"
-                            >
-                                <Trash2 size={14} />
-                            </button>
-                        </div>
-                        <p className="convert-key-note">
-                            발급:{' '}
-                            <a href={spec.issueUrl} target="_blank" rel="noopener noreferrer">
-                                {spec.issueLabel}
-                            </a>
-                        </p>
-                    </section>
-                );
-            })}
-
-            {/* === 구독 연동 (Claude / ChatGPT — 로컬 CLI 토큰 재사용) === */}
-            <section className="convert-settings-section">
-                <label>구독 연동 (Claude · ChatGPT)</label>
-                <p className="convert-key-note">
-                    <strong>Claude Code</strong>{' '}
-                    <span className={subStatus.claude ? 'badge badge-ok' : 'badge badge-warn'}>
-                        {subStatus.claude ? '로그인 감지됨' : '미감지'}
-                    </span>
-                    {'   ·   '}
-                    <strong>ChatGPT (Codex)</strong>{' '}
-                    <span className={subStatus.codex ? 'badge badge-ok' : 'badge badge-warn'}>
-                        {subStatus.codex ? '로그인 감지됨' : '미감지'}
-                    </span>
-                </p>
-                <p className="convert-key-note">
-                    터미널에서 <code>claude</code> 로 로그인하면 API 키 없이 본인 구독으로 회의록을 생성할 수
-                    있습니다 (회의록 탭에서 Claude 선택 → <strong>구독 로그인</strong>). ChatGPT(Codex) 호출
-                    연동은 다음 단계에서 추가됩니다. 본인 머신·본인 구독 전용이며, 비공식 경로라 작동이
-                    보장되지 않습니다.
-                </p>
-            </section>
-
-            {/* === 내 정보 (AI 컨텍스트, #15) === */}
-            <section className="convert-settings-section">
+    const renderKeySpec = (spec: KeySpec) => {
+        const badge = statusBadge(stored[spec.provider], validation[spec.provider]);
+        return (
+            <section key={spec.provider} className="convert-settings-section">
                 <label>
-                    내 정보 (AI 컨텍스트){' '}
-                    {memoryOrig && <span className="badge badge-ok">설정됨</span>}
-                </label>
-                <textarea
-                    className="convert-memory-input"
-                    placeholder="예: 한국어 사용자, B2B SaaS 분야, 존댓말 선호. 자주 쓰는 용어·약어 등"
-                    value={userMemory}
-                    rows={4}
-                    maxLength={USER_MEMORY_MAX_CHARS}
-                    onChange={(e) => setUserMemory(e.target.value)}
-                />
-                <p className="convert-key-note">
-                    AI(문법·번역·개선·구조화) 호출 시 참고 정보로 전달됩니다. {userMemory.length}/
-                    {USER_MEMORY_MAX_CHARS}자
-                </p>
-                <button
-                    className="convert-btn primary"
-                    onClick={handleSaveMemory}
-                    disabled={memorySaving || userMemory === memoryOrig}
-                >
-                    {memorySaving ? '저장 중…' : '내 정보 저장'}
-                </button>
-            </section>
-
-            {/* === 로컬 화자분리 (pyannote, 무료/오프라인) === */}
-            <section className="convert-settings-section">
-                <label>
-                    로컬 화자분리 — Python 경로{' '}
-                    {diarPythonOrig && <span className="badge badge-ok">설정됨</span>}
+                    {spec.label} {badge && <span className={badge.cls}>{badge.text}</span>}
                 </label>
                 <div className="convert-key-row">
                     <input
-                        type="text"
-                        placeholder="/path/to/venv/bin/python3 (pyannote.audio 설치된 Python)"
-                        value={diarPython}
-                        onChange={(e) => setDiarPython(e.target.value)}
+                        type={show[spec.provider] ? 'text' : 'password'}
+                        placeholder={spec.placeholder}
+                        value={values[spec.provider]}
+                        onChange={(e) => setValues((v) => ({ ...v, [spec.provider]: e.target.value }))}
                     />
                     <button
-                        onClick={() => setDiarPython('')}
+                        onClick={() => setShow((s) => ({ ...s, [spec.provider]: !s[spec.provider] }))}
+                        title="표시/숨김"
+                    >
+                        {show[spec.provider] ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                    <button
+                        onClick={() => handleClearKeyInput(spec.provider)}
                         className="danger"
-                        disabled={!diarPython}
-                        title="입력 비우기"
+                        disabled={!stored[spec.provider]}
+                        title="삭제"
                     >
                         <Trash2 size={14} />
                     </button>
                 </div>
                 <p className="convert-key-note">
-                    입력하면 무료·오프라인 <strong>로컬 pyannote</strong> 로 화자 분리 (pyannote.ai 키보다 우선).
-                    해당 Python 에 <code>pyannote.audio</code> 가 설치돼 있어야 합니다. 비우면 클라우드 키 또는 기본 동작.
+                    발급:{' '}
+                    <a href={spec.issueUrl} target="_blank" rel="noopener noreferrer">
+                        {spec.issueLabel}
+                    </a>
                 </p>
             </section>
+        );
+    };
 
-            {/* === Google Drive === */}
+    return (
+        <div className="convert-settings">
+            <div className="settings-tabs">
+                <button
+                    type="button"
+                    className={`settings-tab${activeTab === 'basic' ? ' active' : ''}`}
+                    onClick={() => setActiveTab('basic')}
+                >
+                    기본 설정
+                </button>
+                <button
+                    type="button"
+                    className={`settings-tab${activeTab === 'ai' ? ' active' : ''}`}
+                    onClick={() => setActiveTab('ai')}
+                >
+                    AI 설정
+                </button>
+                <button
+                    type="button"
+                    className={`settings-tab${activeTab === 'extra' ? ' active' : ''}`}
+                    onClick={() => setActiveTab('extra')}
+                >
+                    추가 설정
+                </button>
+            </div>
+
+            {activeTab === 'ai' && (
+                <>
+                    {KEY_SPECS.filter((s) => AI_PROVIDERS.includes(s.provider)).map(renderKeySpec)}
+
+            <hr className="settings-divider" />
+
+            {/* === 구독 연동 (Claude / ChatGPT — 로컬 CLI 토큰 재사용) === */}
+            <section className="convert-settings-section">
+                <div className="sub-link-list">
+                    {/* Claude */}
+                    <div className="sub-link-row">
+                        <span className="sub-link-name">Claude 구독 연동</span>
+                        <span className={subStatus.claude ? 'badge badge-ok' : 'badge badge-warn'}>
+                            {subStatus.claude
+                                ? `${subStatus.claudePlan ? subStatus.claudePlan + ' · ' : ''}연결됨`
+                                : '연결 안 됨'}
+                        </span>
+                    </div>
+                    {!subStatus.claude && (
+                        <p className="convert-key-note sub-link-hint">
+                            연결하려면 터미널에서 <code>claude</code> 로 로그인하세요 (
+                            <a href="https://code.claude.com" target="_blank" rel="noopener noreferrer">
+                                Claude Code 설치 안내
+                            </a>
+                            ).
+                        </p>
+                    )}
+
+                    {/* ChatGPT (Codex) */}
+                    <div className="sub-link-row">
+                        <span className="sub-link-name">ChatGPT 구독 연동</span>
+                        <span className={subStatus.codex ? 'badge badge-ok' : 'badge badge-warn'}>
+                            {subStatus.codex
+                                ? `${subStatus.codexPlan ? subStatus.codexPlan + ' · ' : ''}연결됨`
+                                : '연결 안 됨'}
+                        </span>
+                    </div>
+                    {!subStatus.codex && (
+                        <p className="convert-key-note sub-link-hint">
+                            연결하려면 터미널에서 <code>codex</code> 로 로그인하세요 (
+                            <a href="https://developers.openai.com/codex" target="_blank" rel="noopener noreferrer">
+                                Codex 설치 안내
+                            </a>
+                            ).
+                        </p>
+                    )}
+
+                    {/* Grok — 구독 연동 준비중. 고정 표시. */}
+                    <div className="sub-link-row">
+                        <span className="sub-link-name">Grok 구독 연동</span>
+                        <span className="badge badge-muted">준비중</span>
+                    </div>
+
+                    {/* Gemini — 구독 연동 미지원(제공사 차단). 고정 표시. */}
+                    <div className="sub-link-row">
+                        <span className="sub-link-name">Gemini 구독 연동</span>
+                        <span className="badge badge-muted">지원 안함</span>
+                    </div>
+                </div>
+
+                <p className="convert-key-note">
+                    현재 이용 중인 AI 구독 플랜과 연동할 수 있습니다. 단, 제공사 정책에 따라 연동이 중단될
+                    수 있습니다.
+                </p>
+            </section>
+                </>
+            )}
+
+            {activeTab === 'extra' && (
+                <>
+                    {/* === 나의 정보 (AI 컨텍스트) — 추가 설정 맨 위 === */}
+                    <section className="convert-settings-section">
+                        <label>
+                            나의 정보 (옵션){' '}
+                            {memoryOrig && <span className="badge badge-ok">설정됨</span>}
+                        </label>
+                        <textarea
+                            className="convert-memory-input"
+                            placeholder="예: 한국어 사용자, B2B SaaS 분야, 존댓말 선호. 자주 쓰는 용어·약어 등"
+                            value={userMemory}
+                            rows={4}
+                            maxLength={USER_MEMORY_MAX_CHARS}
+                            onChange={(e) => setUserMemory(e.target.value)}
+                        />
+                        <p className="convert-key-note">
+                            {userMemory.length}/{USER_MEMORY_MAX_CHARS}자
+                        </p>
+                    </section>
+
+                    <hr className="settings-divider" />
+
+                    {/* === Google Drive === */}
             <section className="convert-settings-section drive-section">
                 <label>
                     Google Drive 연동
@@ -637,8 +668,58 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                 {driveError && <p className="drive-error">{driveError}</p>}
             </section>
 
-            {/* === 아이폰 연결 (LAN 파일 공유) — 데스크탑 앱 전용 === */}
-            {isTauri() && <LanShareSection />}
+            <hr className="settings-divider" />
+
+                    {KEY_SPECS.filter((s) => !AI_PROVIDERS.includes(s.provider)).map(renderKeySpec)}
+
+            {/* === pyannote.ai 로컬 설치 경로 === */}
+            <section className="convert-settings-section">
+                <label>
+                    pyannote.ai 로컬 설치 경로{' '}
+                    {diarPythonOrig && <span className="badge badge-ok">설정됨</span>}
+                </label>
+                <div className="convert-key-row">
+                    <input
+                        type="text"
+                        placeholder="/path/to/venv/bin/python3 (pyannote.audio 설치된 Python)"
+                        value={diarPython}
+                        onChange={(e) => setDiarPython(e.target.value)}
+                    />
+                    <button
+                        onClick={() => setDiarPython('')}
+                        className="danger"
+                        disabled={!diarPython}
+                        title="입력 비우기"
+                    >
+                        <Trash2 size={14} />
+                    </button>
+                </div>
+                <p className="convert-key-note">
+                    해당 Python 에 <code>pyannote.audio</code> 가 설치돼 있어야 합니다. 비우면 클라우드 키 또는
+                    기본 동작.
+                </p>
+            </section>
+                </>
+            )}
+
+            {/* === 기본 설정 — AI 모델 + 아이폰 연결 === */}
+            {activeTab === 'basic' && (
+                <>
+                    <AIModelPicker />
+
+                    <hr className="settings-divider" />
+
+                    {isTauri() ? (
+                        <LanShareSection />
+                    ) : (
+                        <section className="convert-settings-section">
+                            <p className="convert-key-note">
+                                아이폰 연결은 데스크탑 앱에서만 사용할 수 있습니다.
+                            </p>
+                        </section>
+                    )}
+                </>
+            )}
 
             {postSaveWarn && <p className="convert-key-note warn">{postSaveWarn}</p>}
 

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -504,6 +504,101 @@
     font-size: 13px;
     margin: 0;
 }
+.settings-tabs {
+    display: flex;
+    gap: 2px;
+    border-bottom: 1px solid var(--border-color, #e5e5e0);
+}
+.settings-tab {
+    padding: 8px 14px;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-secondary);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    margin-bottom: -1px;
+}
+.settings-tab:hover {
+    color: var(--text-primary);
+}
+.settings-tab.active {
+    color: var(--text-primary);
+    border-bottom-color: var(--text-primary);
+}
+/* 섹션 그룹 구분선 (회색 실선) */
+.settings-divider {
+    border: none;
+    border-top: 1px solid var(--border-primary);
+    margin: 2px 0;
+}
+
+/* AI 모델 선택 (회사 → 인증 → 모델 단계형) */
+.ai-model-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.ai-model-key {
+    width: 38px;
+    flex-shrink: 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+.ai-seg {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+.ai-seg-btn {
+    padding: 5px 12px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    cursor: pointer;
+}
+.ai-seg-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--text-primary);
+}
+.ai-seg-btn.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+.ai-seg-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+.ai-model-row select {
+    flex: 1;
+}
+
+/* 구독 연동 — provider 별 행 */
+.sub-link-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.sub-link-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 0;
+}
+.sub-link-name {
+    font-size: 14px;
+    color: var(--text-primary);
+    font-weight: 500;
+}
+.sub-link-hint {
+    margin: -2px 0 4px;
+    padding-left: 2px;
+}
+
 .convert-settings-section {
     display: flex;
     flex-direction: column;
@@ -530,6 +625,10 @@
 .convert-settings-section .badge-warn {
     background: rgba(239, 68, 68, 0.15);
     color: #dc2626;
+}
+.convert-settings-section .badge-muted {
+    background: rgba(120, 120, 120, 0.14);
+    color: var(--text-secondary);
 }
 .convert-key-note.warn {
     color: #dc2626;
@@ -759,8 +858,6 @@
     align-items: center;
     gap: 8px;
     margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px dashed var(--border-primary);
 }
 
 .drive-connect-row button {

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback, useMemo } from 'react';
 import { AIMode, AIResponse, TranslateLanguage } from '../types/ai';
-import { callAI, hasApiKey, getApiKey, setApiKey, removeApiKey, applyDiff } from '../services/aiService';
-import type { ClaudeAuthMode, NotesJobResult } from '../types/converter';
-import type { Provider } from '../services/secureStorage';
-import { getClaudeAuthMode, setClaudeAuthMode as persistClaudeAuthMode } from '../services/subscriptionService';
+import { callAI, hasApiKey, getApiKey, setApiKey, removeApiKey, applyDiff, isAuthError } from '../services/aiService';
+import { getAIModelSelection } from '../services/aiModelConfig';
+import { setValidationStatus } from '../services/apiValidation';
+import type { NotesJobResult } from '../types/converter';
 
 export function useAI() {
     const [mode, setMode] = useState<AIMode>('grammar');
@@ -14,10 +14,6 @@ export function useAI() {
     const [streamingText, setStreamingText] = useState<string>('');
     const [apiKeySet, setApiKeySet] = useState(hasApiKey());
     const [panelVisible, setPanelVisible] = useState(false);
-    // 공통 LLM 모델 선택 — 회의록 모드에서 실제 사용. 그 외 모드는 항상 Gemini.
-    const [selectedModel, setSelectedModel] = useState<Provider>('gemini');
-    // Claude 인증 소스 (API 키 / 구독 OAuth) — localStorage 동기화.
-    const [claudeAuthMode, setClaudeAuthModeState] = useState<ClaudeAuthMode>(getClaudeAuthMode());
     // 회의록 작성 (mode === 'meeting-notes') 전용 옵션/결과
     const [notesTemplate, setNotesTemplate] = useState<string>('general');
     const [notesResult, setNotesResult] = useState<NotesJobResult | null>(null);
@@ -64,11 +60,16 @@ export function useAI() {
                     improveQuality: activeMode === 'improve' ? 'quality' : undefined,
                 },
                 (text) => setStreamingText(text),
-                { provider: selectedModel, claudeAuth: claudeAuthMode },
             );
             setResponse(result);
             return result;
         } catch (err) {
+            // 실제 사용 중 인증 실패(키 무효)면 설정 검증 상태를 invalid 로 갱신(정상→확인 필요).
+            // API 키 인증일 때만 — 구독 인증은 별개(설정의 "연결됨" 표시로 관리).
+            const sel = getAIModelSelection();
+            if (sel.auth === 'api_key' && isAuthError(err)) {
+                setValidationStatus(sel.company, 'invalid');
+            }
             // Tauri invoke 실패는 string 으로 reject(Err(String)) — Error 가 아니라
             // 그대로 두면 fallback 으로 뭉개진다. string 이면 그 원문(HTTP status 등)을 표면화.
             const message =
@@ -82,7 +83,7 @@ export function useAI() {
         } finally {
             setIsLoading(false);
         }
-    }, [mode, language, selectedModel, claudeAuthMode]);
+    }, [mode, language]);
 
     // Accept/Reject individual chunk
     const acceptChunk = useCallback((chunkId: number) => {
@@ -121,11 +122,6 @@ export function useAI() {
         setStreamingText('');
     }, []);
 
-    const setClaudeAuthMode = useCallback((m: ClaudeAuthMode) => {
-        setClaudeAuthModeState(m);
-        persistClaudeAuthMode(m);
-    }, []);
-
     // Build final text from accepted/rejected chunks
     const getFinalText = useCallback((): string | null => {
         if (!response) return null;
@@ -160,8 +156,6 @@ export function useAI() {
         panelVisible,
         allDecided,
         undecidedCount,
-        selectedModel,
-        claudeAuthMode,
         notesTemplate,
         notesResult,
 
@@ -181,8 +175,6 @@ export function useAI() {
         getFinalText,
         setResponse,
         setError,
-        setSelectedModel,
-        setClaudeAuthMode,
         setNotesTemplate,
         setNotesResult,
         setIsLoading,

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -1,8 +1,9 @@
 import { useState, useCallback, useMemo } from 'react';
 import { AIMode, AIResponse, TranslateLanguage } from '../types/ai';
 import { callAI, hasApiKey, getApiKey, setApiKey, removeApiKey, applyDiff } from '../services/aiService';
-import type { NotesJobResult } from '../types/converter';
+import type { ClaudeAuthMode, NotesJobResult } from '../types/converter';
 import type { Provider } from '../services/secureStorage';
+import { getClaudeAuthMode, setClaudeAuthMode as persistClaudeAuthMode } from '../services/subscriptionService';
 
 export function useAI() {
     const [mode, setMode] = useState<AIMode>('grammar');
@@ -15,6 +16,8 @@ export function useAI() {
     const [panelVisible, setPanelVisible] = useState(false);
     // 공통 LLM 모델 선택 — 회의록 모드에서 실제 사용. 그 외 모드는 항상 Gemini.
     const [selectedModel, setSelectedModel] = useState<Provider>('gemini');
+    // Claude 인증 소스 (API 키 / 구독 OAuth) — localStorage 동기화.
+    const [claudeAuthMode, setClaudeAuthModeState] = useState<ClaudeAuthMode>(getClaudeAuthMode());
     // 회의록 작성 (mode === 'meeting-notes') 전용 옵션/결과
     const [notesTemplate, setNotesTemplate] = useState<string>('general');
     const [notesResult, setNotesResult] = useState<NotesJobResult | null>(null);
@@ -61,6 +64,7 @@ export function useAI() {
                     improveQuality: activeMode === 'improve' ? 'quality' : undefined,
                 },
                 (text) => setStreamingText(text),
+                { provider: selectedModel, claudeAuth: claudeAuthMode },
             );
             setResponse(result);
             return result;
@@ -71,7 +75,7 @@ export function useAI() {
         } finally {
             setIsLoading(false);
         }
-    }, [mode, language]);
+    }, [mode, language, selectedModel, claudeAuthMode]);
 
     // Accept/Reject individual chunk
     const acceptChunk = useCallback((chunkId: number) => {
@@ -110,6 +114,11 @@ export function useAI() {
         setStreamingText('');
     }, []);
 
+    const setClaudeAuthMode = useCallback((m: ClaudeAuthMode) => {
+        setClaudeAuthModeState(m);
+        persistClaudeAuthMode(m);
+    }, []);
+
     // Build final text from accepted/rejected chunks
     const getFinalText = useCallback((): string | null => {
         if (!response) return null;
@@ -145,6 +154,7 @@ export function useAI() {
         allDecided,
         undecidedCount,
         selectedModel,
+        claudeAuthMode,
         notesTemplate,
         notesResult,
 
@@ -165,6 +175,7 @@ export function useAI() {
         setResponse,
         setError,
         setSelectedModel,
+        setClaudeAuthMode,
         setNotesTemplate,
         setNotesResult,
         setIsLoading,

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -69,7 +69,14 @@ export function useAI() {
             setResponse(result);
             return result;
         } catch (err) {
-            const message = err instanceof Error ? err.message : 'AI 요청 중 오류가 발생했습니다.';
+            // Tauri invoke 실패는 string 으로 reject(Err(String)) — Error 가 아니라
+            // 그대로 두면 fallback 으로 뭉개진다. string 이면 그 원문(HTTP status 등)을 표면화.
+            const message =
+                err instanceof Error
+                    ? err.message
+                    : typeof err === 'string'
+                        ? err
+                        : 'AI 요청 중 오류가 발생했습니다.';
             setError(message);
             return null;
         } finally {

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -1,0 +1,319 @@
+// Slide[] → .pptx (ArrayBuffer) — 이슈 #6 PPTX 내보내기
+//
+// PptxGenJS 로 네이티브 편집 가능 pptx 를 생성한다. WKWebView 의 blob:// 다운로드
+// 버그(WebKit #216918) 때문에 writeFile()/blob 대신 outputType:'arraybuffer' 로
+// 받아 Rust(save_pptx)가 fs::write 한다.
+//
+// "검정 글씨/흰 배경" 빈약 슬라이드를 피하려고 슬라이드 마스터(테마)를 정의한다.
+
+import PptxGenJS from 'pptxgenjs';
+import type { Slide, SlideBlock, InlineSpan } from './markdownToSlides';
+
+// ─── 테마 상수 (MarkMind 톤) ───
+const COLORS = {
+  accent: '2F6FED', // 헤더 막대 / 강조
+  title: '1A1A2E',
+  body: '2D2D3A',
+  subhead: '2F6FED',
+  codeBg: 'F4F5F7',
+  codeFg: '24292F',
+  faint: '9AA0A6',
+  bg: 'FFFFFF',
+};
+const FONT = 'Helvetica Neue';
+const MONO = 'Courier New';
+
+// 16:9 inch 기준 본문 영역
+const PAGE_W = 13.333;
+const BODY = { x: 0.7, top: 1.55, bottom: 7.0, w: PAGE_W - 1.4 };
+
+type Pptx = InstanceType<typeof PptxGenJS>;
+
+function defineMasters(pptx: Pptx) {
+  pptx.defineSlideMaster({
+    title: 'TITLE_SLIDE',
+    background: { color: COLORS.bg },
+    objects: [
+      { rect: { x: 0, y: 3.95, w: PAGE_W, h: 0.05, fill: { color: COLORS.accent } } },
+    ],
+  });
+  pptx.defineSlideMaster({
+    title: 'CONTENT',
+    background: { color: COLORS.bg },
+    objects: [
+      // 상단 제목 영역 액센트 막대
+      { rect: { x: 0, y: 1.25, w: PAGE_W, h: 0.035, fill: { color: COLORS.accent } } },
+    ],
+    slideNumber: { x: PAGE_W - 0.9, y: 7.05, color: COLORS.faint, fontSize: 10 },
+  });
+}
+
+/** InlineSpan[] → PptxGenJS rich-text 배열. */
+function spansToRich(
+  spans: InlineSpan[],
+  base: { bullet?: boolean; indentLevel?: number; breakLine?: boolean; fontSize?: number; color?: string },
+) {
+  return spans.map((s, idx) => ({
+    text: s.text,
+    options: {
+      bold: s.bold,
+      italic: s.italic,
+      fontFace: s.code ? MONO : FONT,
+      // 첫 run 에만 bullet/indent/breakLine 적용
+      ...(idx === 0
+        ? {
+            bullet: base.bullet ? { indent: 14 } : undefined,
+            indentLevel: base.indentLevel,
+            breakLine: base.breakLine,
+          }
+        : {}),
+      fontSize: base.fontSize,
+      color: base.color,
+    },
+  }));
+}
+
+const ext = (src: string) => src.split('.').pop()?.toLowerCase() ?? '';
+const MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  bmp: 'image/bmp',
+};
+
+/**
+ * 본문 이미지 경로 → PptxGenJS addImage 인자. 로컬 파일은 base64 data URL 로 읽어
+ * 넣고(WKWebView 가 직접 못 가져옴), http(s)/data URL 은 path 로 전달. 실패 시 null.
+ */
+async function resolveImage(
+  src: string,
+  baseDir?: string,
+): Promise<{ data?: string; path?: string } | null> {
+  if (src.startsWith('data:')) return { data: src };
+  if (/^https?:\/\//i.test(src)) return { path: src };
+  try {
+    const { readFile } = await import('@tauri-apps/plugin-fs');
+    // asset:// 또는 상대/절대 로컬 경로
+    let p = src.replace(/^asset:\/\/(localhost\/)?/i, '');
+    p = decodeURIComponent(p);
+    if (!p.startsWith('/') && baseDir) p = `${baseDir.replace(/\/$/, '')}/${p}`;
+    const bytes = await readFile(p);
+    let bin = '';
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    const b64 = btoa(bin);
+    const mime = MIME[ext(p)] ?? 'image/png';
+    return { data: `data:${mime};base64,${b64}` };
+  } catch (e) {
+    console.warn('[buildPptx] 이미지 로드 실패, 건너뜀:', src, e);
+    return null;
+  }
+}
+
+function renderTitleSlide(pptx: Pptx, slide: Slide) {
+  const s = pptx.addSlide({ masterName: 'TITLE_SLIDE' });
+  s.addText(slide.title || 'Untitled', {
+    x: 0.8,
+    y: 2.7,
+    w: PAGE_W - 1.6,
+    h: 1.2,
+    fontFace: FONT,
+    fontSize: 40,
+    bold: true,
+    color: COLORS.title,
+    align: 'left',
+    valign: 'bottom',
+  });
+  // 본문 첫 text/bullet 를 부제로
+  const sub = slide.body.find((b) => b.kind === 'text' || b.kind === 'bullet');
+  if (sub && (sub.kind === 'text' || sub.kind === 'bullet')) {
+    s.addText(sub.spans.map((x) => x.text).join(''), {
+      x: 0.8,
+      y: 4.15,
+      w: PAGE_W - 1.6,
+      h: 0.8,
+      fontFace: FONT,
+      fontSize: 18,
+      color: COLORS.faint,
+      align: 'left',
+    });
+  }
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
+async function renderContentSlide(pptx: Pptx, slide: Slide, baseDir?: string) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  if (slide.title) {
+    s.addText(slide.title, {
+      x: BODY.x,
+      y: 0.4,
+      w: BODY.w,
+      h: 0.8,
+      fontFace: FONT,
+      fontSize: 26,
+      bold: true,
+      color: COLORS.title,
+      valign: 'middle',
+    });
+  }
+
+  // 블록을 위→아래 커서로 배치. text/bullet/subhead 는 연속 그룹으로 묶어 하나의
+  // 텍스트박스(fit:shrink)로, table/image/code 는 개별 박스로.
+  let y = BODY.top;
+  const avail = () => BODY.bottom - y;
+  let textRun: SlideBlock[] = [];
+
+  const flushText = () => {
+    if (textRun.length === 0) return;
+    const rich: ReturnType<typeof spansToRich> = [];
+    for (const b of textRun) {
+      if (b.kind === 'subhead') {
+        rich.push(
+          ...spansToRich([{ text: b.text, bold: true }], {
+            breakLine: true,
+            fontSize: 18,
+            color: COLORS.subhead,
+          }),
+        );
+      } else if (b.kind === 'bullet') {
+        rich.push(
+          ...spansToRich(b.spans, {
+            bullet: true,
+            indentLevel: b.indent,
+            breakLine: true,
+            fontSize: 16,
+            color: COLORS.body,
+          }),
+        );
+      } else if (b.kind === 'text') {
+        rich.push(
+          ...spansToRich(b.spans, {
+            breakLine: true,
+            fontSize: 16,
+            color: COLORS.body,
+          }),
+        );
+      }
+    }
+    const lines = textRun.length;
+    const h = Math.min(avail(), Math.max(0.5, lines * 0.42));
+    s.addText(rich, {
+      x: BODY.x,
+      y,
+      w: BODY.w,
+      h,
+      valign: 'top',
+      align: 'left',
+      lineSpacingMultiple: 1.15,
+      fit: 'shrink',
+    });
+    y += h + 0.12;
+    textRun = [];
+  };
+
+  for (const b of slide.body) {
+    if (b.kind === 'text' || b.kind === 'bullet' || b.kind === 'subhead') {
+      textRun.push(b);
+      continue;
+    }
+    flushText();
+    if (avail() < 0.6) break; // 공간 소진
+    if (b.kind === 'code') {
+      const codeLines = b.text.split('\n').length;
+      const h = Math.min(avail(), Math.max(0.5, codeLines * 0.26 + 0.3));
+      s.addText(b.text, {
+        x: BODY.x,
+        y,
+        w: BODY.w,
+        h,
+        fontFace: MONO,
+        fontSize: 12,
+        color: COLORS.codeFg,
+        fill: { color: COLORS.codeBg },
+        align: 'left',
+        valign: 'top',
+        margin: 6,
+        fit: 'shrink',
+      });
+      y += h + 0.12;
+    } else if (b.kind === 'table') {
+      const rows = b.rows.map((r, ri) =>
+        r.map((cell) => ({
+          text: cell,
+          options: {
+            bold: ri === 0,
+            color: ri === 0 ? 'FFFFFF' : COLORS.body,
+            fill: { color: ri === 0 ? COLORS.accent : 'FFFFFF' },
+            fontFace: FONT,
+            fontSize: 13,
+          },
+        })),
+      );
+      const h = Math.min(avail(), Math.max(0.4, b.rows.length * 0.4));
+      s.addTable(rows, {
+        x: BODY.x,
+        y,
+        w: BODY.w,
+        h,
+        border: { type: 'solid', pt: 0.5, color: 'D7DAE0' },
+        valign: 'middle',
+      });
+      y += h + 0.15;
+    } else if (b.kind === 'image') {
+      const img = await resolveImage(b.src, baseDir);
+      const h = Math.min(avail(), 3.2);
+      if (img) {
+        s.addImage({
+          ...img,
+          x: BODY.x,
+          y,
+          w: BODY.w,
+          h,
+          sizing: { type: 'contain', w: BODY.w, h },
+          altText: b.alt,
+        });
+      } else {
+        s.addText(`[이미지: ${b.alt || b.src}]`, {
+          x: BODY.x,
+          y,
+          w: BODY.w,
+          h: 0.5,
+          fontFace: FONT,
+          fontSize: 12,
+          italic: true,
+          color: COLORS.faint,
+        });
+        y -= h - 0.5;
+      }
+      y += h + 0.15;
+    }
+  }
+  flushText();
+
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
+/**
+ * Slide[] → .pptx ArrayBuffer.
+ * @param baseDir 현재 문서 디렉토리(상대 이미지 경로 해석용, 옵션)
+ */
+export async function buildPptx(
+  slides: Slide[],
+  opts?: { title?: string; baseDir?: string },
+): Promise<ArrayBuffer> {
+  const pptx = new PptxGenJS();
+  pptx.defineLayout({ name: 'MM_16x9', width: PAGE_W, height: 7.5 });
+  pptx.layout = 'MM_16x9';
+  pptx.author = 'MarkMind';
+  if (opts?.title) pptx.title = opts.title;
+  defineMasters(pptx);
+
+  for (const slide of slides) {
+    if (slide.layout === 'title') renderTitleSlide(pptx, slide);
+    else await renderContentSlide(pptx, slide, opts?.baseDir);
+  }
+
+  return (await pptx.write({ outputType: 'arraybuffer' })) as ArrayBuffer;
+}

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { markdownToSlides, parseInline, slidesFromLlmJson } from './markdownToSlides';
+
+describe('markdownToSlides — 분할 규칙', () => {
+  it('수평선(---) 으로 슬라이드를 나눈다', () => {
+    const md = ['# A', 'alpha', '', '---', '', '# B', 'beta'].join('\n');
+    const slides = markdownToSlides(md);
+    expect(slides.map((s) => s.title)).toEqual(['A', 'B']);
+  });
+
+  it('--- 없어도 slide-level 헤딩(H1)으로 폴백 분할', () => {
+    const md = ['# One', 'x', '# Two', 'y', '# Three', 'z'].join('\n');
+    const slides = markdownToSlides(md);
+    expect(slides.length).toBe(3);
+    expect(slides.map((s) => s.title)).toEqual(['One', 'Two', 'Three']);
+  });
+
+  it('frontmatter 의 --- 를 슬라이드 경계로 오인하지 않는다', () => {
+    const md = [
+      '---',
+      'title: Deck',
+      'author: me',
+      '---',
+      '# First',
+      'content',
+      '---',
+      '# Second',
+      'more',
+    ].join('\n');
+    const slides = markdownToSlides(md);
+    expect(slides.map((s) => s.title)).toEqual(['First', 'Second']);
+  });
+
+  it('H1 이 바로 H2 로 이어지면 slide-level=2, H1 은 타이틀 슬라이드', () => {
+    const md = ['# Cover', '## Section A', 'a', '## Section B', 'b'].join('\n');
+    const slides = markdownToSlides(md);
+    // Cover(title) + Section A + Section B
+    expect(slides.map((s) => s.title)).toEqual([
+      'Cover',
+      'Section A',
+      'Section B',
+    ]);
+    expect(slides[0].layout).toBe('title');
+    expect(slides[1].layout).toBe('content');
+  });
+
+  it('펜스 코드블록 안의 --- 와 # 은 경계/헤딩이 아니다', () => {
+    const md = [
+      '# Code',
+      '```',
+      '# not a heading',
+      '---',
+      '```',
+      'after',
+    ].join('\n');
+    const slides = markdownToSlides(md);
+    expect(slides.length).toBe(1);
+    expect(slides[0].body.some((b) => b.kind === 'code')).toBe(true);
+  });
+});
+
+describe('markdownToSlides — 본문 블록', () => {
+  it('리스트는 bullet, 단락은 text, 하위 헤딩은 subhead', () => {
+    const md = ['# T', 'para line', '', '- item1', '- item2', '', '## sub'].join(
+      '\n',
+    );
+    const slides = markdownToSlides(md);
+    const kinds = slides[0].body.map((b) => b.kind);
+    expect(kinds).toContain('text');
+    expect(kinds).toContain('bullet');
+    expect(kinds).toContain('subhead');
+  });
+
+  it('표를 table 블록으로(구분행 제거)', () => {
+    const md = ['# T', '| a | b |', '| --- | --- |', '| 1 | 2 |'].join('\n');
+    const slides = markdownToSlides(md);
+    const table = slides[0].body.find((b) => b.kind === 'table');
+    expect(table).toBeDefined();
+    if (table && table.kind === 'table') {
+      expect(table.rows).toEqual([
+        ['a', 'b'],
+        ['1', '2'],
+      ]);
+    }
+  });
+
+  it('이미지 전용 라인을 image 블록으로', () => {
+    const md = ['# T', '![alt text](img/pic.png)'].join('\n');
+    const slides = markdownToSlides(md);
+    const img = slides[0].body.find((b) => b.kind === 'image');
+    expect(img).toBeDefined();
+    if (img && img.kind === 'image') {
+      expect(img.src).toBe('img/pic.png');
+      expect(img.alt).toBe('alt text');
+    }
+  });
+
+  it('::: notes 블록을 발표자 노트로 추출', () => {
+    const md = ['# T', 'body', '', '::: notes', 'speaker note', ':::'].join(
+      '\n',
+    );
+    const slides = markdownToSlides(md);
+    expect(slides[0].notes).toContain('speaker note');
+    // 노트가 본문 text 로 새지 않아야
+    const text = slides[0].body
+      .filter((b) => b.kind === 'text')
+      .map((b) => (b.kind === 'text' ? b.spans.map((s) => s.text).join('') : ''))
+      .join(' ');
+    expect(text).not.toContain('speaker note');
+  });
+
+  it('빈 문서도 최소 1장', () => {
+    expect(markdownToSlides('').length).toBe(1);
+    expect(markdownToSlides('   \n  \n').length).toBe(1);
+  });
+});
+
+describe('slidesFromLlmJson', () => {
+  it('정상 JSON 을 슬라이드로 매핑', () => {
+    const raw = JSON.stringify({
+      slides: [
+        { title: 'Cover', layout: 'title', bullets: ['subtitle'] },
+        { title: 'S1', layout: 'content', bullets: ['a', 'b'] },
+      ],
+    });
+    const slides = slidesFromLlmJson(raw);
+    expect(slides?.map((s) => s.title)).toEqual(['Cover', 'S1']);
+    expect(slides?.[0].layout).toBe('title');
+    expect(slides?.[1].body.filter((b) => b.kind === 'bullet').length).toBe(2);
+  });
+
+  it('코드펜스/잡텍스트로 감싸도 추출', () => {
+    const raw = '```json\n{"slides":[{"title":"T","bullets":["x"]}]}\n```';
+    const slides = slidesFromLlmJson(raw);
+    expect(slides?.length).toBe(1);
+    expect(slides?.[0].title).toBe('T');
+  });
+
+  it('잘린 JSON 에서 완성된 슬라이드만 부분 복구', () => {
+    // 마지막 객체가 토큰 한도로 잘린 상황
+    const raw =
+      '{"slides":[{"title":"A","layout":"title","bullets":["s"]},' +
+      '{"title":"B","layout":"content","bullets":["b1","b2"]},' +
+      '{"title":"C","layout":"content","bullets":["c1",';
+    const slides = slidesFromLlmJson(raw);
+    expect(slides?.map((s) => s.title)).toEqual(['A', 'B']); // C 는 미완성 → 제외
+  });
+
+  it('완전 비 JSON 은 null', () => {
+    expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
+  });
+});
+
+describe('parseInline', () => {
+  it('bold/italic/code 스팬 분리', () => {
+    const spans = parseInline('a **b** c *d* e `f`');
+    expect(spans.find((s) => s.bold)?.text).toBe('b');
+    expect(spans.find((s) => s.italic)?.text).toBe('d');
+    expect(spans.find((s) => s.code)?.text).toBe('f');
+  });
+
+  it('서식 없으면 단일 스팬', () => {
+    const spans = parseInline('plain text');
+    expect(spans).toEqual([{ text: 'plain text' }]);
+  });
+});

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -1,0 +1,416 @@
+// 마크다운 → 슬라이드 모델 (결정론 파서) — 이슈 #6 PPTX 내보내기
+//
+// Pandoc 표준 슬라이드 분할 규약을 채택한다:
+//   - 수평선(`---`)은 항상 새 슬라이드를 시작한다.
+//   - slide-level 헤딩은 항상 새 슬라이드를 시작한다.
+//   - slide-level 보다 위(더 큰 헤딩, 예: H1<H2)는 타이틀 슬라이드가 된다.
+//   - slide-level 보다 아래 헤딩은 슬라이드 내부 소제목이 된다.
+// slide-level = "내용이 바로 뒤따르는 최상위 헤딩 레벨"(없으면 1).
+//
+// 핵심 함정: YAML frontmatter 의 `---` 와 슬라이드 구분 `---` 혼동 → frontmatter 를
+// 가장 먼저 제거한다. 펜스 코드블록 안의 `---`/`#` 은 경계/헤딩으로 보지 않는다.
+//
+// 이 파서의 출력(Slide[])은 buildPptx.ts 와 LLM 스마트 레이아웃 경로가 공유하는
+// 단일 스키마다(경로 통일).
+
+export interface InlineSpan {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  code?: boolean;
+}
+
+export type SlideBlock =
+  | { kind: 'bullet'; spans: InlineSpan[]; indent: number }
+  | { kind: 'text'; spans: InlineSpan[] }
+  | { kind: 'subhead'; text: string }
+  | { kind: 'code'; text: string; lang?: string }
+  | { kind: 'table'; rows: string[][] } // rows[0] = 헤더
+  | { kind: 'image'; src: string; alt?: string };
+
+export interface Slide {
+  title: string;
+  layout: 'title' | 'content';
+  body: SlideBlock[];
+  notes?: string;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const HR_RE = /^\s*([-*_])(?:\s*\1){2,}\s*$/; // ---, ***, ___ (3개 이상)
+const FENCE_RE = /^\s*(```|~~~)(.*)$/;
+const LIST_RE = /^(\s*)(?:[-*+]|\d+[.)])\s+(.*)$/;
+const TABLE_ROW_RE = /^\s*\|(.+)\|\s*$/;
+const TABLE_SEP_RE = /^\s*\|?[\s:|-]+\|?\s*$/; // |---|:--:| 류 구분행
+const IMAGE_ONLY_RE = /^\s*!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+
+/** YAML frontmatter 제거 + 본문에서 `title:` 회수(덱 제목 폴백용). */
+function stripFrontmatter(md: string): { body: string; title?: string } {
+  const lines = md.split('\n');
+  if (lines[0]?.trim() !== '---') return { body: md };
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return { body: md }; // 닫는 --- 없음 → frontmatter 아님
+  let title: string | undefined;
+  for (let i = 1; i < end; i++) {
+    const m = lines[i].match(/^title\s*:\s*(.+)$/i);
+    if (m) title = m[1].trim().replace(/^["']|["']$/g, '');
+  }
+  return { body: lines.slice(end + 1).join('\n'), title };
+}
+
+/** 한 줄을 의미 토큰으로 분류. 펜스 코드블록은 상위에서 atomic 처리. */
+type Line =
+  | { t: 'heading'; level: number; text: string }
+  | { t: 'hr' }
+  | { t: 'list'; indent: number; text: string }
+  | { t: 'table'; cells: string[] }
+  | { t: 'tablesep' }
+  | { t: 'image'; alt: string; src: string }
+  | { t: 'blank' }
+  | { t: 'text'; text: string };
+
+function classify(line: string): Line {
+  if (line.trim() === '') return { t: 'blank' };
+  if (HR_RE.test(line)) return { t: 'hr' };
+  const h = line.match(HEADING_RE);
+  if (h) return { t: 'heading', level: h[1].length, text: h[2].trim() };
+  const img = line.match(IMAGE_ONLY_RE);
+  if (img) return { t: 'image', alt: img[1], src: img[2].trim() };
+  const li = line.match(LIST_RE);
+  if (li) return { t: 'list', indent: Math.floor(li[1].length / 2), text: li[2] };
+  if (TABLE_ROW_RE.test(line)) {
+    if (TABLE_SEP_RE.test(line) && line.includes('-'))
+      return { t: 'tablesep' };
+    const cells = line
+      .trim()
+      .replace(/^\||\|$/g, '')
+      .split('|')
+      .map((c) => c.trim());
+    return { t: 'table', cells };
+  }
+  return { t: 'text', text: line };
+}
+
+/** 인라인 마크다운(`**bold**`, `*em*`/`_em_`, `` `code` ``) → 스팬 배열. */
+export function parseInline(text: string): InlineSpan[] {
+  const spans: InlineSpan[] = [];
+  // 토큰: `code` | **bold** | __bold__ | *em* | _em_
+  const re = /(`[^`]+`)|(\*\*[^*]+\*\*|__[^_]+__)|(\*[^*]+\*|_[^_]+_)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) spans.push({ text: text.slice(last, m.index) });
+    if (m[1]) spans.push({ text: m[1].slice(1, -1), code: true });
+    else if (m[2]) spans.push({ text: m[2].slice(2, -2), bold: true });
+    else if (m[3]) spans.push({ text: m[3].slice(1, -1), italic: true });
+    last = re.lastIndex;
+  }
+  if (last < text.length) spans.push({ text: text.slice(last) });
+  return spans.length > 0 ? spans : [{ text }];
+}
+
+/** LLM 슬라이드 객체({title,layout,bullets,notes}) → Slide. */
+function llmObjToSlide(o: Record<string, unknown>, index: number): Slide {
+  const title = typeof o.title === 'string' ? o.title : '';
+  const bullets = Array.isArray(o.bullets)
+    ? (o.bullets as unknown[]).filter((b): b is string => typeof b === 'string')
+    : [];
+  const layout: 'title' | 'content' =
+    o.layout === 'title' || (index === 0 && o.layout !== 'content') ? 'title' : 'content';
+  const body: SlideBlock[] =
+    layout === 'title'
+      ? bullets.slice(0, 1).map((b) => ({ kind: 'text', spans: parseInline(b) }))
+      : bullets.map((b) => ({ kind: 'bullet', spans: parseInline(b), indent: 0 }));
+  const notes = typeof o.notes === 'string' && o.notes.trim() ? o.notes.trim() : undefined;
+  return { title, layout, body, notes };
+}
+
+/**
+ * 문자열에서 최상위 균형 `{...}` 객체들을 순서대로 추출(문자열/이스케이프 인식).
+ * 잘린 JSON 에서 "완성된 객체까지만" 살리는 데 쓴다.
+ */
+function extractBalancedObjects(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let startIdx = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === '{') {
+      if (depth === 0) startIdx = i;
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0 && startIdx !== -1) {
+        out.push(s.slice(startIdx, i + 1));
+        startIdx = -1;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * LLM 스마트 레이아웃(generate_slides_llm)의 JSON 응답 → Slide[].
+ * 기대 형태: { "slides": [ { title, layout?, bullets[], notes? } ] }.
+ *
+ * 1) 코드펜스/잡텍스트 제거 후 첫 `{`~마지막 `}` 를 strict 파싱.
+ * 2) strict 실패(주로 max_output_tokens 로 JSON 이 잘림) → 부분 복구:
+ *    `"slides"` 배열에서 완성된 `{...}` 객체만 추출해 살린다(우아한 degradation).
+ * 둘 다 실패하면 null(→ 호출부가 규칙 기반으로 폴백).
+ */
+export function slidesFromLlmJson(raw: string): Slide[] | null {
+  // 1) strict
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    try {
+      const obj = JSON.parse(raw.slice(start, end + 1));
+      const arr = Array.isArray(obj) ? obj : obj.slides;
+      if (Array.isArray(arr) && arr.length > 0) {
+        return arr.map((s, i) => llmObjToSlide((s ?? {}) as Record<string, unknown>, i));
+      }
+    } catch {
+      /* 잘림 가능성 → 부분 복구로 진행 */
+    }
+  }
+
+  // 2) 부분 복구 — "slides" 배열 이후의 완성된 객체만 추출.
+  const arrPos = raw.search(/"slides"\s*:\s*\[/);
+  const scanFrom = arrPos === -1 ? start === -1 ? 0 : start : arrPos;
+  const objs = extractBalancedObjects(raw.slice(scanFrom));
+  const slides: Slide[] = [];
+  objs.forEach((objStr, i) => {
+    try {
+      const o = JSON.parse(objStr) as Record<string, unknown>;
+      // 슬라이드 객체로 보이는 것만(bullets/title 키 보유)
+      if ('bullets' in o || 'title' in o) slides.push(llmObjToSlide(o, slides.length));
+      else void i;
+    } catch {
+      /* 마지막 잘린 객체는 무시 */
+    }
+  });
+  return slides.length > 0 ? slides : null;
+}
+
+/** slide-level 산정 — 내용이 바로 뒤따르는 최상위(가장 작은 번호) 헤딩 레벨. */
+function computeSlideLevel(lines: Line[]): number {
+  let best = 7;
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    if (ln.t !== 'heading') continue;
+    // 다음 비어있지 않은 라인이 헤딩이 아니면 = 내용이 뒤따름
+    let j = i + 1;
+    while (j < lines.length && lines[j].t === 'blank') j++;
+    const next = lines[j];
+    if (!next || next.t !== 'heading') {
+      if (ln.level < best) best = ln.level;
+    }
+  }
+  return best === 7 ? 1 : best;
+}
+
+/** 슬라이드 본문 라인들을 SlideBlock[] 로 변환. */
+function parseBody(lines: Line[], slideLevel: number): SlideBlock[] {
+  const blocks: SlideBlock[] = [];
+  let para: string[] = [];
+  let table: string[][] | null = null;
+
+  const flushPara = () => {
+    if (para.length > 0) {
+      blocks.push({ kind: 'text', spans: parseInline(para.join(' ')) });
+      para = [];
+    }
+  };
+  const flushTable = () => {
+    if (table && table.length > 0) {
+      blocks.push({ kind: 'table', rows: table });
+    }
+    table = null;
+  };
+
+  for (const ln of lines) {
+    if (ln.t !== 'table' && ln.t !== 'tablesep') flushTable();
+    switch (ln.t) {
+      case 'blank':
+        flushPara();
+        break;
+      case 'heading':
+        flushPara();
+        if (ln.level > slideLevel)
+          blocks.push({ kind: 'subhead', text: ln.text });
+        // slide-level 이하 헤딩은 상위에서 슬라이드 경계로 소비됨(여기 안 옴)
+        break;
+      case 'list':
+        flushPara();
+        blocks.push({
+          kind: 'bullet',
+          spans: parseInline(ln.text),
+          indent: ln.indent,
+        });
+        break;
+      case 'image':
+        flushPara();
+        blocks.push({ kind: 'image', src: ln.src, alt: ln.alt || undefined });
+        break;
+      case 'table':
+        if (!table) table = [];
+        table.push(ln.cells);
+        break;
+      case 'tablesep':
+        break; // 구분행 무시
+      case 'text':
+        para.push(ln.text);
+        break;
+    }
+  }
+  flushPara();
+  flushTable();
+  return blocks;
+}
+
+/** `::: notes ... :::` 또는 `<!-- notes: ... -->` 발표자 노트 추출 + 본문에서 제거. */
+function extractNotes(body: string): { body: string; notes?: string } {
+  const notes: string[] = [];
+  let out = body.replace(
+    /^:::+\s*notes\s*$([\s\S]*?)^:::+\s*$/gim,
+    (_all, inner: string) => {
+      notes.push(inner.trim());
+      return '';
+    },
+  );
+  out = out.replace(/<!--\s*notes:\s*([\s\S]*?)-->/gi, (_all, inner: string) => {
+    notes.push(inner.trim());
+    return '';
+  });
+  return { body: out, notes: notes.length ? notes.join('\n\n') : undefined };
+}
+
+/**
+ * 마크다운 문자열 → Slide[].
+ * frontmatter 제거 → 펜스 코드 atomic 토큰화 → slide-level 산정 →
+ * 수평선/slide-level 헤딩 경계로 분할 → 슬라이드별 본문 파싱.
+ */
+export function markdownToSlides(markdown: string): Slide[] {
+  const { body: noFm } = stripFrontmatter(markdown);
+  const { body: noNotesBody, notes: docNotes } = extractNotes(noFm);
+
+  // 1) 펜스 코드블록을 atomic 으로: 코드 라인은 분류하지 않고 통째 보관.
+  const rawLines = noNotesBody.split('\n');
+  type Item = { line: Line } | { code: { text: string; lang?: string } };
+  const items: Item[] = [];
+  let i = 0;
+  while (i < rawLines.length) {
+    const fence = rawLines[i].match(FENCE_RE);
+    if (fence) {
+      const marker = fence[1];
+      const lang = fence[2].trim() || undefined;
+      const buf: string[] = [];
+      i++;
+      while (i < rawLines.length && !rawLines[i].trimStart().startsWith(marker)) {
+        buf.push(rawLines[i]);
+        i++;
+      }
+      i++; // 닫는 펜스 소비
+      items.push({ code: { text: buf.join('\n'), lang } });
+      continue;
+    }
+    items.push({ line: classify(rawLines[i]) });
+    i++;
+  }
+
+  // slide-level 산정엔 일반 라인만 사용(코드블록은 content 로 취급).
+  const lineView: Line[] = items.map((it) =>
+    'code' in it ? ({ t: 'text', text: '' } as Line) : it.line,
+  );
+  const slideLevel = computeSlideLevel(lineView);
+
+  // 2) 경계 분할: 수평선 / slide-level 이하 헤딩에서 새 슬라이드.
+  type Seg = { title: string; level: number | null; items: Item[] };
+  const segs: Seg[] = [];
+  let cur: Seg | null = null;
+  const ensure = () => {
+    if (!cur) {
+      cur = { title: '', level: null, items: [] };
+      segs.push(cur);
+    }
+    return cur;
+  };
+  for (const it of items) {
+    if ('code' in it) {
+      ensure().items.push(it);
+      continue;
+    }
+    const ln = it.line;
+    if (ln.t === 'hr') {
+      cur = null; // 다음 내용이 새 슬라이드
+      continue;
+    }
+    if (ln.t === 'heading' && ln.level <= slideLevel) {
+      cur = { title: ln.text, level: ln.level, items: [] };
+      segs.push(cur);
+      continue;
+    }
+    ensure().items.push(it);
+  }
+
+  // 3) 세그먼트 → Slide. 빈 세그먼트(공백만)는 버린다.
+  const slides: Slide[] = [];
+  for (const seg of segs) {
+    const merged: SlideBlock[] = [];
+    // 코드블록을 본문 순서대로 끼워넣기 위해 items 를 직접 순회
+    let pendingLines: Line[] = [];
+    const flushLines = () => {
+      if (pendingLines.length) {
+        merged.push(...parseBody(pendingLines, slideLevel));
+        pendingLines = [];
+      }
+    };
+    for (const it of seg.items) {
+      if ('code' in it) {
+        flushLines();
+        merged.push({ kind: 'code', text: it.code.text, lang: it.code.lang });
+      } else {
+        pendingLines.push(it.line);
+      }
+    }
+    flushLines();
+
+    const hasContent = merged.length > 0;
+    if (!seg.title && !hasContent) continue;
+
+    // 타이틀 레이아웃: slide-level 보다 위 헤딩(level < slideLevel) 이거나
+    // 제목만 있고 본문이 사실상 없는 경우.
+    const isTitle =
+      (seg.level !== null && seg.level < slideLevel) ||
+      (!!seg.title && !hasContent);
+
+    slides.push({
+      title: seg.title,
+      layout: isTitle ? 'title' : 'content',
+      body: merged,
+    });
+  }
+
+  // 문서 전체 노트는 첫 슬라이드에 붙인다(슬라이드별 ::: notes 는 향후 확장).
+  if (docNotes && slides.length > 0) slides[0].notes = docNotes;
+
+  // 슬라이드가 하나도 없으면(빈 문서) 최소 1장.
+  if (slides.length === 0) {
+    slides.push({ title: '', layout: 'title', body: [] });
+  }
+  return slides;
+}

--- a/src/services/aiModelConfig.ts
+++ b/src/services/aiModelConfig.ts
@@ -1,0 +1,137 @@
+/**
+ * 전역 AI 모델 설정 — 회사(company) → 인증(auth) → 모델(model) 3단계.
+ *
+ * 모든 AI 작업(문법·번역·개선·구조화·회의록)이 이 설정 하나를 따른다.
+ * 새 회사(Grok 등) 추가 = AI_CATALOG 에 항목 1개 + 호출 경로 1개. UI 는 카탈로그를
+ * 그대로 읽어 렌더하므로 회사가 늘면 자동 확장된다.
+ *
+ * 모델 ID/목록은 이 파일 한 곳에서만 관리한다(조정 쉬움).
+ */
+
+/** LLM 공급사. 새 회사 추가 시 여기 + AI_CATALOG 에만 손대면 된다. */
+export type AICompany = 'gemini' | 'claude' | 'openai';
+
+/** 인증 방식 — API 키(공식) 또는 구독(로컬 CLI 토큰 재사용). */
+export type AIAuthMode = 'api_key' | 'subscription';
+
+export interface AIModelDef {
+    /** 호출에 쓰는 실제 모델 ID. */
+    id: string;
+    /** UI 표시명. */
+    label: string;
+}
+
+export interface AICompanyDef {
+    /** UI 표시명 ("Claude" 등). */
+    label: string;
+    /** 이 회사가 지원하는 인증 방식(순서 = UI 표시 순서). */
+    auths: AIAuthMode[];
+    /** 인증별 모델 목록. */
+    models: Partial<Record<AIAuthMode, AIModelDef[]>>;
+}
+
+/**
+ * 모델 카탈로그. 모델 ID 는 조정 가능(초안):
+ * - Gemini: types/ai.ts AI_MODELS 와 일치
+ * - Claude: claude-opus-4-8 / claude-sonnet-4-6 / claude-haiku-4-5
+ * - ChatGPT: API 는 gpt-5.4 계열, 구독은 ~/.codex/models_cache.json 의 id(gpt-5.5 등)
+ */
+export const AI_CATALOG: Record<AICompany, AICompanyDef> = {
+    gemini: {
+        label: 'Gemini',
+        auths: ['api_key'], // 구독 연동 미지원(제공사 차단)
+        models: {
+            api_key: [
+                { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (고급)' },
+                { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash (균형)' },
+                { id: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash Lite (가성비)' },
+            ],
+        },
+    },
+    claude: {
+        label: 'Claude',
+        auths: ['api_key', 'subscription'],
+        // API·구독 모델 동일(Claude Code OAuth 로 opus/sonnet/haiku 모두 호출 가능).
+        models: {
+            api_key: [
+                { id: 'claude-opus-4-8', label: 'Opus 4.8 (고급)' },
+                { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (균형)' },
+                { id: 'claude-haiku-4-5', label: 'Haiku 4.5 (가성비)' },
+            ],
+            subscription: [
+                { id: 'claude-opus-4-8', label: 'Opus 4.8 (고급)' },
+                { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6 (균형)' },
+                { id: 'claude-haiku-4-5', label: 'Haiku 4.5 (가성비)' },
+            ],
+        },
+    },
+    openai: {
+        label: 'ChatGPT',
+        auths: ['api_key', 'subscription'],
+        // API 와 구독의 사용 가능 모델이 다름(구독은 ~/.codex/models_cache.json 실측).
+        models: {
+            api_key: [
+                { id: 'gpt-5.5', label: 'GPT-5.5 (고급)' },
+                { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini (균형)' },
+                { id: 'gpt-5.4-nano', label: 'GPT-5.4 Nano (가성비)' },
+            ],
+            subscription: [
+                { id: 'gpt-5.5', label: 'GPT-5.5 (고급)' },
+                { id: 'gpt-5.4', label: 'GPT-5.4 (균형)' },
+                { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini (가성비)' },
+            ],
+        },
+    },
+};
+
+/** 전역 선택 상태 (회사 + 인증 + 모델 ID). */
+export interface AIModelSelection {
+    company: AICompany;
+    auth: AIAuthMode;
+    model: string;
+}
+
+const STORAGE_KEY = 'markmind-ai-model-selection';
+
+/** 기본값 — Gemini 3.1 Pro (API). */
+export const DEFAULT_SELECTION: AIModelSelection = {
+    company: 'gemini',
+    auth: 'api_key',
+    model: 'gemini-3.1-pro-preview',
+};
+
+/** 선택이 카탈로그상 유효한지(회사·인증·모델 조합) 검사 후 보정. */
+export function normalizeSelection(sel: Partial<AIModelSelection> | null): AIModelSelection {
+    const company: AICompany =
+        sel?.company && sel.company in AI_CATALOG ? sel.company : DEFAULT_SELECTION.company;
+    const def = AI_CATALOG[company];
+    const auth: AIAuthMode = sel?.auth && def.auths.includes(sel.auth) ? sel.auth : def.auths[0];
+    const models = def.models[auth] ?? [];
+    const model = models.some((m) => m.id === sel?.model)
+        ? (sel!.model as string)
+        : (models[0]?.id ?? DEFAULT_SELECTION.model);
+    return { company, auth, model };
+}
+
+export function getAIModelSelection(): AIModelSelection {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return normalizeSelection(raw ? (JSON.parse(raw) as AIModelSelection) : null);
+    } catch {
+        return DEFAULT_SELECTION;
+    }
+}
+
+export function setAIModelSelection(sel: AIModelSelection): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(sel));
+}
+
+/** 회사 변경 시 인증/모델을 그 회사의 첫 유효값으로 재설정해 반환. */
+export function selectCompany(company: AICompany): AIModelSelection {
+    return normalizeSelection({ company });
+}
+
+/** 인증 변경 시 모델을 그 인증의 첫 유효값으로 재설정해 반환. */
+export function selectAuth(company: AICompany, auth: AIAuthMode): AIModelSelection {
+    return normalizeSelection({ company, auth });
+}

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -2,7 +2,8 @@ import { GoogleGenAI } from '@google/genai';
 import { AIRequest, AIResponse, DiffChunk, DiffSeg, getModelForMode, AI_MODELS } from '../types/ai';
 import type { FlowchartNode, FlowchartEdge } from '../types/flowchart';
 import { layoutFlowchart } from '../lib/dagre-layout';
-import { getKey, hasKey, setKey, removeKey } from './secureStorage';
+import { getKey, hasKey, setKey, removeKey, type Provider } from './secureStorage';
+import type { ClaudeAuthMode } from '../types/converter';
 import { getCachedUserMemory } from './userMemory';
 import FLOWCHART_SYSTEM_PROMPT from './flowchartPrompt.txt?raw';
 
@@ -338,19 +339,20 @@ export function applyDiff(chunks: DiffChunk[]): string {
 
 // ─── AI API Call ──────────────────────────────────────────
 
+export interface CallAIOptions {
+    /** 호출 모델 공급자. 기본 gemini. 'claude'(또는 그 외)는 Rust 경유 Claude 호출. */
+    provider?: Provider;
+    /** Claude 인증 소스 (구독 OAuth / API 키). provider==='claude' 일 때만 의미. */
+    claudeAuth?: ClaudeAuthMode;
+}
+
 export async function callAI(
     request: AIRequest,
     onStream?: (text: string) => void,
+    options?: CallAIOptions,
 ): Promise<AIResponse> {
-    const apiKey = getApiKey();
-    if (!apiKey) {
-        throw new Error('API 키가 설정되지 않았습니다. 설정에서 Gemini API 키를 입력해주세요.');
-    }
-
-    const ai = new GoogleGenAI({ apiKey });
+    const provider = options?.provider ?? 'gemini';
     const hasPrompt = !!request.prompt?.trim();
-    const model = getModelForMode(request.mode, hasPrompt, request.improveQuality);
-
     const systemPrompt = getSystemPrompt(request);
 
     let userContent = request.content;
@@ -360,32 +362,43 @@ export async function callAI(
 
     let modifiedText = '';
 
-    if (onStream) {
-        // Streaming mode
-        const response = await ai.models.generateContentStream({
-            model,
-            contents: userContent,
-            config: {
-                systemInstruction: systemPrompt,
-            },
-        });
+    if (provider === 'gemini') {
+        const apiKey = getApiKey();
+        if (!apiKey) {
+            throw new Error('Gemini API 키가 설정되지 않았습니다. 설정에서 입력해주세요.');
+        }
+        const ai = new GoogleGenAI({ apiKey });
+        const model = getModelForMode(request.mode, hasPrompt, request.improveQuality);
 
-        for await (const chunk of response) {
-            const text = chunk.text || '';
-            modifiedText += text;
-            onStream(modifiedText);
+        if (onStream) {
+            const response = await ai.models.generateContentStream({
+                model,
+                contents: userContent,
+                config: { systemInstruction: systemPrompt },
+            });
+            for await (const chunk of response) {
+                const text = chunk.text || '';
+                modifiedText += text;
+                onStream(modifiedText);
+            }
+        } else {
+            const response = await ai.models.generateContent({
+                model,
+                contents: userContent,
+                config: { systemInstruction: systemPrompt },
+            });
+            modifiedText = response.text || '';
         }
     } else {
-        // Non-streaming mode
-        const response = await ai.models.generateContent({
-            model,
-            contents: userContent,
-            config: {
-                systemInstruction: systemPrompt,
-            },
+        // Claude (구독 OAuth or API 키) — Rust 경유(구독 토큰은 keychain/refresh 가 Rust 에만).
+        // 스트리밍 미지원: 완료 후 한 번에 diff. onStream 은 호출하지 않는다.
+        const { invoke } = await import('@tauri-apps/api/core');
+        modifiedText = await invoke<string>('ai_generate_claude', {
+            system: systemPrompt,
+            prompt: userContent,
+            claudeAuth: options?.claudeAuth ?? 'api_key',
+            maxTokens: 16000,
         });
-
-        modifiedText = response.text || '';
     }
 
     // Clean up: remove markdown code block wrappers if present

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -389,6 +389,13 @@ export async function callAI(
             });
             modifiedText = response.text || '';
         }
+    } else if (provider === 'openai') {
+        // ChatGPT(Codex 구독) — Rust 경유(비공개 Responses API). 스트리밍 미지원.
+        const { invoke } = await import('@tauri-apps/api/core');
+        modifiedText = await invoke<string>('ai_generate_codex', {
+            system: systemPrompt,
+            prompt: userContent,
+        });
     } else {
         // Claude (구독 OAuth or API 키) — Rust 경유(구독 토큰은 keychain/refresh 가 Rust 에만).
         // 스트리밍 미지원: 완료 후 한 번에 diff. onStream 은 호출하지 않는다.

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,10 +1,10 @@
 import { GoogleGenAI } from '@google/genai';
-import { AIRequest, AIResponse, DiffChunk, DiffSeg, getModelForMode, AI_MODELS } from '../types/ai';
+import { AIRequest, AIResponse, DiffChunk, DiffSeg, AI_MODELS } from '../types/ai';
 import type { FlowchartNode, FlowchartEdge } from '../types/flowchart';
 import { layoutFlowchart } from '../lib/dagre-layout';
-import { getKey, hasKey, setKey, removeKey, type Provider } from './secureStorage';
-import type { ClaudeAuthMode } from '../types/converter';
+import { getKey, hasKey, setKey, removeKey } from './secureStorage';
 import { getCachedUserMemory } from './userMemory';
+import { getAIModelSelection } from './aiModelConfig';
 import FLOWCHART_SYSTEM_PROMPT from './flowchartPrompt.txt?raw';
 
 // ─── API Key Management ───────────────────────────────────
@@ -339,19 +339,26 @@ export function applyDiff(chunks: DiffChunk[]): string {
 
 // ─── AI API Call ──────────────────────────────────────────
 
-export interface CallAIOptions {
-    /** 호출 모델 공급자. 기본 gemini. 'claude'(또는 그 외)는 Rust 경유 Claude 호출. */
-    provider?: Provider;
-    /** Claude 인증 소스 (구독 OAuth / API 키). provider==='claude' 일 때만 의미. */
-    claudeAuth?: ClaudeAuthMode;
+/**
+ * 인증 실패(키/토큰 무효) 에러인지 판별 — 실제 사용 중 키가 안 되면 설정 검증 상태를
+ * 갱신하기 위함(정상→확인 필요). Gemini(@google/genai)는 status 필드, Rust 경유
+ * (Claude/OpenAI)는 에러 문자열(HTTP status / "인증 실패")로 온다.
+ */
+export function isAuthError(err: unknown): boolean {
+    const status = (err as { status?: number } | null)?.status;
+    if (status === 400 || status === 401 || status === 403) return true;
+    const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+    return /\b(401|403)\b|unauthorized|인증\s*실패|invalid[\s_-]*api[\s_-]*key|api[\s_-]*key[^.]*invalid/i.test(
+        msg,
+    );
 }
 
 export async function callAI(
     request: AIRequest,
     onStream?: (text: string) => void,
-    options?: CallAIOptions,
 ): Promise<AIResponse> {
-    const provider = options?.provider ?? 'gemini';
+    // 전역 AI 모델 설정(설정 > 기본 설정)에 따라 회사·인증·모델 결정.
+    const sel = getAIModelSelection();
     const hasPrompt = !!request.prompt?.trim();
     const systemPrompt = getSystemPrompt(request);
 
@@ -362,17 +369,16 @@ export async function callAI(
 
     let modifiedText = '';
 
-    if (provider === 'gemini') {
+    if (sel.company === 'gemini') {
         const apiKey = getApiKey();
         if (!apiKey) {
             throw new Error('Gemini API 키가 설정되지 않았습니다. 설정에서 입력해주세요.');
         }
         const ai = new GoogleGenAI({ apiKey });
-        const model = getModelForMode(request.mode, hasPrompt, request.improveQuality);
 
         if (onStream) {
             const response = await ai.models.generateContentStream({
-                model,
+                model: sel.model,
                 contents: userContent,
                 config: { systemInstruction: systemPrompt },
             });
@@ -383,28 +389,30 @@ export async function callAI(
             }
         } else {
             const response = await ai.models.generateContent({
-                model,
+                model: sel.model,
                 contents: userContent,
                 config: { systemInstruction: systemPrompt },
             });
             modifiedText = response.text || '';
         }
-    } else if (provider === 'openai') {
-        // ChatGPT(Codex 구독) — Rust 경유(비공개 Responses API). 스트리밍 미지원.
+    } else if (sel.company === 'openai') {
+        // ChatGPT — 구독(codex)이면 ai_generate_codex, API 키면 ai_generate_openai. Rust 경유.
         const { invoke } = await import('@tauri-apps/api/core');
-        modifiedText = await invoke<string>('ai_generate_codex', {
+        const command = sel.auth === 'subscription' ? 'ai_generate_codex' : 'ai_generate_openai';
+        modifiedText = await invoke<string>(command, {
             system: systemPrompt,
             prompt: userContent,
+            model: sel.model,
         });
     } else {
-        // Claude (구독 OAuth or API 키) — Rust 경유(구독 토큰은 keychain/refresh 가 Rust 에만).
-        // 스트리밍 미지원: 완료 후 한 번에 diff. onStream 은 호출하지 않는다.
+        // Claude — 구독 OAuth 또는 API 키. Rust 경유. 스트리밍 미지원(완료 후 diff).
         const { invoke } = await import('@tauri-apps/api/core');
         modifiedText = await invoke<string>('ai_generate_claude', {
             system: systemPrompt,
             prompt: userContent,
-            claudeAuth: options?.claudeAuth ?? 'api_key',
+            claudeAuth: sel.auth,
             maxTokens: 16000,
+            model: sel.model,
         });
     }
 

--- a/src/services/apiValidation.ts
+++ b/src/services/apiValidation.ts
@@ -96,6 +96,10 @@ export function validateGoogleCredsFormat(clientId: string, clientSecret: string
 // ─── 검증 상태 캐시 (localStorage) ──────────────────────────────────────────────
 
 export function setValidationStatus(key: ValidationKey, result: ValidationResult): void {
+    // 일시 실패(error: 네트워크/rate limit 등)는 "키가 틀린 것"이 아니라 "확인을 못 한 것".
+    // 이미 valid 인 키를 error 로 덮어쓰면 멀쩡한 키가 "확인 필요"로 뒤집힌다 → 보존.
+    // (invalid: 400/401/403 는 진짜 키 문제이므로 그대로 덮어쓴다.)
+    if (result === 'error' && getValidationStatus(key) === 'valid') return;
     localStorage.setItem(`${STORAGE_PREFIX}${key}`, result);
 }
 

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,0 +1,40 @@
+/**
+ * 구독 OAuth 연동 — 로컬에 로그인해 둔 Claude Code / Codex CLI 토큰을 본인 구독으로
+ * 재사용하기 위한 프론트 헬퍼.
+ *
+ * - 로그인 감지(`detectSubscriptionLogins`)는 토큰 값을 받지 않고 bool 만 받는다(Rust 보장).
+ * - Claude 인증 소스(API 키 ↔ 구독)는 localStorage 에 저장 — 설정/회의록 탭이 공유.
+ */
+
+import { isTauri } from './platform';
+import type { ClaudeAuthMode } from '../types/converter';
+
+export interface SubscriptionStatus {
+    /** Claude Code(keychain) 로그인 감지 여부. */
+    claude: boolean;
+    /** Codex(~/.codex/auth.json) 로그인 감지 여부. */
+    codex: boolean;
+}
+
+/** 로컬 CLI 로그인 감지. 비-Tauri / 실패 시 모두 false. */
+export async function detectSubscriptionLogins(): Promise<SubscriptionStatus> {
+    if (!isTauri()) return { claude: false, codex: false };
+    try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        return await invoke<SubscriptionStatus>('detect_subscription_logins');
+    } catch (err) {
+        console.warn('[subscription] 로그인 감지 실패:', err);
+        return { claude: false, codex: false };
+    }
+}
+
+const CLAUDE_AUTH_KEY = 'markmind-claude-auth-mode';
+
+/** 저장된 Claude 인증 소스 (기본 api_key). */
+export function getClaudeAuthMode(): ClaudeAuthMode {
+    return localStorage.getItem(CLAUDE_AUTH_KEY) === 'subscription' ? 'subscription' : 'api_key';
+}
+
+export function setClaudeAuthMode(mode: ClaudeAuthMode): void {
+    localStorage.setItem(CLAUDE_AUTH_KEY, mode);
+}

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -14,6 +14,10 @@ export interface SubscriptionStatus {
     claude: boolean;
     /** Codex(~/.codex/auth.json) 로그인 감지 여부. */
     codex: boolean;
+    /** Claude 플랜명 ("Max" 등). 토큰에서 추출, 없으면 null. */
+    claudePlan?: string | null;
+    /** ChatGPT 플랜명 ("Plus" 등). id_token 에서 추출, 없으면 null. */
+    codexPlan?: string | null;
 }
 
 /** 로컬 CLI 로그인 감지. 비-Tauri / 실패 시 모두 false. */

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -2,6 +2,8 @@
  * doc-converter 통합 타입 정의 — Rust src-tauri/src/converters/ 와 일치.
  */
 
+import type { AICompany, AIAuthMode } from '../services/aiModelConfig';
+
 export type DetailLevel = 'concise' | 'standard' | 'detailed' | 'verbatim';
 export type NotesProvider = 'claude' | 'gemini';
 export type TemplateSource = 'builtin' | 'user';
@@ -83,9 +85,10 @@ export interface NotesJobOptions {
     template: string;
     source: string;
     detail?: DetailLevel;
-    provider?: NotesProvider;
-    /** Claude provider 사용 시 인증 소스 (기본 api_key). Gemini 에는 무관. */
-    claudeAuth?: ClaudeAuthMode;
+    /** 전역 AI 모델 설정 — 회사 / 인증 / 모델. */
+    company?: AICompany;
+    auth?: AIAuthMode;
+    model?: string;
     outputDir?: string;
 }
 

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -75,12 +75,17 @@ export interface OcrJobResult {
 
 // ─── Notes ───
 
+/** Claude 호출 인증 소스 — API 키(공식) 또는 구독 OAuth(로컬 Claude Code 토큰 재사용). */
+export type ClaudeAuthMode = 'api_key' | 'subscription';
+
 export interface NotesJobOptions {
     transcript: string;
     template: string;
     source: string;
     detail?: DetailLevel;
     provider?: NotesProvider;
+    /** Claude provider 사용 시 인증 소스 (기본 api_key). Gemini 에는 무관. */
+    claudeAuth?: ClaudeAuthMode;
     outputDir?: string;
 }
 


### PR DESCRIPTION
## 요약
본인 구독(Claude / ChatGPT) OAuth 토큰 재사용으로 API 키 없이 LLM 호출 + 전역 AI 모델 설정(회사→인증→모델) + 설정 UI 3탭 개편.

## 주요 변경

### 1. 구독 OAuth 연동 (a3262d0, 8d2755e)
- 로컬 Claude Code(keychain) / Codex CLI(`~/.codex/auth.json`) 토큰을 재사용해 **본인 구독으로** 호출
- Claude: Bearer + `anthropic-beta` + system 블록0 Claude Code identity spoof → **status 200 검증**
- ChatGPT(Codex): `chatgpt.com/backend-api/codex/responses` SSE, `gpt-5.5` → **status 200 검증**
- 본인 머신·본인 구독 전용, 비공식 경로라 **API 키 fallback 병행**

### 2. 전역 AI 모델 설정 (f66cb61)
- 설정 **기본 설정** 탭에 **회사 → 인증 → 모델** 단계형 선택(`AIModelPicker`)
- 모든 AI 작업(문법/번역/개선/구조화/회의록)이 이 설정 하나를 따름 → **AI 에이전트의 모델선택 제거**
- 확장 가능 카탈로그(`aiModelConfig`) — 회사 추가 = 항목 1개 + 호출 경로 1개 (Grok 등 용이)
- **OpenAI API 키 호출 경로 신규**(`openai_api.rs`), `ai_generate_claude/codex` model 파라미터, `notes_pipeline` 회사별 배선

### 3. 설정 UI 개편 + 키 검증 안정화
- 설정 **3탭**(기본/AI/추가) 재구성, 구독 연동 provider별 행 + **플랜명**(Max/Plus) + Grok 준비중/Gemini 지원안함
- 키 검증 버그 fix: **error(일시 실패: 429/네트워크)가 valid 를 덮어쓰지 않음** + **실제 사용 중 인증 실패(401/403) 시 status 갱신**

## 검증
- `cargo check` / `tsc --noEmit` 통과
- 구독 호출 런타임 **status 200** 확인 (Claude 회의록·AI 모드 / ChatGPT)
- ⚠️ 전역 모델 설정 일부(모델 id `gpt-5.4-nano` 등, OpenAI API 키 경로)는 런타임 검증 진행 중 — 400 시 카탈로그만 조정

🤖 Generated with [Claude Code](https://claude.com/claude-code)