### PR TITLE
feat(ui): 상단 UI 개편 — 타이틀바 파일명·네이티브 메뉴·검색 통일·툴바 View/Recent

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
   ],
   "permissions": [
     "core:default",
+    "core:menu:default",
     "core:event:default",
     "core:event:allow-listen",
     "core:event:allow-unlisten",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -42,6 +42,7 @@
     "fs:allow-write-text-file",
     "fs:allow-write-file",
     "fs:allow-exists",
+    "fs:allow-stat",
     "fs:allow-remove",
     "fs:allow-mkdir",
     "fs:allow-copy-file",

--- a/src/App.css
+++ b/src/App.css
@@ -481,6 +481,12 @@ body {
   cursor: not-allowed;
 }
 
+/* 현재 선택된 뷰모드(View 메뉴) — accent 색으로 강조 */
+.dropdown-item.active {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .dropdown-icon-img {
   width: 14px;
   height: 14px;

--- a/src/App.css
+++ b/src/App.css
@@ -745,6 +745,12 @@ body {
   outline: 1.5px solid rgba(255, 140, 0, 0.9);
 }
 
+/* split 오른쪽 정적 프리뷰 검색 하이라이트 — CSS Custom Highlight API(DOM 무변경).
+   ::highlight() 는 색/배경/밑줄만 지원(border-radius·outline 불가). */
+::highlight(mm-preview-search) {
+  background-color: rgba(255, 200, 0, 0.45);
+}
+
 /* CodeMirror 검색 매치 — 통일 SearchBar 가 setSearchQuery 로 구동(네이티브 패널 없음) */
 .cm-searchMatch {
   background: rgba(255, 200, 0, 0.35);
@@ -2746,6 +2752,9 @@ code.hljs {
 }
 
 .tutorial-overlay-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text-primary);

--- a/src/App.css
+++ b/src/App.css
@@ -456,6 +456,68 @@ body {
   animation: fadeIn 100ms ease-out;
 }
 
+/* 가운데 현재 View 인디케이터 (.toolbar 는 드래그 영역이라 no-drag 필수) */
+.toolbar-view-indicator {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.toolbar-view-current {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.toolbar-view-current:hover,
+.toolbar-view-current.active {
+  color: var(--text-primary);
+}
+
+.toolbar-view-caret {
+  opacity: 0.55;
+}
+
+/* 가운데 트리거 기준으로 드롭다운 중앙 정렬 (.toolbar-dropdown-menu 의 left:0 override) */
+.toolbar-view-menu {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* History(최근 파일) 드롭다운 — 폭 넓게, 항목은 [아이콘 | 이름+날짜] */
+.toolbar-recent-menu {
+  min-width: 340px;
+  max-width: 480px;
+}
+
+.dropdown-recent-item {
+  align-items: flex-start;
+}
+
+/* 시계 아이콘 크기 고정 (긴 파일명이 와도 안 찌그러지게) */
+.dropdown-recent-item > svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.dropdown-recent-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+}
+
 .dropdown-item {
   display: flex;
   align-items: center;
@@ -548,10 +610,15 @@ body {
   font-size: 13px;
   color: var(--text-primary);
   font-weight: 500;
+  /* 긴 파일명은 한 줄로 말줄임(글자수 제한). 전체 이름은 hover title 로 확인. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 .dropdown-submenu-path {
   font-size: 11px;
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
   white-space: nowrap;
   overflow: hidden;

--- a/src/App.css
+++ b/src/App.css
@@ -181,6 +181,34 @@ body {
   background: var(--bg-toolbar);
   cursor: default;
   user-select: none;
+  /* 파일명을 신호등 줄 중앙에 배치 (좌/우 빈 영역은 그대로 드래그 가능) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 타이틀바 파일명 슬롯 — 클릭=이름변경이 되도록 드래그 제외(no-drag).
+   내용 폭만 차지해 양옆 빈 공간은 창 드래그 영역으로 남는다. */
+.titlebar-filename {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+  display: inline-flex;
+  align-items: center;
+  max-width: 72%;
+  /* 파일명 가변 폭 — 창(뷰포트) 폭에 비례(vw), min/max 로 클램프. 읽기·편집 공용. */
+  --titlebar-name-w: clamp(240px, 42vw, 760px);
+}
+
+/* 편집 입력: 폭을 가변값으로 채움 (base 의 max-width:300px 해제). */
+.titlebar-filename .toolbar-filename-input {
+  width: var(--titlebar-name-w);
+  max-width: none;
+}
+
+/* 읽기(편집 전) 표시: 동일 로직의 상한 — 짧은 이름은 내용 폭, 긴 이름은
+   창 폭에 비례해 늘어난 뒤 말줄임(...). */
+.titlebar-filename .toolbar-filename {
+  max-width: var(--titlebar-name-w);
 }
 
 /* ---------- Toolbar ---------- */

--- a/src/App.css
+++ b/src/App.css
@@ -582,13 +582,44 @@ body {
 /* ---------- Search Bar ---------- */
 .search-bar {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
   padding: 6px 16px;
   background: var(--bg-toolbar);
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
   animation: fadeIn 150ms ease-out;
+}
+
+.search-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.search-replace-btn {
+  height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.search-replace-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.search-replace-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .search-input {
@@ -709,7 +740,17 @@ body {
   background: rgba(255, 200, 0, 0.35);
   border-radius: 2px;
 }
-.search-result-current {
+.rich-search-highlight-current {
+  background: rgba(255, 140, 0, 0.7);
+  outline: 1.5px solid rgba(255, 140, 0, 0.9);
+}
+
+/* CodeMirror 검색 매치 — 통일 SearchBar 가 setSearchQuery 로 구동(네이티브 패널 없음) */
+.cm-searchMatch {
+  background: rgba(255, 200, 0, 0.35);
+  border-radius: 2px;
+}
+.cm-searchMatch-selected {
   background: rgba(255, 140, 0, 0.7);
   outline: 1.5px solid rgba(255, 140, 0, 0.9);
 }
@@ -1243,15 +1284,12 @@ body {
 
 /* 검색창 닫기 X 버튼 — 크고 명확하게 */
 .search-close-btn {
-  width: 32px;
-  height: 32px;
-  margin-left: 6px;
+  width: 24px;
+  height: 24px;
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-secondary);
-  font-size: 16px;
-  font-weight: 600;
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -843,6 +843,7 @@ function App() {
     setSearchVisible(false);
     setSearchQuery('');
     setSearchReplace('');
+    setSearchShowReplace(false);
     setSearchMatchCount(0);
     setSearchCurrentIndex(-1);
     editorRef.current?.searchClear();
@@ -943,11 +944,44 @@ function App() {
     setSearchCurrentIndex(info.count > 0 ? info.index : -1);
   }, []);
 
+  // split 의 오른쪽 프리뷰(정적 react-markdown HTML)는 Tiptap 이 아니라 검색 명령이 안 닿는다.
+  // DOM 에 <mark> 를 꽂으면 react-markdown 재조정과 충돌하므로, DOM 무변경인 CSS Custom
+  // Highlight API 로 매치 range 만 등록한다(미지원 webview 면 graceful 패스).
+  const PREVIEW_HL = 'mm-preview-search';
+  const clearPreviewHighlight = useCallback(() => {
+    (CSS as unknown as { highlights?: Map<string, unknown> }).highlights?.delete(PREVIEW_HL);
+  }, []);
+  const highlightPreviewDom = useCallback((query: string) => {
+    const reg = (CSS as unknown as { highlights?: Map<string, unknown> }).highlights;
+    const HighlightCtor = (window as unknown as { Highlight?: new (...r: Range[]) => unknown }).Highlight;
+    if (!reg || !HighlightCtor) return; // 미지원 → 패스
+    const root = document.querySelector('.preview-wrapper .markdown-body');
+    if (!root || !query) { reg.delete(PREVIEW_HL); return; }
+    const ranges: Range[] = [];
+    const needle = query.toLowerCase();
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      const hay = (node.textContent ?? '').toLowerCase();
+      let idx = hay.indexOf(needle);
+      while (idx !== -1) {
+        const r = document.createRange();
+        r.setStart(node, idx);
+        r.setEnd(node, idx + query.length);
+        ranges.push(r);
+        idx = hay.indexOf(needle, idx + needle.length);
+      }
+    }
+    if (ranges.length) reg.set(PREVIEW_HL, new HighlightCtor(...ranges));
+    else reg.delete(PREVIEW_HL);
+  }, []);
+
   const runSearch = useCallback((query: string, replace: string) => {
     if (viewMode === 'preview') {
       window.dispatchEvent(new CustomEvent('markmind:rich-search', { detail: { query } }));
     } else {
       applySearchInfo(editorRef.current?.searchSetQuery(query, replace));
+      // split 의 오른쪽(정적 프리뷰) 하이라이트는 아래 effect 가 CSS Highlight API 로 처리.
     }
   }, [viewMode, applySearchInfo]);
 
@@ -967,18 +1001,22 @@ function App() {
       applySearchInfo(all
         ? editorRef.current?.searchReplaceAll(searchReplace)
         : editorRef.current?.searchReplaceCurrent(searchReplace));
+      // split: 소스 변경 → content 갱신 → 아래 effect 가 프리뷰 하이라이트 재계산.
     }
   }, [viewMode, applySearchInfo, searchReplace]);
 
   const closeSearch = useCallback(() => {
-    if (viewMode === 'preview') window.dispatchEvent(new Event('markmind:rich-search-clear'));
-    else editorRef.current?.searchClear();
+    // 양 엔진 모두 해제(미마운트 쪽은 no-op) — split 의 오른쪽 하이라이트까지 확실히 정리.
+    editorRef.current?.searchClear();
+    window.dispatchEvent(new Event('markmind:rich-search-clear'));
+    clearPreviewHighlight();
     setSearchVisible(false);
     setSearchQuery('');
     setSearchReplace('');
+    setSearchShowReplace(false);
     setSearchMatchCount(0);
     setSearchCurrentIndex(-1);
-  }, [viewMode]);
+  }, [clearPreviewHighlight]);
 
   const toggleSearch = useCallback(() => {
     if (searchVisible) {
@@ -995,6 +1033,15 @@ function App() {
     runSearch(searchQuery, searchReplace);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery, searchVisible, viewMode]);
+
+  // split 오른쪽(정적 프리뷰) 하이라이트 — 검색어/내용 변경·재렌더 후 CSS Highlight 재계산.
+  useEffect(() => {
+    if (viewMode === 'split' && searchVisible && searchQuery) {
+      const t = setTimeout(() => highlightPreviewDom(searchQuery), 40);
+      return () => clearTimeout(t);
+    }
+    clearPreviewHighlight();
+  }, [viewMode, searchVisible, searchQuery, content, highlightPreviewDom, clearPreviewHighlight]);
 
   // Rich Text search 결과 count + 현재 index 회신 listen
   useEffect(() => {
@@ -1110,12 +1157,12 @@ function App() {
             break;
           case '2':
             e.preventDefault();
-            setViewMode('split');
+            setViewMode('preview');
             setReadingMode(false);
             break;
           case '3':
             e.preventDefault();
-            setViewMode('preview');
+            setViewMode('split');
             setReadingMode(false);
             break;
           case '4':
@@ -1580,7 +1627,7 @@ function App() {
         <div className="tutorial-overlay" onClick={() => setTutorialVisible(false)}>
           <div className="tutorial-overlay-content" onClick={(e) => e.stopPropagation()}>
             <div className="tutorial-overlay-header">
-              <span className="tutorial-overlay-title"><BookOpen size={16} strokeWidth={1.5} /> Tutorial</span>
+              <span className="tutorial-overlay-title"><BookOpen size={16} strokeWidth={1.5} /><span>Tutorial</span></span>
               <button className="tutorial-overlay-close" onClick={() => setTutorialVisible(false)}><IconX size={16} /></button>
             </div>
             <div className="tutorial-overlay-body">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
 import { FlowchartView } from './components/FlowchartView';
 import { GanttView } from './components/GanttView';
-import { Toolbar, ViewMode } from './components/Toolbar';
+import { Toolbar, EditableFileName, ViewMode } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
 import { OutlinePanel } from './components/OutlinePanel';
 import { RecentFilesPanel } from './components/RecentFilesPanel';
@@ -1405,10 +1405,14 @@ function App() {
             }
           });
         }}
-      />
+      >
+        {/* 파일명을 타이틀바(신호등 줄) 중앙에 표시 — 클릭 시 이름변경.
+            no-drag + stopPropagation 으로 클릭은 편집, 빈 영역은 창 드래그. */}
+        <div className="titlebar-filename" onMouseDown={(e) => e.stopPropagation()}>
+          <EditableFileName fileName={fileName} isDirty={isDirty} onRename={renameFile} />
+        </div>
+      </div>
       <Toolbar
-        fileName={fileName}
-        isDirty={isDirty}
         viewMode={viewMode}
         fontSize={fontSize}
         outlineVisible={outlineVisible}
@@ -1437,7 +1441,6 @@ function App() {
         onToggleAI={handleToggleAI}
         showRecent={isTauri()}
         aiPanelVisible={ai.panelVisible}
-        onRename={renameFile}
       />
 
       {/* Search bar */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { setValidationStatus } from './services/apiValidation';
 import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
 import { FlowchartView } from './components/FlowchartView';
+import { SearchBar } from './components/SearchBar';
 import { GanttView } from './components/GanttView';
 import { Toolbar, EditableFileName, ViewMode } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
@@ -163,10 +164,10 @@ function App() {
   const [recentPanelVisible, setRecentPanelVisible] = useState(false);
   const [searchVisible, setSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchReplace, setSearchReplace] = useState('');
+  const [searchShowReplace, setSearchShowReplace] = useState(false);
   const [searchMatchCount, setSearchMatchCount] = useState(0);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(-1);
-  const searchMatchesRef = useRef<HTMLElement[]>([]);
-  const searchCurrentIndexRef = useRef(-1);
   const isDragging = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
   // viewMode 전환 시 scroll 위치 보존 — Markdown(CodeMirror) ↔ Rich Text(.preview-wrapper) ↔ Split
@@ -838,11 +839,14 @@ function App() {
 
   // Re-attach scroll sync + close search on view mode change
   useEffect(() => {
-    // Close preview search bar
+    // 뷰 전환 시 검색 닫기 + 양 엔진 상태 해제
     setSearchVisible(false);
     setSearchQuery('');
-    // Close CodeMirror search panel
-    editorRef.current?.closeSearch();
+    setSearchReplace('');
+    setSearchMatchCount(0);
+    setSearchCurrentIndex(-1);
+    editorRef.current?.searchClear();
+    window.dispatchEvent(new Event('markmind:rich-search-clear'));
 
     if (viewMode === 'split') {
       reattach();
@@ -930,165 +934,67 @@ function App() {
   }, []);
 
   // Search toggle
-  const toggleSearch = useCallback(() => {
-    // In editor or split mode, toggle CodeMirror's built-in search panel
-    if (viewMode !== 'preview') {
-      editorRef.current?.toggleSearch();
-      return;
+  // ─── 통일 검색 (Markdown/CodeMirror + Rich Text/Tiptap 공용 SearchBar) ───
+  // 엔진 라우팅: 편집/split → editorRef 프로그램 검색(동기 {count,index}), 프리뷰 →
+  // Tiptap window 이벤트(카운트는 markmind:rich-search-count 로 비동기 회신).
+  const applySearchInfo = useCallback((info?: { count: number; index: number } | null) => {
+    if (!info) return;
+    setSearchMatchCount(info.count);
+    setSearchCurrentIndex(info.count > 0 ? info.index : -1);
+  }, []);
+
+  const runSearch = useCallback((query: string, replace: string) => {
+    if (viewMode === 'preview') {
+      window.dispatchEvent(new CustomEvent('markmind:rich-search', { detail: { query } }));
+    } else {
+      applySearchInfo(editorRef.current?.searchSetQuery(query, replace));
     }
-    // In preview mode, show the preview search bar
-    setSearchVisible((prev) => {
-      const next = !prev;
-      if (next) {
-        setTimeout(() => searchInputRef.current?.focus(), 100);
-      } else {
-        setSearchQuery('');
-        clearHighlights();
-        // Rich Text 검색 highlight 도 같이 clear
-        window.dispatchEvent(new Event('markmind:rich-search-clear'));
-      }
-      return next;
-    });
+  }, [viewMode, applySearchInfo]);
+
+  const navigateMatch = useCallback((delta: number) => {
+    if (viewMode === 'preview') {
+      window.dispatchEvent(new Event(delta > 0 ? 'markmind:rich-search-next' : 'markmind:rich-search-prev'));
+    } else {
+      applySearchInfo(delta > 0 ? editorRef.current?.searchNext() : editorRef.current?.searchPrev());
+    }
+  }, [viewMode, applySearchInfo]);
+
+  const replaceMatch = useCallback((all: boolean) => {
+    if (viewMode === 'preview') {
+      const ev = all ? 'markmind:rich-search-replace-all' : 'markmind:rich-search-replace';
+      window.dispatchEvent(new CustomEvent(ev, { detail: { replace: searchReplace } }));
+    } else {
+      applySearchInfo(all
+        ? editorRef.current?.searchReplaceAll(searchReplace)
+        : editorRef.current?.searchReplaceCurrent(searchReplace));
+    }
+  }, [viewMode, applySearchInfo, searchReplace]);
+
+  const closeSearch = useCallback(() => {
+    if (viewMode === 'preview') window.dispatchEvent(new Event('markmind:rich-search-clear'));
+    else editorRef.current?.searchClear();
+    setSearchVisible(false);
+    setSearchQuery('');
+    setSearchReplace('');
+    setSearchMatchCount(0);
+    setSearchCurrentIndex(-1);
   }, [viewMode]);
 
-  // Preview search: scroll a match element into view precisely
-  const scrollToMatch = useCallback((el: HTMLElement) => {
-    const wrapper = document.querySelector('.preview-wrapper') as HTMLElement | null;
-    if (!wrapper) return;
-    const wrapperRect = wrapper.getBoundingClientRect();
-    const elRect = el.getBoundingClientRect();
-    const relativeTop = elRect.top - wrapperRect.top + wrapper.scrollTop;
-    const targetScrollTop = relativeTop - wrapperRect.height / 2 + elRect.height / 2;
-    wrapper.scrollTo({ top: Math.max(0, targetScrollTop), behavior: 'smooth' });
-  }, []);
-
-  // Navigate to a specific match index and update active highlight
-  const goToMatchIndex = useCallback((index: number, matches: HTMLElement[]) => {
-    if (matches.length === 0) return;
-    // Remove active from previous
-    const prevEl = matches[searchCurrentIndexRef.current];
-    if (prevEl) prevEl.classList.remove('search-highlight-active');
-    // Apply active to new
-    const nextEl = matches[index];
-    if (nextEl) {
-      nextEl.classList.add('search-highlight-active');
-      scrollToMatch(nextEl);
-    }
-    searchCurrentIndexRef.current = index;
-    setSearchCurrentIndex(index);
-  }, [scrollToMatch]);
-
-  // Navigate by delta (+1 forward, -1 backward), wrapping around
-  const navigateMatch = useCallback((delta: number) => {
-    // Rich Text 모드 — TipTap search ext 명령으로 위임
-    if (viewMode === 'preview') {
-      const ev = delta > 0 ? 'markmind:rich-search-next' : 'markmind:rich-search-prev';
-      window.dispatchEvent(new Event(ev));
-      // current index UI 도 갱신 — count 가 0보다 크면 modulo
-      setSearchCurrentIndex((cur) => {
-        const total = searchMatchCount;
-        if (total === 0) return -1;
-        return (cur + delta + total) % total;
-      });
-      return;
-    }
-    const matches = searchMatchesRef.current;
-    if (matches.length === 0) return;
-    const next = (searchCurrentIndexRef.current + delta + matches.length) % matches.length;
-    goToMatchIndex(next, matches);
-  }, [goToMatchIndex, viewMode, searchMatchCount]);
-
-  // Highlight all matches in the preview DOM
-  const highlightMatches = useCallback((query: string) => {
-    // Clear previous
-    const oldMarks = document.querySelectorAll('.search-highlight');
-    oldMarks.forEach((mark) => {
-      const parent = mark.parentNode;
-      if (parent) {
-        parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
-        parent.normalize();
-      }
-    });
-    searchMatchesRef.current = [];
-    searchCurrentIndexRef.current = -1;
-    setSearchMatchCount(0);
-    setSearchCurrentIndex(-1);
-
-    if (!query.trim()) return;
-
-    const previewEl = document.querySelector('.preview-wrapper .markdown-body');
-    if (!previewEl) return;
-
-    const walker = document.createTreeWalker(previewEl, NodeFilter.SHOW_TEXT);
-    const found: { node: Text; index: number }[] = [];
-    const lowerQuery = query.toLowerCase();
-
-    let node;
-    while ((node = walker.nextNode())) {
-      const text = (node as Text).textContent || '';
-      let idx = text.toLowerCase().indexOf(lowerQuery);
-      while (idx !== -1) {
-        found.push({ node: node as Text, index: idx });
-        idx = text.toLowerCase().indexOf(lowerQuery, idx + 1);
-      }
-    }
-
-    // Build marks in reverse order to preserve text node indices
-    const marks: HTMLElement[] = [];
-    for (let i = found.length - 1; i >= 0; i--) {
-      const { node: textNode, index } = found[i];
-      try {
-        const range = document.createRange();
-        range.setStart(textNode, index);
-        range.setEnd(textNode, index + query.length);
-        const mark = document.createElement('mark');
-        mark.className = 'search-highlight';
-        range.surroundContents(mark);
-        marks.unshift(mark);
-      } catch {
-        // Skip if range operation fails (e.g., across element boundaries)
-      }
-    }
-
-    searchMatchesRef.current = marks;
-    setSearchMatchCount(marks.length);
-
-    if (marks.length > 0) {
-      goToMatchIndex(0, marks);
-    }
-  }, [goToMatchIndex]);
-
-  const clearHighlights = useCallback(() => {
-    const marks = document.querySelectorAll('.search-highlight');
-    marks.forEach((mark) => {
-      const parent = mark.parentNode;
-      if (parent) {
-        parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
-        parent.normalize();
-      }
-    });
-    searchMatchesRef.current = [];
-    searchCurrentIndexRef.current = -1;
-    setSearchMatchCount(0);
-    setSearchCurrentIndex(-1);
-  }, []);
-
-  useEffect(() => {
-    if (viewMode === 'preview') {
-      // Rich Text 모드 — DOM surroundContents 대신 RichEditor 의 TipTap search 위임
-      // (TipTap ProseMirror tree 와 직접 DOM 조작이 충돌하면 editor 깨짐)
-      window.dispatchEvent(
-        new CustomEvent('markmind:rich-search', { detail: { query: searchQuery } }),
-      );
-      return;
-    }
-    if (searchQuery) {
-      const timer = setTimeout(() => highlightMatches(searchQuery), 200);
-      return () => clearTimeout(timer);
+  const toggleSearch = useCallback(() => {
+    if (searchVisible) {
+      closeSearch();
     } else {
-      clearHighlights();
+      setSearchVisible(true);
+      setTimeout(() => searchInputRef.current?.focus(), 80);
     }
-  }, [searchQuery, content, highlightMatches, clearHighlights, viewMode]);
+  }, [searchVisible, closeSearch]);
+
+  // 검색어 변경 → 활성 엔진에 적용(바가 열려있을 때만). replace 는 결과에 무관해 deps 제외.
+  useEffect(() => {
+    if (!searchVisible) return;
+    runSearch(searchQuery, searchReplace);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, searchVisible, viewMode]);
 
   // Rich Text search 결과 count + 현재 index 회신 listen
   useEffect(() => {
@@ -1192,7 +1098,7 @@ function App() {
             newFile();
             break;
           case 'f':
-            if (viewMode === 'preview') {
+            if (viewMode === 'editor' || viewMode === 'split' || viewMode === 'preview') {
               e.preventDefault();
               toggleSearch();
             }
@@ -1464,53 +1370,24 @@ function App() {
         nativeMenu={isTauri()}
       />
 
-      {/* Search bar */}
+      {/* 통일 검색+바꾸기 바 (Markdown/Rich Text 공용) */}
       {searchVisible && (
-        <div className="search-bar">
-          <input
-            ref={searchInputRef}
-            type="text"
-            className="search-input"
-            placeholder="Search in preview…"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') { toggleSearch(); return; }
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                if (e.shiftKey) navigateMatch(-1);
-                else navigateMatch(1);
-              }
-            }}
-          />
-          {searchMatchCount > 0 ? (
-            <>
-              <span className="search-count">
-                {searchCurrentIndex + 1} / {searchMatchCount}
-              </span>
-              <button
-                className="search-nav-btn"
-                onClick={() => navigateMatch(-1)}
-                title="Previous match (Shift+Enter)"
-              >▲</button>
-              <button
-                className="search-nav-btn"
-                onClick={() => navigateMatch(1)}
-                title="Next match (Enter)"
-              >▼</button>
-            </>
-          ) : searchQuery ? (
-            <span className="search-count search-count-empty">No results</span>
-          ) : null}
-          <button
-            className="search-close-btn"
-            onClick={toggleSearch}
-            title="검색 닫기 (Esc)"
-            aria-label="검색 닫기"
-          >
-            <IconX size={20} strokeWidth={2} />
-          </button>
-        </div>
+        <SearchBar
+          query={searchQuery}
+          replaceValue={searchReplace}
+          count={searchMatchCount}
+          index={searchCurrentIndex}
+          showReplace={searchShowReplace}
+          onQueryChange={setSearchQuery}
+          onReplaceChange={setSearchReplace}
+          onNext={() => navigateMatch(1)}
+          onPrev={() => navigateMatch(-1)}
+          onReplaceOne={() => replaceMatch(false)}
+          onReplaceAll={() => replaceMatch(true)}
+          onToggleReplace={() => setSearchShowReplace((v) => !v)}
+          onClose={toggleSearch}
+          inputRef={searchInputRef}
+        />
       )}
 
       <div className="main-content" ref={containerRef}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { useAI } from './hooks/useAI';
 import { useAuth } from './hooks/useAuth';
 import { useConverter } from './hooks/useConverter';
 import { isTauri } from './services/platform';
+import { useNativeMenu } from './hooks/useNativeMenu';
 import { getCallbackPath } from './services/knowaiAuth';
 import { TUTORIAL_CONTENT } from './constants/tutorial';
 import { Link, Unlink, BookOpen, X as IconX, Sparkles, Loader2 } from 'lucide-react';
@@ -1333,6 +1334,25 @@ function App() {
     );
   }
 
+  // 네이티브 macOS 메뉴바에 File/View 미러링(Tauri 한정) — 툴바 dropdown 은 숨김.
+  // (조기 return 보다 위에 둬 hooks 호출 순서 보장.)
+  useNativeMenu({
+    enabled: isTauri(),
+    viewMode,
+    recentFiles,
+    onNewFile: newFile,
+    onOpenFile: handleOpenFile,
+    onSaveFile: saveFile,
+    onSaveFileAs: saveFileAs,
+    onExportPdf: handleExportPdf,
+    onShowSettings: () => setSettingsVisible(true),
+    onShowTutorial: () => setTutorialVisible(true),
+    onOpenFromDrive: () => setDriveBrowserMode('open'),
+    onSaveToDrive: () => setDriveBrowserMode('save'),
+    onOpenRecent: handleOpenRecentByPath,
+    onViewModeChange: setViewMode,
+  });
+
   // Auth callback route — show only the callback handler
   if (isAuthCallback) {
     return (
@@ -1441,6 +1461,7 @@ function App() {
         onToggleAI={handleToggleAI}
         showRecent={isTauri()}
         aiPanelVisible={ai.panelVisible}
+        nativeMenu={isTauri()}
       />
 
       {/* Search bar */}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -4,7 +4,7 @@ import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
-import { openSearchPanel, closeSearchPanel } from '@codemirror/search';
+import { search, setSearchQuery, getSearchQuery, SearchQuery, findNext, findPrevious, replaceNext, replaceAll } from '@codemirror/search';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags } from '@lezer/highlight';
 
@@ -34,12 +34,22 @@ interface EditorProps {
     onImagePaste?: (file: File) => void;
 }
 
+/** 검색 결과 요약 — 총 매치 수 + 현재 매치 0-based index(-1=없음). */
+export interface SearchInfo {
+    count: number;
+    index: number;
+}
+
 export interface EditorHandle {
-    openSearch: () => void;
-    closeSearch: () => void;
-    /** 검색 panel 토글 — 열려있으면 닫고, 닫혀있으면 엶 */
-    toggleSearch: () => void;
-    isSearchOpen: () => boolean;
+    /** 검색어 설정(+첫 매치로 이동). 전체 매치 하이라이트. */
+    searchSetQuery: (query: string, replace: string) => SearchInfo;
+    searchNext: () => SearchInfo;
+    searchPrev: () => SearchInfo;
+    /** 현재 매치를 바꾸고 다음으로. */
+    searchReplaceCurrent: (replace: string) => SearchInfo;
+    searchReplaceAll: (replace: string) => SearchInfo;
+    /** 검색 상태/하이라이트 해제. */
+    searchClear: () => void;
     scrollToLine: (line: number) => void;
     /** 현재 커서 위치에 텍스트 삽입 (이미지 첨부 `![]()` 등) */
     insertAtCursor: (text: string) => void;
@@ -133,37 +143,84 @@ const darkHighlight = HighlightStyle.define([
     { tag: tags.definition(tags.variableName), color: '#FFB86C' },
 ]);
 
+/** 현재 검색 쿼리의 매치 수 + 현재 선택이 몇 번째 매치인지 계산. */
+function computeSearchInfo(view: EditorView): SearchInfo {
+    const query = getSearchQuery(view.state);
+    if (!query.search) return { count: 0, index: -1 };
+    const cur = view.state.selection.main;
+    let count = 0;
+    let index = -1;
+    try {
+        const cursor = query.getCursor(view.state.doc) as Iterator<{ from: number; to: number }>;
+        for (let r = cursor.next(); !r.done; r = cursor.next()) {
+            if (r.value.from === cur.from && r.value.to === cur.to) index = count;
+            count += 1;
+        }
+    } catch {
+        return { count: 0, index: -1 };
+    }
+    return { count, index };
+}
+
+/** 안정 참조 — 인라인 객체면 매 렌더 reconfigure 돼 검색 상태가 리셋된다(과거 버그).
+ *  searchKeymap=false 로 ⌘F 가 네이티브 패널을 열지 않게 함(App 이 통일 SearchBar 토글). */
+const BASIC_SETUP = {
+    lineNumbers: true,
+    highlightActiveLineGutter: true,
+    highlightActiveLine: true,
+    foldGutter: true,
+    autocompletion: false,
+    bracketMatching: true,
+    indentOnInput: true,
+    searchKeymap: false,
+};
+
 export const Editor = forwardRef<EditorHandle, EditorProps>(
     function Editor({ content, onChange, theme, onSelectionChange, onImagePaste }, ref) {
         const cmRef = useRef<ReactCodeMirrorRef>(null);
+        // onChange via ref → handleChange 가 안정 참조라 부모 리렌더 시 reconfigure 안 됨.
+        const onChangeRef = useRef(onChange);
+        onChangeRef.current = onChange;
 
         useImperativeHandle(ref, () => ({
-            openSearch: () => {
+            searchSetQuery: (query: string, replace: string): SearchInfo => {
                 const view = cmRef.current?.view;
-                if (view) {
-                    openSearchPanel(view);
-                }
+                if (!view) return { count: 0, index: -1 };
+                view.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: query, replace, caseSensitive: false })) });
+                if (query) findNext(view); // 입력 즉시 첫 매치로(브라우저 찾기와 동일)
+                return computeSearchInfo(view);
             },
-            closeSearch: () => {
+            searchNext: (): SearchInfo => {
                 const view = cmRef.current?.view;
-                if (view) {
-                    closeSearchPanel(view);
-                }
+                if (!view) return { count: 0, index: -1 };
+                findNext(view);
+                return computeSearchInfo(view);
             },
-            toggleSearch: () => {
+            searchPrev: (): SearchInfo => {
                 const view = cmRef.current?.view;
-                if (!view) return;
-                const panel = view.dom.querySelector('.cm-search.cm-panel');
-                if (panel) {
-                    closeSearchPanel(view);
-                } else {
-                    openSearchPanel(view);
-                }
+                if (!view) return { count: 0, index: -1 };
+                findPrevious(view);
+                return computeSearchInfo(view);
             },
-            isSearchOpen: () => {
+            searchReplaceCurrent: (replace: string): SearchInfo => {
                 const view = cmRef.current?.view;
-                if (!view) return false;
-                return !!view.dom.querySelector('.cm-search.cm-panel');
+                if (!view) return { count: 0, index: -1 };
+                const q = getSearchQuery(view.state);
+                view.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: q.search, replace, caseSensitive: q.caseSensitive, regexp: q.regexp, wholeWord: q.wholeWord })) });
+                replaceNext(view);
+                return computeSearchInfo(view);
+            },
+            searchReplaceAll: (replace: string): SearchInfo => {
+                const view = cmRef.current?.view;
+                if (!view) return { count: 0, index: -1 };
+                const q = getSearchQuery(view.state);
+                view.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: q.search, replace, caseSensitive: q.caseSensitive, regexp: q.regexp, wholeWord: q.wholeWord })) });
+                replaceAll(view);
+                return computeSearchInfo(view);
+            },
+            searchClear: () => {
+                const view = cmRef.current?.view;
+                if (view) view.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: '' })) });
             },
             scrollToLine: (line: number) => {
                 const view = cmRef.current?.view;
@@ -197,17 +254,18 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(
                 });
                 view.focus();
             },
-        }));
+        }), []);
 
         const handleChange = useCallback((value: string) => {
-            onChange(value);
-        }, [onChange]);
+            onChangeRef.current(value);
+        }, []);
 
         const extensions = useMemo(() => {
             const exts = [
                 markdown({ base: markdownLanguage, codeLanguages: languages }),
                 EditorView.lineWrapping,
                 KO_PHRASES,
+                search(), // 검색 상태 + 전체 매치 하이라이트(패널은 안 띄움 — 통일 SearchBar 가 구동)
                 ...(theme === 'dark' ? [syntaxHighlighting(darkHighlight)] : []),
             ];
 
@@ -270,16 +328,7 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(
                     onChange={handleChange}
                     extensions={extensions}
                     theme={theme === 'dark' ? darkTheme : lightTheme}
-                    basicSetup={{
-                        lineNumbers: true,
-                        highlightActiveLineGutter: true,
-                        highlightActiveLine: true,
-                        foldGutter: true,
-                        autocompletion: false,
-                        bracketMatching: true,
-                        indentOnInput: true,
-                        searchKeymap: true,
-                    }}
+                    basicSetup={BASIC_SETUP}
                 />
             </div>
         );

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -897,19 +897,34 @@ function RichEditor({
             );
         };
 
+        // 현재 매치(-current)를 화면 중앙으로 스크롤(데코레이션 적용 후 다음 frame).
+        const scrollToCurrent = () => {
+            requestAnimationFrame(() => {
+                const el = editor.view.dom.querySelector('.rich-search-highlight-current') as HTMLElement | null;
+                el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            });
+        };
+        // 명령 후 storage 갱신은 다음 frame — setTimeout 0 으로 카운트 보고 + 스크롤.
+        const after = () => { reportCount(); scrollToCurrent(); };
+
         const onSearch = (e: Event) => {
             const detail = (e as CustomEvent<{ query: string }>).detail;
             editor.commands.setSearchTerm(detail.query ?? '');
-            // setSearchTerm 후 storage 갱신은 다음 frame — setTimeout 0
-            setTimeout(reportCount, 0);
+            setTimeout(after, 0);
         };
-        const onNext = () => {
-            editor.commands.nextSearchResult();
-            setTimeout(reportCount, 0);
+        const onNext = () => { editor.commands.nextSearchResult(); setTimeout(after, 0); };
+        const onPrev = () => { editor.commands.previousSearchResult(); setTimeout(after, 0); };
+        const onReplace = (e: Event) => {
+            const detail = (e as CustomEvent<{ replace: string }>).detail;
+            editor.commands.setReplaceTerm(detail.replace ?? '');
+            editor.commands.replace();
+            setTimeout(after, 0);
         };
-        const onPrev = () => {
-            editor.commands.previousSearchResult();
-            setTimeout(reportCount, 0);
+        const onReplaceAll = (e: Event) => {
+            const detail = (e as CustomEvent<{ replace: string }>).detail;
+            editor.commands.setReplaceTerm(detail.replace ?? '');
+            editor.commands.replaceAll();
+            setTimeout(after, 0);
         };
         const onClear = () => {
             editor.commands.setSearchTerm('');
@@ -918,11 +933,15 @@ function RichEditor({
         window.addEventListener('markmind:rich-search', onSearch);
         window.addEventListener('markmind:rich-search-next', onNext);
         window.addEventListener('markmind:rich-search-prev', onPrev);
+        window.addEventListener('markmind:rich-search-replace', onReplace);
+        window.addEventListener('markmind:rich-search-replace-all', onReplaceAll);
         window.addEventListener('markmind:rich-search-clear', onClear);
         return () => {
             window.removeEventListener('markmind:rich-search', onSearch);
             window.removeEventListener('markmind:rich-search-next', onNext);
             window.removeEventListener('markmind:rich-search-prev', onPrev);
+            window.removeEventListener('markmind:rich-search-replace', onReplace);
+            window.removeEventListener('markmind:rich-search-replace-all', onReplaceAll);
             window.removeEventListener('markmind:rich-search-clear', onClear);
         };
     }, [editor]);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,115 @@
+/**
+ * Unified search + replace bar — shared by all view modes (Markdown/CodeMirror,
+ * Rich Text/Tiptap). Purely presentational: it renders the UI and reports user
+ * intent through callbacks; App routes those to the active engine. This keeps
+ * one consistent search UX everywhere (previously CM's native panel and a
+ * separate preview bar diverged completely).
+ *
+ * Keyboard: Enter = next, Shift+Enter = previous, Escape = close. The replace
+ * row is collapsed by default and toggled with the ⇄ button.
+ */
+
+import type { RefObject } from 'react';
+import { ChevronUp, ChevronDown, X, Replace } from 'lucide-react';
+
+interface SearchBarProps {
+    query: string;
+    replaceValue: string;
+    /** Total match count. */
+    count: number;
+    /** 0-based index of the current match, or -1 when none. */
+    index: number;
+    showReplace: boolean;
+    onQueryChange: (q: string) => void;
+    onReplaceChange: (r: string) => void;
+    onNext: () => void;
+    onPrev: () => void;
+    onReplaceOne: () => void;
+    onReplaceAll: () => void;
+    onToggleReplace: () => void;
+    onClose: () => void;
+    /** Focused on open. */
+    inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+export function SearchBar({
+    query,
+    replaceValue,
+    count,
+    index,
+    showReplace,
+    onQueryChange,
+    onReplaceChange,
+    onNext,
+    onPrev,
+    onReplaceOne,
+    onReplaceAll,
+    onToggleReplace,
+    onClose,
+    inputRef,
+}: SearchBarProps) {
+    const hasMatches = count > 0;
+
+    return (
+        <div className="search-bar">
+            <div className="search-bar-row">
+                <input
+                    ref={inputRef}
+                    type="text"
+                    className="search-input"
+                    placeholder="검색…"
+                    value={query}
+                    onChange={(e) => onQueryChange(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+                        else if (e.key === 'Enter') {
+                            e.preventDefault();
+                            if (e.shiftKey) onPrev();
+                            else onNext();
+                        }
+                    }}
+                />
+                {hasMatches ? (
+                    <span className="search-count">{index + 1} / {count}</span>
+                ) : query ? (
+                    <span className="search-count search-count-empty">결과 없음</span>
+                ) : null}
+                <button className="search-nav-btn" onClick={onPrev} disabled={!hasMatches} title="이전 (⇧Enter)">
+                    <ChevronUp size={16} strokeWidth={2} />
+                </button>
+                <button className="search-nav-btn" onClick={onNext} disabled={!hasMatches} title="다음 (Enter)">
+                    <ChevronDown size={16} strokeWidth={2} />
+                </button>
+                <button
+                    className={`search-nav-btn${showReplace ? ' active' : ''}`}
+                    onClick={onToggleReplace}
+                    title="바꾸기"
+                    aria-pressed={showReplace}
+                >
+                    <Replace size={15} strokeWidth={2} />
+                </button>
+                <button className="search-close-btn" onClick={onClose} title="검색 닫기 (Esc)" aria-label="검색 닫기">
+                    <X size={16} strokeWidth={2} />
+                </button>
+            </div>
+
+            {showReplace && (
+                <div className="search-bar-row search-replace-row">
+                    <input
+                        type="text"
+                        className="search-input"
+                        placeholder="바꿀 내용…"
+                        value={replaceValue}
+                        onChange={(e) => onReplaceChange(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+                            else if (e.key === 'Enter') { e.preventDefault(); onReplaceOne(); }
+                        }}
+                    />
+                    <button className="search-replace-btn" onClick={onReplaceOne} disabled={!hasMatches}>바꾸기</button>
+                    <button className="search-replace-btn" onClick={onReplaceAll} disabled={!hasMatches}>모두 바꾸기</button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -6,13 +6,23 @@ import {
     Search, ChevronRight, Sparkles, Check, X,
     Settings,
     FileCode, FileText, AlignVerticalSpaceAround,
-    Network, Share2, ChartBarStacked,
+    Network, Share2, ChartBarStacked, type LucideIcon,
 } from 'lucide-react';
 import * as gdriveService from '../services/gdriveService';
 import type { RecentFile } from '../hooks/useRecentFiles';
 import { BackgroundPicker } from './BackgroundPicker';
 
 export type ViewMode = 'split' | 'editor' | 'preview' | 'mindmap' | 'flowchart' | 'gantt';
+
+/** View 메뉴 항목 — 라벨/단축키/아이콘. 사용자가 보는 순서(편집→읽기→분할→…). */
+const VIEW_MODES: { mode: ViewMode; label: string; shortcut: string; Icon: LucideIcon }[] = [
+    { mode: 'editor', label: 'Markdown', shortcut: '⌘1', Icon: FileCode },
+    { mode: 'preview', label: 'Rich Text', shortcut: '⌘3', Icon: FileText },
+    { mode: 'split', label: 'Split View', shortcut: '⌘2', Icon: Columns2 },
+    { mode: 'mindmap', label: 'Mindmap', shortcut: '⌘4', Icon: Share2 },
+    { mode: 'flowchart', label: 'Flowchart', shortcut: '⌘5', Icon: Network },
+    { mode: 'gantt', label: 'Gantt', shortcut: '⌘6', Icon: ChartBarStacked },
+];
 
 export function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; isDirty: boolean; onRename: (name: string) => void }) {
     const [editing, setEditing] = useState(false);
@@ -90,6 +100,8 @@ interface ToolbarProps {
     outlineVisible: boolean;
     showRecent: boolean;
     aiPanelVisible: boolean;
+    /** Tauri: File/View 는 네이티브 메뉴바로 이동했으므로 툴바에서 숨긴다(웹은 표시). */
+    nativeMenu?: boolean;
     onViewModeChange: (mode: ViewMode) => void;
     onNewFile: () => void;
     onOpenFile: () => void;
@@ -144,11 +156,14 @@ export function Toolbar({
     onToggleAI,
     showRecent,
     aiPanelVisible,
+    nativeMenu,
 }: ToolbarProps) {
     const [fileMenuOpen, setFileMenuOpen] = useState(false);
     const [driveAvailable, setDriveAvailable] = useState(false);
     const [driveConnected, setDriveConnected] = useState(false);
     const menuRef = useRef<HTMLDivElement>(null);
+    const [viewMenuOpen, setViewMenuOpen] = useState(false);
+    const viewMenuRef = useRef<HTMLDivElement>(null);
 
     // Drive 가용성 (OAuth credentials 빌드 주입 + 연결 상태)
     useEffect(() => {
@@ -178,15 +193,34 @@ export function Toolbar({
         return () => document.removeEventListener('mousedown', handler);
     }, [fileMenuOpen]);
 
+    // Close View menu on outside click
+    useEffect(() => {
+        if (!viewMenuOpen) return;
+        const handler = (e: MouseEvent) => {
+            if (viewMenuRef.current && !viewMenuRef.current.contains(e.target as Node)) {
+                setViewMenuOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [viewMenuOpen]);
+
     const handleMenuItem = (action: () => void) => {
         action();
         setFileMenuOpen(false);
+    };
+
+    const handleViewSelect = (mode: ViewMode) => {
+        onViewModeChange(mode);
+        setViewMenuOpen(false);
     };
 
     return (
         <div className="toolbar">
             {/* Left: File dropdown + Tutorial + Recent */}
             <div className="toolbar-group">
+                {/* File·View 메뉴는 Tauri 에선 네이티브 메뉴바로 이동 → 숨김(웹은 유지) */}
+                {!nativeMenu && (<>
                 {/* File dropdown */}
                 <div className="toolbar-dropdown" ref={menuRef}>
                     <button
@@ -291,53 +325,33 @@ export function Toolbar({
                     )}
                 </div>
 
-                <div className="toolbar-divider" />
-
-                {/* View modes — Markdown / Rich Text / Split */}
-                <button
-                    className={`toolbar-btn${viewMode === 'editor' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('editor')}
-                    title="Markdown (⌘1)"
-                >
-                    <FileCode size={16} strokeWidth={1.5} />
-                </button>
-                <button
-                    className={`toolbar-btn${viewMode === 'preview' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('preview')}
-                    title="Rich Text (⌘3)"
-                >
-                    <FileText size={16} strokeWidth={1.5} />
-                </button>
-                <button
-                    className={`toolbar-btn${viewMode === 'split' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('split')}
-                    title="Split View (⌘2)"
-                >
-                    <Columns2 size={16} strokeWidth={1.5} />
-                </button>
-                <button
-                    className={`toolbar-btn${viewMode === 'mindmap' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('mindmap')}
-                    title="Mindmap (⌘4)"
-                >
-                    <Share2 size={16} strokeWidth={1.5} />
-                </button>
-                <button
-                    className={`toolbar-btn${viewMode === 'flowchart' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('flowchart')}
-                    title="Flowchart (⌘5)"
-                >
-                    <Network size={16} strokeWidth={1.5} />
-                </button>
-                <button
-                    className={`toolbar-btn${viewMode === 'gantt' ? ' active' : ''}`}
-                    onClick={() => onViewModeChange('gantt')}
-                    title="Gantt (⌘6)"
-                >
-                    <ChartBarStacked size={16} strokeWidth={1.5} />
-                </button>
+                {/* View dropdown — 모든 뷰모드를 한 메뉴로 묶어 툴바 공간 확보 */}
+                <div className="toolbar-dropdown" ref={viewMenuRef}>
+                    <button
+                        className={`toolbar-text-btn${viewMenuOpen ? ' active' : ''}`}
+                        onClick={() => setViewMenuOpen((v) => !v)}
+                    >
+                        <span>View</span>
+                    </button>
+                    {viewMenuOpen && (
+                        <div className="toolbar-dropdown-menu">
+                            {VIEW_MODES.map(({ mode, label, shortcut, Icon }) => (
+                                <button
+                                    key={mode}
+                                    className={`dropdown-item${viewMode === mode ? ' active' : ''}`}
+                                    onClick={() => handleViewSelect(mode)}
+                                >
+                                    <Icon size={14} strokeWidth={1.5} />
+                                    <span>{label}</span>
+                                    <span className="dropdown-shortcut">{shortcut}</span>
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
 
                 <div className="toolbar-divider" />
+                </>)}
 
                 {/* Outline + Search */}
                 <button className={`toolbar-btn${outlineVisible ? ' active' : ''}`} onClick={onToggleOutline} title="Outline">

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,7 +14,7 @@ import { BackgroundPicker } from './BackgroundPicker';
 
 export type ViewMode = 'split' | 'editor' | 'preview' | 'mindmap' | 'flowchart' | 'gantt';
 
-function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; isDirty: boolean; onRename: (name: string) => void }) {
+export function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; isDirty: boolean; onRename: (name: string) => void }) {
     const [editing, setEditing] = useState(false);
     const [editValue, setEditValue] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
@@ -85,8 +85,6 @@ function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; i
 }
 
 interface ToolbarProps {
-    fileName: string;
-    isDirty: boolean;
     viewMode: ViewMode;
     fontSize: number;
     outlineVisible: boolean;
@@ -115,12 +113,9 @@ interface ToolbarProps {
     onSaveToDrive: () => void;
     onToggleSearch: () => void;
     onToggleAI: () => void;
-    onRename: (newName: string) => void;
 }
 
 export function Toolbar({
-    fileName,
-    isDirty,
     viewMode,
     fontSize,
     outlineVisible,
@@ -147,7 +142,6 @@ export function Toolbar({
     onSaveToDrive,
     onToggleSearch,
     onToggleAI,
-    onRename,
     showRecent,
     aiPanelVisible,
 }: ToolbarProps) {
@@ -390,13 +384,6 @@ export function Toolbar({
                     <Maximize size={16} strokeWidth={1.5} />
                 </button>
             </div>
-
-            {/* Center: File name (editable) */}
-            <EditableFileName
-                fileName={fileName}
-                isDirty={isDirty}
-                onRename={onRename}
-            />
 
             {/* Right: AI 에이전트 단일 진입점(#60 — 음성/이미지 인식·슬라이드 모두 패널 모드로 흡수) */}
             <div className="toolbar-group">

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -17,8 +17,8 @@ export type ViewMode = 'split' | 'editor' | 'preview' | 'mindmap' | 'flowchart' 
 /** View 메뉴 항목 — 라벨/단축키/아이콘. 사용자가 보는 순서(편집→읽기→분할→…). */
 const VIEW_MODES: { mode: ViewMode; label: string; shortcut: string; Icon: LucideIcon }[] = [
     { mode: 'editor', label: 'Markdown', shortcut: '⌘1', Icon: FileCode },
-    { mode: 'preview', label: 'Rich Text', shortcut: '⌘3', Icon: FileText },
-    { mode: 'split', label: 'Split View', shortcut: '⌘2', Icon: Columns2 },
+    { mode: 'preview', label: 'Rich Text', shortcut: '⌘2', Icon: FileText },
+    { mode: 'split', label: 'Split View', shortcut: '⌘3', Icon: Columns2 },
     { mode: 'mindmap', label: 'Mindmap', shortcut: '⌘4', Icon: Share2 },
     { mode: 'flowchart', label: 'Flowchart', shortcut: '⌘5', Icon: Network },
     { mode: 'gantt', label: 'Gantt', shortcut: '⌘6', Icon: ChartBarStacked },
@@ -266,7 +266,7 @@ export function Toolbar({
                                         title={!driveConnected ? 'Settings 에서 Google Drive 연결 필요' : ''}
                                     >
                                         <img src="/googledrive.png" alt="" className="dropdown-icon-img" />
-                                        <span>Open from Drive…</span>
+                                        <span>Open from Google Drive…</span>
                                     </button>
                                     <button
                                         className="dropdown-item"
@@ -275,7 +275,7 @@ export function Toolbar({
                                         title={!driveConnected ? 'Settings 에서 Google Drive 연결 필요' : ''}
                                     >
                                         <img src="/googledrive.png" alt="" className="dropdown-icon-img" />
-                                        <span>Save to Drive…</span>
+                                        <span>Save to Google Drive…</span>
                                     </button>
                                 </>
                             )}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,8 +2,8 @@ import { useState, useRef, useEffect } from 'react';
 import {
     Columns2, BookOpen,
     FilePlus, FolderOpen, Save, Download, FileDown,
-    CirclePlus, CircleMinus, BookMarked, Maximize, Clock,
-    Search, ChevronRight, Sparkles, Check, X,
+    CirclePlus, CircleMinus, BookMarked, Maximize, Clock, History,
+    Search, ChevronRight, ChevronDown, Sparkles, Check, X,
     Settings,
     FileCode, FileText, AlignVerticalSpaceAround,
     Network, Share2, ChartBarStacked, type LucideIcon,
@@ -23,6 +23,17 @@ const VIEW_MODES: { mode: ViewMode; label: string; shortcut: string; Icon: Lucid
     { mode: 'flowchart', label: 'Flowchart', shortcut: '⌘5', Icon: Network },
     { mode: 'gantt', label: 'Gantt', shortcut: '⌘6', Icon: ChartBarStacked },
 ];
+
+/** 최근 파일 날짜 표시 — 오늘이면 시각, 아니면 YYYY.MM.DD. */
+function formatRecentDate(ts: number): string {
+    const d = new Date(ts);
+    const now = new Date();
+    const p2 = (n: number) => String(n).padStart(2, '0');
+    if (d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate()) {
+        return `오늘 ${p2(d.getHours())}:${p2(d.getMinutes())}`;
+    }
+    return `${d.getFullYear()}.${p2(d.getMonth() + 1)}.${p2(d.getDate())}`;
+}
 
 export function EditableFileName({ fileName, isDirty, onRename }: { fileName: string; isDirty: boolean; onRename: (name: string) => void }) {
     const [editing, setEditing] = useState(false);
@@ -164,6 +175,10 @@ export function Toolbar({
     const menuRef = useRef<HTMLDivElement>(null);
     const [viewMenuOpen, setViewMenuOpen] = useState(false);
     const viewMenuRef = useRef<HTMLDivElement>(null);
+    const [recentMenuOpen, setRecentMenuOpen] = useState(false);
+    const recentMenuRef = useRef<HTMLDivElement>(null);
+    // 최근 파일별 마지막 편집(mtime) — 메뉴 열 때 fs.stat 으로 채움(실패 시 lastOpened 폴백).
+    const [recentDates, setRecentDates] = useState<Record<string, number>>({});
 
     // Drive 가용성 (OAuth credentials 빌드 주입 + 연결 상태)
     useEffect(() => {
@@ -205,6 +220,41 @@ export function Toolbar({
         return () => document.removeEventListener('mousedown', handler);
     }, [viewMenuOpen]);
 
+    // Close Recent menu on outside click
+    useEffect(() => {
+        if (!recentMenuOpen) return;
+        const handler = (e: MouseEvent) => {
+            if (recentMenuRef.current && !recentMenuRef.current.contains(e.target as Node)) {
+                setRecentMenuOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [recentMenuOpen]);
+
+    // 최근 파일 메뉴(File 서브메뉴 / History 드롭다운)가 열리면 각 파일 mtime 조회.
+    useEffect(() => {
+        if (!(fileMenuOpen || recentMenuOpen) || recentFiles.length === 0) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const { stat } = await import('@tauri-apps/plugin-fs');
+                const entries = await Promise.all(recentFiles.map(async (f) => {
+                    try {
+                        const info = await stat(f.path);
+                        return [f.path, info.mtime ? new Date(info.mtime).getTime() : f.lastOpened] as const;
+                    } catch {
+                        return [f.path, f.lastOpened] as const;
+                    }
+                }));
+                if (!cancelled) setRecentDates(Object.fromEntries(entries));
+            } catch {
+                /* plugin 미가용 — 표시 시 lastOpened 폴백 */
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [fileMenuOpen, recentMenuOpen, recentFiles]);
+
     const handleMenuItem = (action: () => void) => {
         action();
         setFileMenuOpen(false);
@@ -214,6 +264,10 @@ export function Toolbar({
         onViewModeChange(mode);
         setViewMenuOpen(false);
     };
+
+    // 현재 View — 가운데 인디케이터 트리거에 아이콘+이름 표시.
+    const currentView = VIEW_MODES.find((v) => v.mode === viewMode);
+    const CurrentViewIcon = currentView?.Icon;
 
     return (
         <div className="toolbar">
@@ -297,7 +351,7 @@ export function Toolbar({
                                                         title={f.path}
                                                     >
                                                         <span className="dropdown-submenu-name">{f.name}</span>
-                                                        <span className="dropdown-submenu-path">{f.path}</span>
+                                                        <span className="dropdown-submenu-path">{formatRecentDate(recentDates[f.path] ?? f.lastOpened)}</span>
                                                     </button>
                                                 ))}
                                                 {recentFiles.length > 5 && (
@@ -325,33 +379,45 @@ export function Toolbar({
                     )}
                 </div>
 
-                {/* View dropdown — 모든 뷰모드를 한 메뉴로 묶어 툴바 공간 확보 */}
-                <div className="toolbar-dropdown" ref={viewMenuRef}>
-                    <button
-                        className={`toolbar-text-btn${viewMenuOpen ? ' active' : ''}`}
-                        onClick={() => setViewMenuOpen((v) => !v)}
-                    >
-                        <span>View</span>
-                    </button>
-                    {viewMenuOpen && (
-                        <div className="toolbar-dropdown-menu">
-                            {VIEW_MODES.map(({ mode, label, shortcut, Icon }) => (
-                                <button
-                                    key={mode}
-                                    className={`dropdown-item${viewMode === mode ? ' active' : ''}`}
-                                    onClick={() => handleViewSelect(mode)}
-                                >
-                                    <Icon size={14} strokeWidth={1.5} />
-                                    <span>{label}</span>
-                                    <span className="dropdown-shortcut">{shortcut}</span>
-                                </button>
-                            ))}
-                        </div>
-                    )}
-                </div>
-
                 <div className="toolbar-divider" />
                 </>)}
+
+                {/* Open Recent — 드롭다운 메뉴(최근 파일 목록). Outline 왼쪽 */}
+                {showRecent && (
+                    <div className="toolbar-dropdown" ref={recentMenuRef}>
+                        <button
+                            className={`toolbar-btn${recentMenuOpen ? ' active' : ''}`}
+                            onClick={() => setRecentMenuOpen((v) => !v)}
+                            title="Open Recent"
+                        >
+                            <History size={16} strokeWidth={1.5} />
+                        </button>
+                        {recentMenuOpen && (
+                            <div className="toolbar-dropdown-menu toolbar-recent-menu">
+                                {recentFiles.length === 0 ? (
+                                    <div className="dropdown-submenu-empty">최근 파일 없음</div>
+                                ) : (
+                                    <>
+                                        {recentFiles.slice(0, 12).map((f) => (
+                                            <button
+                                                key={f.path}
+                                                className="dropdown-item dropdown-recent-item"
+                                                onClick={() => { setRecentMenuOpen(false); onOpenRecent(f.path); }}
+                                                title={f.path}
+                                            >
+                                                <Clock size={14} strokeWidth={1.5} />
+                                                <span className="dropdown-recent-text">
+                                                    <span className="dropdown-submenu-name">{f.name}</span>
+                                                    <span className="dropdown-submenu-path">{formatRecentDate(recentDates[f.path] ?? f.lastOpened)}</span>
+                                                </span>
+                                            </button>
+                                        ))}
+                                    </>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 {/* Outline + Search */}
                 <button className={`toolbar-btn${outlineVisible ? ' active' : ''}`} onClick={onToggleOutline} title="Outline">
@@ -397,6 +463,34 @@ export function Toolbar({
                 <button className="toolbar-btn" onClick={onToggleReadingMode} title="Full / Reading Mode">
                     <Maximize size={16} strokeWidth={1.5} />
                 </button>
+            </div>
+
+            {/* 가운데: 현재 View 인디케이터 — 아이콘+이름 표시, 클릭하면 드롭다운으로 전환 */}
+            <div className="toolbar-dropdown toolbar-view-indicator" ref={viewMenuRef}>
+                <button
+                    className={`toolbar-view-current${viewMenuOpen ? ' active' : ''}`}
+                    onClick={() => setViewMenuOpen((v) => !v)}
+                    title="현재 View — 클릭해 전환"
+                >
+                    {CurrentViewIcon && <CurrentViewIcon size={15} strokeWidth={1.6} />}
+                    <span>{currentView?.label ?? 'View'}</span>
+                    <ChevronDown size={13} strokeWidth={2} className="toolbar-view-caret" />
+                </button>
+                {viewMenuOpen && (
+                    <div className="toolbar-dropdown-menu toolbar-view-menu">
+                        {VIEW_MODES.map(({ mode, label, shortcut, Icon }) => (
+                            <button
+                                key={mode}
+                                className={`dropdown-item${viewMode === mode ? ' active' : ''}`}
+                                onClick={() => handleViewSelect(mode)}
+                            >
+                                <Icon size={14} strokeWidth={1.5} />
+                                <span>{label}</span>
+                                <span className="dropdown-shortcut">{shortcut}</span>
+                            </button>
+                        ))}
+                    </div>
+                )}
             </div>
 
             {/* Right: AI 에이전트 단일 진입점(#60 — 음성/이미지 인식·슬라이드 모두 패널 모드로 흡수) */}

--- a/src/hooks/useNativeMenu.ts
+++ b/src/hooks/useNativeMenu.ts
@@ -48,6 +48,17 @@ const VIEW_ITEMS: { mode: ViewMode; label: string; accelerator: string }[] = [
     { mode: 'gantt', label: 'Gantt', accelerator: 'CmdOrCtrl+6' },
 ];
 
+/** 최근 파일 날짜 — 오늘이면 시각, 아니면 YYYY.MM.DD (툴바와 동일 포맷). */
+function formatRecentDate(ts: number): string {
+    const d = new Date(ts);
+    const now = new Date();
+    const p2 = (n: number) => String(n).padStart(2, '0');
+    if (d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth() && d.getDate() === now.getDate()) {
+        return `오늘 ${p2(d.getHours())}:${p2(d.getMinutes())}`;
+    }
+    return `${d.getFullYear()}.${p2(d.getMonth() + 1)}.${p2(d.getDate())}`;
+}
+
 export function useNativeMenu(opts: UseNativeMenuOptions) {
     // Latest handlers/state — menu `action` closures read through this ref so the
     // menu never goes stale and doesn't need rebuilding when handlers change.
@@ -79,10 +90,20 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
             });
 
             // Open Recent submenu (data-driven → triggers rebuild on change).
+            // 각 항목에 편집 날짜(mtime, 실패 시 lastOpened) 를 텍스트로 병기.
             const recent = ref.current.recentFiles.slice(0, 10);
+            const { stat } = await import('@tauri-apps/plugin-fs');
             const recentItems = recent.length
-                ? await Promise.all(recent.map((f) =>
-                    MenuItem.new({ id: `recent:${f.path}`, text: f.name, action: () => h().onOpenRecent(f.path) })))
+                ? await Promise.all(recent.map(async (f) => {
+                    let ts = f.lastOpened;
+                    try {
+                        const info = await stat(f.path);
+                        if (info.mtime) ts = new Date(info.mtime).getTime();
+                    } catch { /* lastOpened 폴백 */ }
+                    // 네이티브 메뉴는 CSS 가 안 먹으므로 파일명 글자수를 직접 제한(말줄임).
+                    const name = f.name.length > 48 ? `${f.name.slice(0, 47)}…` : f.name;
+                    return MenuItem.new({ id: `recent:${f.path}`, text: `${name}    ${formatRecentDate(ts)}`, action: () => h().onOpenRecent(f.path) });
+                }))
                 : [await MenuItem.new({ id: 'recent-empty', text: '최근 파일 없음', enabled: false, action: () => {} })];
             const recentSubmenu = await Submenu.new({ text: 'Open Recent', items: recentItems });
 

--- a/src/hooks/useNativeMenu.ts
+++ b/src/hooks/useNativeMenu.ts
@@ -1,0 +1,167 @@
+/**
+ * Native macOS application menu (Tauri only).
+ *
+ * macOS shows the focused app's menu in the system menu bar. We mirror our
+ * File/View actions there so the in-app toolbar can drop those dropdowns (frees
+ * space). Built entirely with the Tauri v2 JS menu API — each item's `action`
+ * calls the existing React handler directly (no Rust, no event bridge).
+ *
+ * - First submenu becomes the macOS app menu (Settings/Hide/Quit).
+ * - View modes are CheckMenuItems reflecting the current mode; we update their
+ *   checked state on `viewMode` change without rebuilding the whole menu.
+ * - Accelerators are shown natively; macOS consumes the key equivalent before
+ *   the webview, so the existing frontend keydown handler stays as the web /
+ *   backup path without double-firing.
+ * - On web (non-Tauri) this hook is a no-op; the toolbar keeps its dropdowns.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { CheckMenuItem } from '@tauri-apps/api/menu';
+import type { ViewMode } from '../components/Toolbar';
+import type { RecentFile } from './useRecentFiles';
+
+export interface UseNativeMenuOptions {
+    /** Only build the native menu when true (= running under Tauri). */
+    enabled: boolean;
+    viewMode: ViewMode;
+    recentFiles: RecentFile[];
+    onNewFile: () => void;
+    onOpenFile: () => void;
+    onSaveFile: () => void;
+    onSaveFileAs: () => void;
+    onExportPdf: () => void;
+    onShowSettings: () => void;
+    onShowTutorial: () => void;
+    onOpenFromDrive: () => void;
+    onSaveToDrive: () => void;
+    onOpenRecent: (path: string) => void;
+    onViewModeChange: (mode: ViewMode) => void;
+}
+
+/** View menu order = shortcut order (⌘1‥⌘6). */
+const VIEW_ITEMS: { mode: ViewMode; label: string; accelerator: string }[] = [
+    { mode: 'editor', label: 'Markdown', accelerator: 'CmdOrCtrl+1' },
+    { mode: 'split', label: 'Split View', accelerator: 'CmdOrCtrl+2' },
+    { mode: 'preview', label: 'Rich Text', accelerator: 'CmdOrCtrl+3' },
+    { mode: 'mindmap', label: 'Mindmap', accelerator: 'CmdOrCtrl+4' },
+    { mode: 'flowchart', label: 'Flowchart', accelerator: 'CmdOrCtrl+5' },
+    { mode: 'gantt', label: 'Gantt', accelerator: 'CmdOrCtrl+6' },
+];
+
+export function useNativeMenu(opts: UseNativeMenuOptions) {
+    // Latest handlers/state — menu `action` closures read through this ref so the
+    // menu never goes stale and doesn't need rebuilding when handlers change.
+    const ref = useRef(opts);
+    ref.current = opts;
+    // CheckMenuItem handles by mode, for cheap check-state updates.
+    const checksRef = useRef<Record<string, CheckMenuItem>>({});
+
+    // Build / rebuild the menu. Rebuilds only when the recent-files list changes
+    // (the only data baked into items); handlers go through `ref`, viewMode is
+    // handled by the separate effect below.
+    useEffect(() => {
+        if (!opts.enabled) return;
+        let disposed = false;
+        (async () => {
+            const { Menu, Submenu, MenuItem, CheckMenuItem, PredefinedMenuItem } = await import('@tauri-apps/api/menu');
+            const h = () => ref.current;
+            const sep = () => PredefinedMenuItem.new({ item: 'Separator' });
+
+            // App menu (first submenu → macOS application menu, titled by app name).
+            const appMenu = await Submenu.new({
+                text: 'MarkMind',
+                items: [
+                    await MenuItem.new({ id: 'settings', text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h().onShowSettings() }),
+                    await sep(),
+                    await PredefinedMenuItem.new({ item: 'Hide' }),
+                    await PredefinedMenuItem.new({ item: 'Quit' }),
+                ],
+            });
+
+            // Open Recent submenu (data-driven → triggers rebuild on change).
+            const recent = ref.current.recentFiles.slice(0, 10);
+            const recentItems = recent.length
+                ? await Promise.all(recent.map((f) =>
+                    MenuItem.new({ id: `recent:${f.path}`, text: f.name, action: () => h().onOpenRecent(f.path) })))
+                : [await MenuItem.new({ id: 'recent-empty', text: '최근 파일 없음', enabled: false, action: () => {} })];
+            const recentSubmenu = await Submenu.new({ text: 'Open Recent', items: recentItems });
+
+            const fileMenu = await Submenu.new({
+                text: 'File',
+                items: [
+                    await MenuItem.new({ id: 'new', text: 'New', accelerator: 'CmdOrCtrl+N', action: () => h().onNewFile() }),
+                    await MenuItem.new({ id: 'open', text: 'Open…', accelerator: 'CmdOrCtrl+O', action: () => h().onOpenFile() }),
+                    recentSubmenu,
+                    await sep(),
+                    await MenuItem.new({ id: 'save', text: 'Save', accelerator: 'CmdOrCtrl+S', action: () => h().onSaveFile() }),
+                    await MenuItem.new({ id: 'saveas', text: 'Save As…', accelerator: 'CmdOrCtrl+Shift+S', action: () => h().onSaveFileAs() }),
+                    await sep(),
+                    await MenuItem.new({ id: 'export', text: 'Export as PDF…', accelerator: 'CmdOrCtrl+P', action: () => h().onExportPdf() }),
+                    await sep(),
+                    await MenuItem.new({ id: 'drive-open', text: 'Open from Drive…', action: () => h().onOpenFromDrive() }),
+                    await MenuItem.new({ id: 'drive-save', text: 'Save to Drive…', action: () => h().onSaveToDrive() }),
+                ],
+            });
+
+            const editMenu = await Submenu.new({
+                text: 'Edit',
+                items: [
+                    await PredefinedMenuItem.new({ item: 'Undo' }),
+                    await PredefinedMenuItem.new({ item: 'Redo' }),
+                    await sep(),
+                    await PredefinedMenuItem.new({ item: 'Cut' }),
+                    await PredefinedMenuItem.new({ item: 'Copy' }),
+                    await PredefinedMenuItem.new({ item: 'Paste' }),
+                    await PredefinedMenuItem.new({ item: 'SelectAll' }),
+                ],
+            });
+
+            // View menu — checkable, reflects the current mode.
+            const checks: Record<string, CheckMenuItem> = {};
+            const viewItems = [];
+            for (const v of VIEW_ITEMS) {
+                const item = await CheckMenuItem.new({
+                    id: `view:${v.mode}`,
+                    text: v.label,
+                    accelerator: v.accelerator,
+                    checked: ref.current.viewMode === v.mode,
+                    action: () => h().onViewModeChange(v.mode),
+                });
+                checks[v.mode] = item;
+                viewItems.push(item);
+            }
+            const viewMenu = await Submenu.new({ text: 'View', items: viewItems });
+
+            const windowMenu = await Submenu.new({
+                text: 'Window',
+                items: [
+                    await PredefinedMenuItem.new({ item: 'Minimize' }),
+                    await PredefinedMenuItem.new({ item: 'Maximize' }),
+                    await sep(),
+                    await PredefinedMenuItem.new({ item: 'Fullscreen' }),
+                ],
+            });
+
+            const helpMenu = await Submenu.new({
+                text: 'Help',
+                items: [await MenuItem.new({ id: 'tutorial', text: 'Tutorial', action: () => h().onShowTutorial() })],
+            });
+
+            const menu = await Menu.new({ items: [appMenu, fileMenu, editMenu, viewMenu, windowMenu, helpMenu] });
+            if (disposed) return;
+            checksRef.current = checks;
+            await menu.setAsAppMenu();
+        })().catch((e) => console.error('[useNativeMenu] build failed:', e));
+
+        return () => { disposed = true; };
+    }, [opts.enabled, opts.recentFiles]);
+
+    // Reflect the active view mode without rebuilding the whole menu.
+    useEffect(() => {
+        if (!opts.enabled) return;
+        const checks = checksRef.current;
+        for (const v of VIEW_ITEMS) {
+            checks[v.mode]?.setChecked(opts.viewMode === v.mode).catch(() => {});
+        }
+    }, [opts.enabled, opts.viewMode]);
+}

--- a/src/hooks/useNativeMenu.ts
+++ b/src/hooks/useNativeMenu.ts
@@ -41,8 +41,8 @@ export interface UseNativeMenuOptions {
 /** View menu order = shortcut order (⌘1‥⌘6). */
 const VIEW_ITEMS: { mode: ViewMode; label: string; accelerator: string }[] = [
     { mode: 'editor', label: 'Markdown', accelerator: 'CmdOrCtrl+1' },
-    { mode: 'split', label: 'Split View', accelerator: 'CmdOrCtrl+2' },
-    { mode: 'preview', label: 'Rich Text', accelerator: 'CmdOrCtrl+3' },
+    { mode: 'preview', label: 'Rich Text', accelerator: 'CmdOrCtrl+2' },
+    { mode: 'split', label: 'Split View', accelerator: 'CmdOrCtrl+3' },
     { mode: 'mindmap', label: 'Mindmap', accelerator: 'CmdOrCtrl+4' },
     { mode: 'flowchart', label: 'Flowchart', accelerator: 'CmdOrCtrl+5' },
     { mode: 'gantt', label: 'Gantt', accelerator: 'CmdOrCtrl+6' },
@@ -98,8 +98,8 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
                     await sep(),
                     await MenuItem.new({ id: 'export', text: 'Export as PDF…', accelerator: 'CmdOrCtrl+P', action: () => h().onExportPdf() }),
                     await sep(),
-                    await MenuItem.new({ id: 'drive-open', text: 'Open from Drive…', action: () => h().onOpenFromDrive() }),
-                    await MenuItem.new({ id: 'drive-save', text: 'Save to Drive…', action: () => h().onSaveToDrive() }),
+                    await MenuItem.new({ id: 'drive-open', text: 'Open from Google Drive…', action: () => h().onOpenFromDrive() }),
+                    await MenuItem.new({ id: 'drive-save', text: 'Save to Google Drive…', action: () => h().onSaveToDrive() }),
                 ],
             });
 


### PR DESCRIPTION
상단 UI 전반 개편 (5개 커밋). macOS 전용 앱 기준으로 타이틀바·메뉴·검색·툴바를 정리.

## 커밋
1. **파일명 → 타이틀바 중앙** + 가변 폭 — 신호등 줄에 파일명(클릭 이름변경), 창 폭 비례 입력
2. **File/View → 네이티브 macOS 메뉴바** — Tauri v2 JS 메뉴 API, 툴바 File/View 숨김(웹은 유지), ⌘1~6
3. **Markdown·Rich Text 검색 통일** — 단일 검색+바꾸기 바(CM 프로그램 검색 + Tiptap), Enter/⇧Enter/Esc 일관
4. **split 양쪽 하이라이트** + Drive 라벨(Google Drive)·View 순서(⌘1 Markdown/⌘2 Rich Text/⌘3 Split)·Tutorial 정렬·replace 토글 리셋
5. **툴바 현재 View 인디케이터**(가운데, 클릭 전환) + **최근 파일 드롭다운**(History 아이콘, 편집 날짜·회색·말줄임)

## 주요 기술 포인트
- 검색 bug 근본 해결: 인라인 `basicSetup` → 매 렌더 reconfigure → CM 검색 패널 닫힘 → **안정 참조화**로 제거. CM 네이티브 패널 폐기하고 `@codemirror/search` 프로그램 구동(`search()`+setSearchQuery/findNext/replace).
- split 오른쪽(정적 react-markdown) 하이라이트 = **CSS Custom Highlight API**(DOM 무변경, 미지원 시 graceful).
- 최근 파일 편집 날짜 = `fs.stat` mtime(실패 시 lastOpened). `fs:allow-stat` 추가.
- 네이티브 메뉴 = JS 메뉴 API, 각 항목 action 이 기존 핸들러 직접 호출(Rust/이벤트브리지 없음).

## 검증
- tsc + vite build + vitest 121 + cargo check 통과.
- ⚠️ **런타임 GUI 검증 필요**(제가 GUI 테스트 불가): 네이티브 메뉴/단축키 단일발동, 검색 Enter/▲▼/바꾸기, split 양쪽 하이라이트, 타이틀바 파일명, View 인디케이터·최근 파일 메뉴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)