### PR TITLE
refactor(ai): dead-code 경고 13건 정리 + 슬라이드 생성 AICompany 통일

### DIFF
--- a/src-tauri/src/converters/audio_splitter.rs
+++ b/src-tauri/src/converters/audio_splitter.rs
@@ -9,15 +9,14 @@
 //! 1) .app 안 동봉 sidecar (current_exe 의 sibling, Tauri externalBin 으로 빌드)
 //! 2) 시스템 PATH (which / `/opt/homebrew/bin` / `/usr/local/bin`)
 //! 3) ffmpeg-sidecar 다운로드 cache (~/Library/Caches/ffmpeg-sidecar/)
-//! 4) ffmpeg-sidecar auto_download() 후 (3) 재시도
+//!
+//! 자동 다운로드(auto_download) 폴백은 제거됨 — 배포는 동봉 sidecar 를 우선하고,
+//! 없으면 위 3단계로만 해결한다(빌드 산출물 비결정성·런타임 지연 회피).
 
 use crate::converters::error::{ConverterError, ConverterResult};
 use chrono::DateTime;
 use std::path::{Path, PathBuf};
-use std::sync::Once;
 use tokio::process::Command;
-
-static INIT: Once = Once::new();
 
 /// 청크 크기 가드 — 초과 시 16kHz mono 32kbps mp3 로 다운인코딩.
 /// 임계 15MB → 대부분 청크가 Gemini inline base64 path 임계 (~20MB request body) 안에 들어가
@@ -31,23 +30,6 @@ pub struct AudioChunk {
     pub start_sec: f64,
     #[allow(dead_code)]
     pub index: usize,
-}
-
-/// ffmpeg-sidecar 자동 다운로드 (1회만). 동봉 binary 가 있으면 호출 안 함.
-pub fn ensure_ffmpeg_blocking() -> ConverterResult<()> {
-    let mut err: Option<String> = None;
-    INIT.call_once(|| {
-        if let Err(e) = ffmpeg_sidecar::download::auto_download() {
-            err = Some(e.to_string());
-        }
-    });
-    if let Some(msg) = err {
-        return Err(ConverterError::Ffmpeg(format!(
-            "ffmpeg 자동 다운로드 실패: {}",
-            msg
-        )));
-    }
-    Ok(())
 }
 
 /// current_exe 의 sibling 에 동봉된 sidecar binary 검색.

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -7,15 +7,7 @@ use super::error::ConverterError;
 use super::notes_pipeline::{self, NotesJobOptions, NotesJobResult};
 use super::ocr_pipeline::{self, OcrJobOptions, OcrJobResult};
 use super::progress::ProgressEmitter;
-use serde::Serialize;
 use tauri::AppHandle;
-
-#[derive(Debug, Serialize)]
-pub struct JobError {
-    pub message: String,
-    #[serde(rename = "jobId")]
-    pub job_id: String,
-}
 
 /// Frontend 가 jobId 전달하면 그걸 사용 — listener 필터링으로 다른 윈도우의 동시
 /// 진행 event 와 분리. 없으면 자체 생성 (backward compat).
@@ -84,54 +76,103 @@ const SLIDES_MAX_TOKENS: u32 = 32000;
 
 const SLIDES_SYSTEM: &str = "You are a presentation designer. Convert the given Markdown document into a concise slide deck. Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[{\"title\":string,\"layout\":\"title\"|\"content\",\"bullets\":string[],\"notes\":string?}]}. Rules: the first slide is layout \"title\" (deck title + optional one-line subtitle as a single bullet); other slides are \"content\"; keep each bullet short (<= ~12 words); at most ~6 bullets per slide; split dense content across multiple slides to avoid overcrowding; omit the \"notes\" field unless it adds real speaker value (keeps output compact); preserve the document's language; do not invent facts.";
 
