### PR TITLE
feat(mindmap): 노드 순서변경(reorder) — 아웃라이너 버튼+키보드

### DIFF
--- a/src/components/MindmapCanvas.css
+++ b/src/components/MindmapCanvas.css
@@ -29,6 +29,12 @@
     padding: 10px 30px 10px 16px;
 }
 
+/* selected node — keyboard reorder target (↑↓/Tab) gets an accent ring */
+.mm-node.mm-selected {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent), var(--shadow-md);
+}
+
 /* left accent stripe — clean rectangle (::before, no border miter), level-shaded */
 .mm-node::before {
     content: '';
@@ -150,6 +156,25 @@
 .mm-toolbar button:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
+}
+
+/* disabled reorder buttons (e.g. first sibling can't move up) */
+.mm-toolbar button:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+.mm-toolbar button:disabled:hover {
+    background: transparent;
+    color: var(--text-secondary);
+}
+
+/* thin divider between the reorder group and edit/add/delete */
+.mm-toolbar-sep {
+    width: 1px;
+    align-self: stretch;
+    margin: 2px 1px;
+    background: var(--border-primary);
 }
 
 /* jump-to-section — absolute top-right corner (equal top/right margin), shown on

--- a/src/components/MindmapCanvas.tsx
+++ b/src/components/MindmapCanvas.tsx
@@ -23,8 +23,9 @@ import {
     type Edge,
     type NodeProps,
 } from '@xyflow/react';
-import { Plus, Pencil, Trash2, SquareArrowOutUpRight } from 'lucide-react';
+import { Plus, Pencil, Trash2, SquareArrowOutUpRight, ChevronUp, ChevronDown, IndentIncrease, IndentDecrease } from 'lucide-react';
 import type { MindmapNode } from '../types/mindmap';
+import type { ReorderOp } from '../lib/mindmapReorder';
 import { PALETTE } from '../lib/d3-layout';
 import '@xyflow/react/dist/style.css';
 import './MindmapCanvas.css';
@@ -42,6 +43,13 @@ export interface MindmapNodeData {
     mdLine?: number;
     // injected by MindmapView
     isEditing?: boolean;
+    isSelected?: boolean;
+    /** Reorder affordances — enabled per the markdown-bridge rules (see mindmapReorder). */
+    canUp?: boolean;
+    canDown?: boolean;
+    canIndent?: boolean;
+    canOutdent?: boolean;
+    onMove?: (op: ReorderOp) => void;
     onStartEdit?: () => void;
     onJumpToSource?: () => void;
     onUpdateLabel?: (value: string) => void;