+//
+// 모든 AI 작업은 전역 회사(company)→인증(auth)→모델(model) 선택(aiModelConfig)을
+// 따른다 — 슬라이드 생성도 회의록 파이프라인과 동일하게 3사·구독/API 키를 지원한다.
 #[tauri::command]
 pub async fn generate_slides_llm(
     markdown: String,
-    provider: super::NotesProvider,
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+    model: Option<String>,
 ) -> Result<String, String> {
     use super::keychain::{get_key, Provider};
     use super::llm;
+    use crate::subscription_auth::{AICompany, ClaudeAuthMode};
 
     let prompt = format!(
         "Convert this Markdown document into slides as specified.\n\n<markdown>\n{}\n</markdown>",
         markdown
     );
 
-    let text = match provider {
-        super::NotesProvider::Claude => {
-            let key = get_key(Provider::Claude)
-                .map_err(err_to_string)?
-                .ok_or_else(|| "CLAUDE_API_KEY 가 없습니다. Settings 에서 등록하세요.".to_string())?;
-            // 큰 문서(20장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
-            // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
-            let opts = llm::anthropic::ClaudeOptions {
-                max_output_tokens: Some(SLIDES_MAX_TOKENS),
-                system: Some(SLIDES_SYSTEM.to_string()),
-            };
-            llm::anthropic::generate_text(
-                llm::anthropic::ClaudeAuth::ApiKey(&key),
-                super::MODEL_NOTES_CLAUDE,
-                &prompt,
-                Some(opts),
-            )
-            .await
-            .map_err(err_to_string)?
-            .text
-        }
-        super::NotesProvider::Gemini => {
+    // 큰 덱(50장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
+    // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
+    let text = match company {
+        AICompany::Gemini => {
+            // Gemini 는 구독 미지원 → 항상 API 키. system 파라미터가 없어 프롬프트 앞에 결합.
             let key = get_key(Provider::Gemini)
                 .map_err(err_to_string)?
-                .ok_or_else(|| "GEMINI_API_KEY 가 없습니다. Settings 에서 등록하세요.".to_string())?;
-            // Gemini 는 system 파라미터를 따로 안 받으므로 프롬프트 앞에 지시문 결합.
+                .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+            let model_id = model.as_deref().unwrap_or(super::MODEL_NOTES_GEMINI);
             let full = format!("{}\n\n{}", SLIDES_SYSTEM, prompt);
             let cfg = llm::gemini::GenerationConfig {
                 max_output_tokens: Some(SLIDES_MAX_TOKENS),
                 temperature: Some(0.3),
             };
-            llm::gemini::generate_text(&key, super::MODEL_NOTES_GEMINI, &full, Vec::new(), Some(cfg))
+            llm::gemini::generate_text(&key, model_id, &full, Vec::new(), Some(cfg))
                 .await
                 .map_err(err_to_string)?
                 .text
+        }
+        AICompany::Claude => {
+            let model_id = model
+                .clone()
+                .unwrap_or_else(|| super::MODEL_NOTES_CLAUDE.to_string());
+            let opts = llm::anthropic::ClaudeOptions {
+                max_output_tokens: Some(SLIDES_MAX_TOKENS),
+                system: Some(SLIDES_SYSTEM.to_string()),
+            };
+            let result = match auth {
+                ClaudeAuthMode::Subscription => {
+                    let token = crate::subscription_auth::claude_access_token().await?;
+                    llm::anthropic::generate_text(
+                        llm::anthropic::ClaudeAuth::Subscription(&token),
+                        &model_id,
+                        &prompt,
+                        Some(opts),
+                    )
+                    .await
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let key = get_key(Provider::Claude)
+                        .map_err(err_to_string)?
+                        .ok_or_else(|| {
+                            "Claude API 키가 없습니다. Settings 에서 등록하거나 구독 로그인을 사용하세요."
+                                .to_string()
+                        })?;
+                    llm::anthropic::generate_text(
+                        llm::anthropic::ClaudeAuth::ApiKey(&key),
+                        &model_id,
+                        &prompt,
+                        Some(opts),
+                    )
+                    .await
+                }
+            };
+            result.map_err(err_to_string)?.text
+        }
+        AICompany::Openai => {
+            let model_id = model.clone().unwrap_or_else(|| super::MODEL_CODEX.to_string());
+            let result = match auth {
+                ClaudeAuthMode::Subscription => {
+                    let tokens = crate::subscription_auth::read_codex_tokens()?;
+                    llm::openai_codex::generate_text(
+                        &tokens.access_token,
+                        tokens.account_id.as_deref(),
+                        &model_id,
+                        Some(SLIDES_SYSTEM),
+                        &prompt,
+                    )
+                    .await
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let key = get_key(Provider::Openai)
+                        .map_err(err_to_string)?
+                        .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+                    llm::openai_api::generate_text(&key, &model_id, Some(SLIDES_SYSTEM), &prompt).await
+                }
+            };
+            result.map_err(err_to_string)?.text
         }
     };
 

--- a/src-tauri/src/converters/error.rs
+++ b/src-tauri/src/converters/error.rs
@@ -1,6 +1,5 @@
 //! 통합 에러 타입. Tauri command 결과에서 직렬화 가능하도록 String 화.
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -79,14 +78,4 @@ impl From<keyring::Error> for ConverterError {
     fn from(err: keyring::Error) -> Self {
         ConverterError::Keychain(err.to_string())
     }
-}
-
-/// Frontend 에 전달할 구조화된 에러 정보 (level/context/message)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorReport {
-    pub level: String,
-    pub context: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
 }

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -108,20 +108,6 @@ pub struct GenerateResult {
     pub usage: UsageInfo,
 }
 
-/// LLM provider — 회의록 생성용
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum NotesProvider {
-    Claude,
-    Gemini,
-}
-
-impl Default for NotesProvider {
-    fn default() -> Self {
-        NotesProvider::Claude
-    }
-}
-
 /// 회의록 상세도
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -145,16 +131,6 @@ impl std::fmt::Display for DetailLevel {
             DetailLevel::Standard => "standard",
             DetailLevel::Detailed => "detailed",
             DetailLevel::Verbatim => "verbatim",
-        };
-        write!(f, "{}", s)
-    }
-}
-
-impl std::fmt::Display for NotesProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            NotesProvider::Claude => "claude",
-            NotesProvider::Gemini => "gemini",
         };
         write!(f, "{}", s)
     }

--- a/src-tauri/src/converters/speaker_dedup.rs
+++ b/src-tauri/src/converters/speaker_dedup.rs
@@ -84,7 +84,8 @@ struct DedupGroup {
 pub struct DedupOutcome {
     pub text: String,
     pub usage: Option<UsageInfo>,
-    /// alias → primary 통합된 라벨 수
+    /// alias → primary 통합된 라벨 수 (현재 미소비 — 향후 "N명 통합" 표시용 보존)
+    #[allow(dead_code)]
     pub merged_count: usize,
 }
 

--- a/src-tauri/src/converters/vad.rs
+++ b/src-tauri/src/converters/vad.rs
@@ -407,7 +407,7 @@ pub async fn trim_silence(
     let list_path = work_dir.join("concat.txt");
     tokio::fs::write(&list_path, &list_script).await?;
 
-    let mut child = Command::new(ffmpeg_path()?)
+    let child = Command::new(ffmpeg_path()?)
         .args([
             "-y",
             "-f",

--- a/src-tauri/src/gdrive/auth.rs
+++ b/src-tauri/src/gdrive/auth.rs
@@ -67,6 +67,7 @@ struct TokenResponse {
     #[serde(default)]
     refresh_token: Option<String>,
     #[serde(default)]
+    #[allow(dead_code)] // OAuth 응답 스키마 보존 — 값은 현재 미사용
     scope: Option<String>,
 }
 

--- a/src-tauri/src/gdrive/storage.rs
+++ b/src-tauri/src/gdrive/storage.rs
@@ -64,6 +64,7 @@ pub fn get_client_id() -> GDriveResult<Option<String>> {
     Ok(v.gdrive_client_id.filter(|s| !s.trim().is_empty()))
 }
 
+#[allow(dead_code)] // 대칭 CRUD 헬퍼 — 현재 reset_all() 통합 경로 사용, 개별 관리용 보존
 pub fn delete_client_credentials() -> GDriveResult<()> {
     crate::secrets::update(|v| {
         v.gdrive_client_id = None;
@@ -74,6 +75,7 @@ pub fn delete_client_credentials() -> GDriveResult<()> {
 
 // ─── refresh_token / user_email ───
 
+#[allow(dead_code)] // 대칭 CRUD 헬퍼 — 현재 save_oauth_result() 통합 경로 사용, 개별 관리용 보존
 pub fn save_refresh_token(token: &str) -> GDriveResult<()> {
     let val = token.to_string();
     crate::secrets::update(|v| v.gdrive_refresh_token = Some(val)).map_err(to_gderr)
@@ -84,10 +86,12 @@ pub fn get_refresh_token() -> GDriveResult<Option<String>> {
     Ok(v.gdrive_refresh_token.filter(|s| !s.trim().is_empty()))
 }
 
+#[allow(dead_code)] // 대칭 CRUD 헬퍼 — 현재 disconnect()/reset_all() 통합 경로 사용, 개별 관리용 보존
 pub fn delete_refresh_token() -> GDriveResult<()> {
     crate::secrets::update(|v| v.gdrive_refresh_token = None).map_err(to_gderr)
 }
 
+#[allow(dead_code)] // 대칭 CRUD 헬퍼 — 현재 save_oauth_result() 통합 경로 사용, 개별 관리용 보존
 pub fn save_user_email(email: &str) -> GDriveResult<()> {
     let val = email.to_string();
     crate::secrets::update(|v| v.gdrive_user_email = Some(val)).map_err(to_gderr)
@@ -109,6 +113,7 @@ pub fn get_user_email() -> GDriveResult<Option<String>> {
     Ok(v.gdrive_user_email.filter(|s| !s.trim().is_empty()))
 }
 
+#[allow(dead_code)] // 대칭 CRUD 헬퍼 — 현재 disconnect()/reset_all() 통합 경로 사용, 개별 관리용 보존
 pub fn delete_user_email() -> GDriveResult<()> {
     crate::secrets::update(|v| v.gdrive_user_email = None).map_err(to_gderr)
 }

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -111,13 +111,6 @@ fn write_claude_creds(creds: &ClaudeCreds) -> Result<(), String> {
     claude_entry()?.set_password(&json).map_err(|e| e.to_string())
 }
 
-/// Claude Code 로그인 존재 여부 (토큰 값은 노출하지 않음).
-pub fn claude_logged_in() -> bool {
-    read_claude_creds()
-        .map(|c| !c.claude_ai_oauth.access_token.is_empty())
-        .unwrap_or(false)
-}
-
 /// 유효한 Claude 구독 access token 반환. 만료 임박이면 refresh 후 keychain write-back.
 ///
 /// write-back 실패(권한 프롬프트 거부 등)는 치명적이지 않다 — 이번 호출용 토큰은 그대로 반환.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { AIMode, DiffChunk } from './types/ai';
 import { Editor, EditorHandle } from './components/Editor';
 import { McpProposalView } from './components/McpProposalView';
 import { generateDiff, isAuthError } from './services/aiService';
-import { getAIModelSelection } from './services/aiModelConfig';
+import { getAIModelSelection, AI_CATALOG } from './services/aiModelConfig';
 import { setValidationStatus } from './services/apiValidation';
 import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
@@ -244,24 +244,26 @@ function App() {
 
   // PPTX export (이슈 #6) — 규칙 기반 + LLM 스마트 레이아웃.
   // 프론트 PptxGenJS 로 ArrayBuffer 생성 → Rust save_pptx 로 저장(WKWebView blob 버그 우회).
-  const [pptxAiProviders, setPptxAiProviders] = useState<{ claude: boolean; gemini: boolean }>({
-    claude: false,
-    gemini: false,
-  });
+  // 전역 AI 선택(회사/인증)이 슬라이드 생성에 쓸 준비가 됐는지.
+  // API 키 인증이면 그 회사 키 등록 여부, 구독 인증이면 백엔드가 호출 시 검증(여기선 준비로 간주).
+  const [pptxAiReady, setPptxAiReady] = useState(false);
   // PPTX 내보내기 진행 표시(특히 AI 레이아웃은 LLM 호출로 수초~수십초 소요).
   const [pptxBusy, setPptxBusy] = useState<string | null>(null);
   useEffect(() => {
     if (!isTauri()) return;
     (async () => {
       try {
+        const sel = getAIModelSelection();
+        if (sel.auth === 'subscription') {
+          // 구독 인증은 백엔드가 호출 시 검증 — 사전엔 준비된 것으로 간주.
+          setPptxAiReady(true);
+          return;
+        }
         const { invoke } = await import('@tauri-apps/api/core');
-        const [claude, gemini] = await Promise.all([
-          invoke<boolean>('has_api_key', { provider: 'claude' }),
-          invoke<boolean>('has_api_key', { provider: 'gemini' }),
-        ]);
-        setPptxAiProviders({ claude, gemini });
+        const ready = await invoke<boolean>('has_api_key', { provider: sel.company });
+        setPptxAiReady(ready);
       } catch {
-        /* 키 조회 실패 시 AI 옵션 비활성 유지 */
+        setPptxAiReady(false);
       }
     })();
   }, [settingsVisible]);
@@ -269,10 +271,8 @@ function App() {
   // PPTX 내보내기 — LLM 스마트 레이아웃 단일 경로(디폴트). 규칙 기반은 LLM 응답을
   // 전혀 해석 못한 catastrophic 실패 시의 안전망으로만 내부 사용한다.
   const handleExportPptx = useCallback(async () => {
-    if (!pptxAiProviders.claude && !pptxAiProviders.gemini) {
-      alert('PPTX 내보내기는 AI 레이아웃을 사용합니다. Settings 에서 Claude 또는 Gemini API 키를 등록하세요.');
-      return;
-    }
+    // 모든 AI 작업은 전역 회사/인증/모델 선택(Settings > 기본 설정)을 따른다.
+    const sel = getAIModelSelection();
     const baseName = (fileName || 'Untitled').replace(/\.(md|markdown|mdx|txt)$/i, '');
     try {
       const [{ save }, { invoke }, { markdownToSlides, slidesFromLlmJson }, { buildPptx }] =
@@ -289,13 +289,18 @@ function App() {
       });
       if (!path) return; // 사용자 취소
 
-      const provider = pptxAiProviders.claude ? 'claude' : 'gemini';
-      setPptxBusy(`AI 슬라이드 생성 중… (${provider === 'claude' ? 'Claude' : 'Gemini'})`);
+      const companyLabel = AI_CATALOG[sel.company].label;
+      setPptxBusy(`AI 슬라이드 생성 중… (${companyLabel})`);
 
-      const raw = await invoke<string>('generate_slides_llm', { markdown: content, provider });
+      const raw = await invoke<string>('generate_slides_llm', {
+        markdown: content,
+        company: sel.company,
+        auth: sel.auth,
+        model: sel.model,
+      });
       let slides = slidesFromLlmJson(raw);
       console.log(
-        `[export_pptx] AI(${provider}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장`,
+        `[export_pptx] AI(${sel.company}/${sel.auth}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장`,
       );
       if (!slides || slides.length === 0) {
         // 조용한 폴백 금지 — 사용자에게 알리고 원문 로깅(메모리: silent fallback 함정)
@@ -314,7 +319,7 @@ function App() {
     } finally {
       setPptxBusy(null);
     }
-  }, [fileName, filePath, content, pptxAiProviders]);
+  }, [fileName, filePath, content]);
 
   // AI
   const ai = useAI();
@@ -1762,7 +1767,7 @@ function App() {
           onConsumeAudioDropped={() => setAudioDropped(null)}
           onConsumeOcrDropped={() => setOcrDropped(null)}
           onExportPptx={handleExportPptx}
-          pptxAvailable={pptxAiProviders.claude || pptxAiProviders.gemini}
+          pptxAvailable={pptxAiReady}
           pptxBusy={pptxBusy}
         />
 

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -5,7 +5,6 @@
 import type { AICompany, AIAuthMode } from '../services/aiModelConfig';
 
 export type DetailLevel = 'concise' | 'standard' | 'detailed' | 'verbatim';
-export type NotesProvider = 'claude' | 'gemini';
 export type TemplateSource = 'builtin' | 'user';
 
 export interface UsageInfo {


### PR DESCRIPTION
## Summary
- 컴파일 경고 **13건 → 0건** (dead-code 정리)
- 모든 AI 사용을 신버전 `AICompany`(전역 회사→인증→모델)로 통일 — 슬라이드 생성까지 3사·구독/API키 지원, 구버전 `NotesProvider` 완전 제거

## Changes
**Part 1 — 경고 13건 정리**
- 삭제: `vad.rs` 불필요 `mut`, `JobError`/`ErrorReport` struct, `audio_splitter` `INIT`+`ensure_ffmpeg_blocking`(미사용 auto_download 폴백), `claude_logged_in`
- `#[allow(dead_code)]` 보존: OAuth `scope` 필드, `speaker_dedup` `merged_count`, gdrive 대칭 CRUD 헬퍼 5개
- `audio_splitter` 모듈 doc의 stale한 auto_download 폴백 설명 정정

**Part 2 — AICompany 통일**
- `generate_slides_llm`: `NotesProvider`(2사·API키) → `AICompany`(Gemini/Claude/OpenAI) + `auth`(구독/API키) + `model`
- `NotesProvider` enum/Display(백엔드)·타입(프론트) 제거
- `handleExportPptx`: 전역 `getAIModelSelection` 따름 (Settings의 회사/인증/모델)

## Test plan
- [x] `cargo check` 경고 0
- [x] `tsc --noEmit` exit 0
- [ ] PPTX export — Gemini(API키) 정상 동작
- [ ] PPTX export — **OpenAI 또는 Claude 구독** 경로 동작 (이번에 새로 열린 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)