@@ -103,7 +111,7 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: NodePr
     }, [d]);
 
     return (
-        <div className={`mm-node${isRoot ? ' mm-root' : ''}`} style={{ borderColor: thinBorder, background, '--mm-stripe': stripe } as CSSProperties}>
+        <div className={`mm-node${isRoot ? ' mm-root' : ''}${d.isSelected ? ' mm-selected' : ''}`} style={{ borderColor: thinBorder, background, '--mm-stripe': stripe } as CSSProperties}>
             <Handle
                 id="left"
                 type={isRoot ? 'source' : d.side === 'left' ? 'source' : 'target'}
@@ -161,6 +169,23 @@ const MindmapNodeComponent = memo(function MindmapNodeComponent({ data }: NodePr
             {/* hover toolbar */}
             {!d.isEditing && (
                 <div className="mm-toolbar nodrag" onClick={(e) => e.stopPropagation()}>
+                    {!isRoot && (
+                        <>
+                            <button title="위로 이동 (↑)" disabled={!d.canUp} onClick={(e) => { e.stopPropagation(); d.onMove?.('up'); }}>
+                                <ChevronUp size={12} />
+                            </button>
+                            <button title="아래로 이동 (↓)" disabled={!d.canDown} onClick={(e) => { e.stopPropagation(); d.onMove?.('down'); }}>
+                                <ChevronDown size={12} />
+                            </button>
+                            <button title="들여쓰기 (Tab)" disabled={!d.canIndent} onClick={(e) => { e.stopPropagation(); d.onMove?.('indent'); }}>
+                                <IndentIncrease size={12} />
+                            </button>
+                            <button title="내어쓰기 (⇧Tab)" disabled={!d.canOutdent} onClick={(e) => { e.stopPropagation(); d.onMove?.('outdent'); }}>
+                                <IndentDecrease size={12} />
+                            </button>
+                            <span className="mm-toolbar-sep" aria-hidden="true" />
+                        </>
+                    )}
                     <button title="이름 편집" onClick={(e) => { e.stopPropagation(); d.onStartEdit?.(); }}>
                         <Pencil size={12} />
                     </button>
@@ -186,9 +211,45 @@ interface MindmapCanvasProps {
     edges: Edge[];
     /** Re-fit the viewport when this key changes (e.g. document switch). */
     fitKey?: string;
+    /** Currently selected node id (for keyboard reorder + highlight). */
+    selectedId?: string | null;
+    /** True while a label is being edited — suppresses reorder keyboard. */
+    editing?: boolean;
+    onSelect?: (id: string | null) => void;
+    onReorder?: (id: string, op: ReorderOp) => void;
 }
 
-function MindmapCanvasInner({ nodes, edges, fitKey }: MindmapCanvasProps) {
+function MindmapCanvasInner({ nodes, edges, fitKey, selectedId, editing, onSelect, onReorder }: MindmapCanvasProps) {
+    // Refs so the once-bound document listener always sees fresh values.
+    const selRef = useRef(selectedId);
+    selRef.current = selectedId;
+    const editingRef = useRef(editing);
+    editingRef.current = editing;
+    const reorderRef = useRef(onReorder);
+    reorderRef.current = onReorder;
+
+    // Outliner keyboard: ↑/↓ reorder siblings, Tab/⇧Tab indent/outdent the
+    // selected node. Ignored while editing, when an input is focused, or with a
+    // modifier held (those belong to the app's global shortcuts).
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            const id = selRef.current;
+            if (!id || editingRef.current) return;
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+            const t = e.target as HTMLElement | null;
+            if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+            let op: ReorderOp | null = null;
+            if (e.key === 'ArrowUp') op = 'up';
+            else if (e.key === 'ArrowDown') op = 'down';
+            else if (e.key === 'Tab') op = e.shiftKey ? 'outdent' : 'indent';
+            if (!op) return;
+            e.preventDefault();
+            reorderRef.current?.(id, op);
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+    }, []);
+
     return (
         <ReactFlow
             key={fitKey}
@@ -199,6 +260,8 @@ function MindmapCanvasInner({ nodes, edges, fitKey }: MindmapCanvasProps) {
             nodesDraggable={false}
             nodesConnectable={false}
             elementsSelectable
+            onNodeClick={(_, node) => onSelect?.(node.id)}
+            onPaneClick={() => onSelect?.(null)}
             fitView
             fitViewOptions={{ padding: 0.2, maxZoom: 1.2 }}
             minZoom={0.1}

--- a/src/components/MindmapView.tsx
+++ b/src/components/MindmapView.tsx
@@ -15,6 +15,7 @@ import { Loader2, ListTree } from 'lucide-react';
 import { MindmapCanvas, type MindmapNodeData } from './MindmapCanvas';
 import { calculateD3Layout } from '../lib/d3-layout';
 import { documentToTree, treeToDocument } from '../lib/markdownTree';
+import { reorderNode, canReorder, type ReorderOp } from '../lib/mindmapReorder';
 import type { MindmapNode } from '../types/mindmap';
 import './MindmapView.css';
 
@@ -70,6 +71,7 @@ export function MindmapView({ content, onChange, fileName, onJumpToSource, onStr
     const [tree, setTree] = useState<MindmapNode>(initial.tree);
     const [frontmatter, setFrontmatter] = useState(initial.frontmatter);
     const [editingId, setEditingId] = useState<string | null>(null);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
 
     // refs for stable handlers + self-echo suppression
     const treeRef = useRef(tree);
@@ -128,6 +130,16 @@ export function MindmapView({ content, onChange, fileName, onJumpToSource, onStr
         commitTree(clone);
     }, [commitTree]);
 
+    /** Outliner reorder (up/down/indent/outdent). Re-selects the moved node by
+     *  its new path-based id so highlight/keyboard stay on it after re-parse. */
+    const moveNode = useCallback((id: string, op: ReorderOp) => {
+        const res = reorderNode(treeRef.current, id, op);
+        if (!res) return;
+        setEditingId(null);
+        const newTree = commitTree(res.tree);
+        if (findNodeById(newTree, res.newId)) setSelectedId(res.newId);
+    }, [commitTree]);
+
     const layout = useMemo(() => calculateD3Layout(tree, NOOP), [tree]);
 
     const nodes: Node[] = useMemo(() =>
@@ -138,6 +150,12 @@ export function MindmapView({ content, onChange, fileName, onJumpToSource, onStr
                 data: {
                     ...base,
                     isEditing: n.id === editingId,
+                    isSelected: n.id === selectedId,
+                    canUp: canReorder(tree, n.id, 'up'),
+                    canDown: canReorder(tree, n.id, 'down'),
+                    canIndent: canReorder(tree, n.id, 'indent'),
+                    canOutdent: canReorder(tree, n.id, 'outdent'),
+                    onMove: (op: ReorderOp) => moveNode(n.id, op),
                     onStartEdit: () => setEditingId(n.id),
                     onUpdateLabel: (v: string) => updateLabel(n.id, v),
                     onCancelEdit: () => setEditingId(null),
@@ -149,7 +167,7 @@ export function MindmapView({ content, onChange, fileName, onJumpToSource, onStr
                 } satisfies MindmapNodeData,
             };
         }),
-        [layout, editingId, updateLabel, addChild, deleteNode, onJumpToSource],
+        [layout, tree, editingId, selectedId, updateLabel, addChild, deleteNode, moveNode, onJumpToSource],
     );
 
     return (
@@ -174,7 +192,15 @@ export function MindmapView({ content, onChange, fileName, onJumpToSource, onStr
                 </div>
             )}
             <div className="mindmap-canvas-wrap">
-                <MindmapCanvas nodes={nodes} edges={layout.edges} fitKey={stem} />
+                <MindmapCanvas
+                    nodes={nodes}
+                    edges={layout.edges}
+                    fitKey={stem}
+                    selectedId={selectedId}
+                    editing={editingId !== null}
+                    onSelect={setSelectedId}
+                    onReorder={moveNode}
+                />
             </div>
         </div>
     );

--- a/src/lib/mindmapReorder.test.ts
+++ b/src/lib/mindmapReorder.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { documentToTree, treeToDocument } from './markdownTree';
+import { reorderNode, canReorder, type ReorderOp } from './mindmapReorder';
+import type { MindmapNode } from '../types/mindmap';
+
+/** Resolve a path-based id (n/0/2) against a tree. */
+function nodeById(root: MindmapNode, id: string): MindmapNode | null {
+    const parts = id.split('/').slice(1).map(Number);
+    let cur: MindmapNode | undefined = root;
+    for (const i of parts) {
+        cur = cur?.children[i];
+        if (!cur) return null;
+    }
+    return cur ?? null;
+}
+
+/** Parse → reorder → serialize → re-parse. Returns the canonical markdown, the
+ *  moved node's new id, and the label that id resolves to after the round-trip. */
+function apply(md: string, id: string, op: ReorderOp) {
+    const { tree } = documentToTree(md, 'Untitled');
+    const res = reorderNode(tree, id, op);
+    if (!res) return null;
+    const out = treeToDocument(res.tree, '', 'Untitled');
+    const { tree: reparsed } = documentToTree(out, 'Untitled');
+    return { out: out.trim(), newId: res.newId, label: nodeById(reparsed, res.newId)?.label };
+}
+
+describe('mindmapReorder — same-level order (up/down)', () => {
+    it('moves a heading down among heading siblings', () => {
+        const r = apply('# Doc\n## A\n## B', 'n/0', 'down');
+        expect(r?.out).toBe('# Doc\n\n## B\n\n## A');
+        expect(r?.newId).toBe('n/1');
+        expect(r?.label).toBe('A'); // the moved node is still A, now at n/1
+    });
+
+    it('moves a heading up among heading siblings', () => {
+        const r = apply('# Doc\n## A\n## B', 'n/1', 'up');
+        expect(r?.out).toBe('# Doc\n\n## B\n\n## A');
+        expect(r?.label).toBe('B');
+    });
+
+    it('reorders bullet siblings', () => {
+        const r = apply('# Doc\n- a\n- b', 'n/1', 'up');
+        expect(r?.out).toBe('# Doc\n- b\n- a');
+        expect(r?.label).toBe('b');
+    });
+
+    it('blocks moving the first sibling up', () => {
+        expect(canReorder(documentToTree('# Doc\n## A\n## B', 'Untitled').tree, 'n/0', 'up')).toBe(false);
+        expect(apply('# Doc\n## A\n## B', 'n/0', 'up')).toBeNull();
+    });
+
+    it('blocks moving the last sibling down', () => {
+        expect(apply('# Doc\n## A\n## B', 'n/1', 'down')).toBeNull();
+    });
+
+    it('blocks crossing the list/heading boundary (bullet cannot pass a heading)', () => {
+        const tree = documentToTree('# Doc\n- a\n## B', 'Untitled').tree;
+        expect(canReorder(tree, 'n/0', 'down')).toBe(false); // bullet a can't go below heading B
+        expect(canReorder(tree, 'n/1', 'up')).toBe(false);   // heading B can't go above bullet a
+        expect(apply('# Doc\n- a\n## B', 'n/0', 'down')).toBeNull();
+    });
+});
+
+describe('mindmapReorder — cross-level (indent/outdent)', () => {
+    it('demotes a heading under its previous heading sibling (re-levels ##→###)', () => {
+        const r = apply('# Doc\n## A\n## B', 'n/1', 'indent');
+        expect(r?.out).toBe('# Doc\n\n## A\n\n### B');
+        expect(r?.newId).toBe('n/0/0');
+        expect(r?.label).toBe('B');
+    });
+
+    it('outdents a heading to its grandparent (###→##)', () => {
+        const r = apply('# Doc\n## A\n### B', 'n/0/0', 'outdent');
+        expect(r?.out).toBe('# Doc\n\n## A\n\n## B');
+        expect(r?.newId).toBe('n/1');
+        expect(r?.label).toBe('B');
+    });
+
+    it('demotes a heading under a bullet → coerced to a sub-bullet (invariant A)', () => {
+        const r = apply('# Doc\n- a\n## B', 'n/1', 'indent');
+        expect(r?.out).toBe('# Doc\n- a\n  - B');
+        expect(r?.newId).toBe('n/0/0');
+        expect(r?.label).toBe('B');
+    });
+
+    it('demotes a bullet under its previous bullet', () => {
+        const r = apply('# Doc\n- a\n- b', 'n/1', 'indent');
+        expect(r?.out).toBe('# Doc\n- a\n  - b');
+        expect(r?.label).toBe('b');
+    });
+
+    it('carries the moved subtree with the node (demote re-levels descendants)', () => {
+        const r = apply('# Doc\n## A\n## B\n### C', 'n/1', 'indent');
+        // B (with child C) becomes a child of A: B ##→###, C ###→####
+        expect(r?.out).toBe('# Doc\n\n## A\n\n### B\n\n#### C');
+        expect(r?.label).toBe('B');
+    });
+
+    it('blocks indenting the first child (no previous sibling)', () => {
+        expect(canReorder(documentToTree('# Doc\n## A\n## B', 'Untitled').tree, 'n/0', 'indent')).toBe(false);
+        expect(apply('# Doc\n## A\n## B', 'n/0', 'indent')).toBeNull();
+    });
+
+    it('blocks outdenting a direct child of the root', () => {
+        expect(canReorder(documentToTree('# Doc\n## A', 'Untitled').tree, 'n/0', 'outdent')).toBe(false);
+        expect(apply('# Doc\n## A', 'n/0', 'outdent')).toBeNull();
+    });
+
+    it('keeps the lists-before-headings invariant when inserting a bullet', () => {
+        // Section A holds a bullet then a sub-heading; outdent the deep bullet so
+        // it lands in A's list group (before the sub-heading), not after it.
+        const src = '# Doc\n## A\n- x\n### Sub\n- y';
+        // locate y: A=n/0; A children = [x(list n/0/0), Sub(heading n/0/1)]; y under Sub = n/0/1/0
+        const r = apply(src, 'n/0/1/0', 'outdent');
+        // y promotes to be A's child; as a list it must precede Sub → re-parses cleanly
+        expect(r?.label).toBe('y');
+        // round-trip stable: re-serialize equals the parsed output (no drift)
+        const reparsed = documentToTree(r!.out + '\n', 'Untitled').tree;
+        expect(treeToDocument(reparsed, '', 'Untitled').trim()).toBe(r?.out);
+    });
+});
+
+describe('mindmapReorder — round-trip stability', () => {
+    it('every op output re-serializes idempotently', () => {
+        const cases: Array<[string, string, ReorderOp]> = [
+            ['# Doc\n## A\n## B', 'n/0', 'down'],
+            ['# Doc\n## A\n## B', 'n/1', 'indent'],
+            ['# Doc\n## A\n### B', 'n/0/0', 'outdent'],
+            ['# Doc\n- a\n## B', 'n/1', 'indent'],
+        ];
+        for (const [md, id, op] of cases) {
+            const r = apply(md, id, op)!;
+            const reparsed = documentToTree(r.out + '\n', 'Untitled').tree;
+            expect(treeToDocument(reparsed, '', 'Untitled').trim()).toBe(r.out);
+        }
+    });
+});

--- a/src/lib/mindmapReorder.ts
+++ b/src/lib/mindmapReorder.ts
@@ -1,0 +1,165 @@
+/**
+ * Outliner-style node reorder for the mindmap (markdown↔tree bridge aware).
+ *
+ * The mindmap is a derived view of markdown, so "moving a node" really means
+ * restructuring the underlying document. These four operations mirror an
+ * outliner (Obsidian outline / Workflowy):
+ *
+ *   up / down  — reorder among same-level siblings (same heading/list group)
+ *   indent     — demote: become the last child of the previous sibling
+ *   outdent    — promote: become a sibling of the parent (after it)
+ *
+ * The serializer (markdownTree.ts `serializeNode`) is structural + clamped:
+ *   - list nesting depth is computed from tree depth (no stored level),
+ *   - heading level = clamp(wanted, parentHeadingLevel+1, 6).
+ * So after a move we only have to keep the tree VALID; the serializer fixes
+ * levels. "Valid" means two invariants the markdown round-trip relies on:
+ *
+ *   (A) origin compatibility — a `list` node may only hold `list` children
+ *       (you cannot nest a heading inside a bullet in CommonMark). So when a
+ *       node lands under a list parent we coerce the whole moved subtree to
+ *       the list family.
+ *   (B) sibling ordering — within any parent, all `list` children precede all
+ *       `heading` children (the parser attaches bullets to a heading until a
+ *       sub-heading appears, then later bullets bind to that sub-heading). So
+ *       inserts are clamped into the node's own origin group.
+ *
+ * Heading-family moves additionally drop `mdLevel` on the moved subtree so the
+ * serializer re-levels it structurally (no skipped `##`→`####`). All functions
+ * are pure: `reorderNode` clones the input and returns a fresh tree.
+ *
+ * IDs are path-based (`n/0/2`) and regenerate on re-parse, so each op also
+ * returns the moved node's NEW id (computed from the stable new-parent path)
+ * for the view to re-select after commit.
+ */
+
+import type { MindmapNode } from '../types/mindmap';
+
+export type ReorderOp = 'up' | 'down' | 'indent' | 'outdent';
+
+interface Located {
+    node: MindmapNode;
+    parent: MindmapNode;
+    index: number;
+    grandparent: MindmapNode | null;
+    /** Index of `parent` within `grandparent` (−1 when parent is the root). */
+    parentIndex: number;
+}
+
+/** Effective origin family: 'root' / undefined behave as the heading family. */
+function effOrigin(n: MindmapNode): 'heading' | 'list' {
+    return n.mdOrigin === 'list' ? 'list' : 'heading';
+}
+
+function nodeAtPath(root: MindmapNode, parts: number[]): MindmapNode | null {
+    let cur: MindmapNode | undefined = root;
+    for (const i of parts) {
+        cur = cur?.children[i];
+        if (!cur) return null;
+    }
+    return cur ?? null;
+}
+
+/** Resolve a path-based id to the node plus its parent/grandparent context. */
+function locate(root: MindmapNode, id: string): Located | null {
+    const parts = id.split('/').slice(1).map(Number);
+    if (parts.length === 0) return null; // the root itself cannot be moved
+    const index = parts[parts.length - 1];
+    const parentParts = parts.slice(0, -1);
+    const parent = nodeAtPath(root, parentParts);
+    if (!parent) return null;
+    const node = parent.children[index];
+    if (!node) return null;
+    const grandparent = parentParts.length === 0 ? null : nodeAtPath(root, parentParts.slice(0, -1));
+    const parentIndex = parentParts.length === 0 ? -1 : parentParts[parentParts.length - 1];
+    return { node, parent, index, grandparent, parentIndex };
+}
+
+/** Invariant (A): a node under a list parent — and its whole subtree — must be
+ *  list-origin. Drop levels too (lists carry no heading level). */
+function coerceListFamily(n: MindmapNode): void {
+    n.mdOrigin = 'list';
+    delete n.mdLevel;
+    for (const c of n.children) coerceListFamily(c);
+}
+
+/** Heading-family move: re-level structurally by dropping stored heading levels
+ *  on the moved subtree (origins kept, so headings stay headings, lists lists). */
+function stripLevels(n: MindmapNode): void {
+    delete n.mdLevel;
+    for (const c of n.children) stripLevels(c);
+}
+
+/** Index where the heading group starts (= end of the list group). */
+function firstHeadingIndex(children: MindmapNode[]): number {
+    const i = children.findIndex((c) => effOrigin(c) === 'heading');
+    return i === -1 ? children.length : i;
+}
+
+/** Insert `node` into `parent.children` at `preferred`, clamped to keep
+ *  invariant (B): lists before headings. Returns the actual insert index. */
+function insertOrdered(parent: MindmapNode, node: MindmapNode, preferred: number): number {
+    const fh = firstHeadingIndex(parent.children);
+    const [lo, hi] = effOrigin(node) === 'list' ? [0, fh] : [fh, parent.children.length];
+    const idx = Math.max(lo, Math.min(preferred, hi));
+    parent.children.splice(idx, 0, node);
+    return idx;
+}
+
+/** Whether `op` is allowed for the node `id` (drives button enable/disable). */
+export function canReorder(root: MindmapNode, id: string, op: ReorderOp): boolean {
+    const loc = locate(root, id);
+    if (!loc) return false;
+    const { node, parent, index, grandparent } = loc;
+    switch (op) {
+        case 'up':
+            return index > 0 && effOrigin(parent.children[index - 1]) === effOrigin(node);
+        case 'down':
+            return index < parent.children.length - 1 && effOrigin(parent.children[index + 1]) === effOrigin(node);
+        case 'indent':
+            return index > 0; // needs a previous sibling to nest under
+        case 'outdent':
+            return !!grandparent; // a direct child of the root cannot promote
+    }
+}
+
+/**
+ * Apply a reorder op. Returns a fresh mutated tree + the moved node's new id,
+ * or null when the op is not allowed (mirrors `canReorder`).
+ */
+export function reorderNode(
+    root: MindmapNode,
+    id: string,
+    op: ReorderOp,
+): { tree: MindmapNode; newId: string } | null {
+    const tree = structuredClone(root);
+    const loc = locate(tree, id);
+    if (!loc) return null;
+    const { node, parent, index, grandparent, parentIndex } = loc;
+
+    if (op === 'up' || op === 'down') {
+        const j = op === 'up' ? index - 1 : index + 1;
+        if (j < 0 || j >= parent.children.length) return null;
+        if (effOrigin(parent.children[j]) !== effOrigin(node)) return null; // group boundary
+        [parent.children[index], parent.children[j]] = [parent.children[j], parent.children[index]];
+        return { tree, newId: `${parent.id}/${j}` };
+    }
+
+    if (op === 'indent') {
+        if (index === 0) return null;
+        const target = parent.children[index - 1]; // previous sibling (stays at index−1)
+        parent.children.splice(index, 1);
+        if (effOrigin(target) === 'list') coerceListFamily(node);
+        else stripLevels(node);
+        const insertIdx = insertOrdered(target, node, target.children.length);
+        return { tree, newId: `${target.id}/${insertIdx}` };
+    }
+
+    // outdent
+    if (!grandparent) return null;
+    parent.children.splice(index, 1);
+    if (effOrigin(grandparent) === 'list') coerceListFamily(node);
+    else stripLevels(node);
+    const insertIdx = insertOrdered(grandparent, node, parentIndex + 1);
+    return { tree, newId: `${grandparent.id}/${insertIdx}` };
+}


### PR DESCRIPTION
## 배경
이슈 #46의 잔여 항목 **마인드맵 노드 순서변경(reorder)**. 마인드맵은 마크다운의 파생 뷰라, 노드 이동 = 마크다운 구조 재배치. 아웃라이너(Obsidian/Workflowy) 모델로 구현.

> ⚠️ **스택형 PR** — base가 `feat/remove-vault-graph`(#69). #69를 main에 머지한 뒤 이 PR을 main으로 retarget(또는 #69 머지 후 자동 갱신)하세요. 같은 파일(MindmapView/Canvas)을 수정해 vault 제거 위에 쌓였습니다.

## 두 방향 매핑 (요청)
- **① 같은 레벨 순서** → `↑`/`↓` (같은 origin 그룹 swap, 경계는 비활성)
- **② 다른 레벨 이동** → `Tab`/`⇧Tab` (들여/내어쓰기, origin·레벨 자동 정합)

## 핵심 — 마크다운 브리지 불변식 준수
직렬화기 분석에서 도출한 함정 3가지 대응:
- **(A) origin 호환성**: 리스트 밑엔 헤딩 불가 → 서브트리 list family로 coerce
- **(B) 정렬 불변식**: 부모 자식은 `list*→heading*` 순서 → 삽입 위치 clamp
- **레벨 재계산**: 헤딩 이동 시 `mdLevel` strip → 직렬화기가 구조적 재레벨(##→### 스킵 없음)
- **ID 재생성**: 경로 기반 ID라 이동 후 새 ID 반환·재선택

## 변경
- `mindmapReorder.ts`(신규): `reorderNode`(up/down/indent/outdent) + `canReorder`
- `mindmapReorder.test.ts`(신규, 15): 마크다운 왕복·경계 차단·coercion·**멱등성**
- `MindmapView/Canvas`(+css): hover 툴바 4버튼(불가 시 비활성) + 키보드(편집/입력/⌘조합 시 무시) + 노드 선택(accent 링) + 이동 후 자동 재선택

## 검증
- **vitest 121**(reorder 15 + 골든 26 포함) + tsc + vite build 통과
- 런타임 QA(`npm run tauri dev`)는 별도 — 버튼/키보드 체감 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)