### PR TITLE
feat(ai): AI 에이전트 이미지 생성 + Settings/AI 선택 UX 정비

### DIFF
--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -274,6 +274,7 @@ pub async fn ai_generate_openai(
 // WKWebView 의 fetch CORS 제약을 피하려 네이티브 HTTP(reqwest) 경유한다.
 #[tauri::command]
 pub async fn generate_image_gemini(
+    model: String,
     prompt: String,
     aspect_ratio: String,
     quality: String,
@@ -284,11 +285,12 @@ pub async fn generate_image_gemini(
     let key = get_key(Provider::Gemini)
         .map_err(err_to_string)?
         .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_gemini(&key, &prompt, &aspect_ratio, &quality, &reference_images).await
+    image_gen::generate_gemini(&key, &model, &prompt, &aspect_ratio, &quality, &reference_images).await
 }
 
 #[tauri::command]
 pub async fn generate_image_openai(
+    model: String,
     prompt: String,
     aspect_ratio: String,
     quality: String,
@@ -299,7 +301,7 @@ pub async fn generate_image_openai(
     let key = get_key(Provider::Openai)
         .map_err(err_to_string)?
         .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_openai(&key, &prompt, &aspect_ratio, &quality, &reference_images).await
+    image_gen::generate_openai(&key, &model, &prompt, &aspect_ratio, &quality, &reference_images).await
 }
 
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -266,6 +266,42 @@ pub async fn ai_generate_openai(
         .map_err(err_to_string)
 }
 
+// ─── 이미지 생성 (Gemini 3.1 Flash Image / OpenAI gpt-image-1) ──────────────
+//
+// React AI "이미지 생성" 모드. 키는 기존 Settings(Keychain)의 gemini/openai 를 재사용한다
+// (새 키 입력 UI 없음). 참조 이미지는 data URL 배열로 전달하고, 반환은 base64 data URL
+// 배열(개수 1)로 정규화 — 프론트의 삽입/저장 코드가 공급사와 무관하게 공통 동작한다.
+// WKWebView 의 fetch CORS 제약을 피하려 네이티브 HTTP(reqwest) 경유한다.
+#[tauri::command]
+pub async fn generate_image_gemini(
+    prompt: String,
+    aspect_ratio: String,
+    quality: String,
+    reference_images: Vec<String>,
+) -> Result<Vec<String>, String> {
+    use super::keychain::{get_key, Provider};
+    use super::llm::image_gen;
+    let key = get_key(Provider::Gemini)
+        .map_err(err_to_string)?
+        .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+    image_gen::generate_gemini(&key, &prompt, &aspect_ratio, &quality, &reference_images).await
+}
+
+#[tauri::command]
+pub async fn generate_image_openai(
+    prompt: String,
+    aspect_ratio: String,
+    quality: String,
+    reference_images: Vec<String>,
+) -> Result<Vec<String>, String> {
+    use super::keychain::{get_key, Provider};
+    use super::llm::image_gen;
+    let key = get_key(Provider::Openai)
+        .map_err(err_to_string)?
+        .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+    image_gen::generate_openai(&key, &prompt, &aspect_ratio, &quality, &reference_images).await
+}
+
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────
 
 #[cfg(test)]

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -277,7 +277,7 @@ pub async fn generate_image_gemini(
     model: String,
     prompt: String,
     aspect_ratio: String,
-    quality: String,
+    resolution: String,
     reference_images: Vec<String>,
 ) -> Result<Vec<String>, String> {
     use super::keychain::{get_key, Provider};
@@ -285,7 +285,7 @@ pub async fn generate_image_gemini(
     let key = get_key(Provider::Gemini)
         .map_err(err_to_string)?
         .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_gemini(&key, &model, &prompt, &aspect_ratio, &quality, &reference_images).await
+    image_gen::generate_gemini(&key, &model, &prompt, &aspect_ratio, &resolution, &reference_images).await
 }
 
 #[tauri::command]
@@ -293,6 +293,7 @@ pub async fn generate_image_openai(
     model: String,
     prompt: String,
     aspect_ratio: String,
+    resolution: String,
     quality: String,
     reference_images: Vec<String>,
 ) -> Result<Vec<String>, String> {
@@ -301,7 +302,7 @@ pub async fn generate_image_openai(
     let key = get_key(Provider::Openai)
         .map_err(err_to_string)?
         .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_openai(&key, &model, &prompt, &aspect_ratio, &quality, &reference_images).await
+    image_gen::generate_openai(&key, &model, &prompt, &aspect_ratio, &resolution, &quality, &reference_images).await
 }
 
 // ─── 화자 라벨 후처리 (STT 결과 정리용) ─────────────────────────

--- a/src-tauri/src/converters/error.rs
+++ b/src-tauri/src/converters/error.rs
@@ -16,6 +16,9 @@ pub enum ConverterError {
     #[error("ChatGPT(Codex) API 오류: {0}")]
     Codex(String),
 
+    #[error("OpenAI API 오류: {0}")]
+    OpenAi(String),
+
     #[error("네트워크 연결이 불안정합니다. 잠시 후 다시 시도해주세요. ({0})")]
     Network(String),
 

--- a/src-tauri/src/converters/llm/image_gen.rs
+++ b/src-tauri/src/converters/llm/image_gen.rs
@@ -14,8 +14,8 @@ use base64::Engine;
 use serde::Deserialize;
 use std::time::Duration;
 
-/// 이미지 생성은 4K/참조 등으로 텍스트보다 느릴 수 있어 넉넉히.
-const TIMEOUT_SECS: u64 = 180;
+/// 이미지 생성은 4K/참조/high 품질이면 OpenAI 공식 기준 최대 2분+ 소요 → 넉넉히 5분.
+const TIMEOUT_SECS: u64 = 300;
 
 /// data URL(`data:{mime};base64,{data}`) → (mime, base64) 분리. 형식 불일치 시 None.
 fn parse_data_url(s: &str) -> Option<(String, String)> {

--- a/src-tauri/src/converters/llm/image_gen.rs
+++ b/src-tauri/src/converters/llm/image_gen.rs
@@ -7,6 +7,11 @@
 //! 참조 이미지는 프론트에서 `data:image/...;base64,...` 문자열로 전달.
 //! 두 공급사 모두 결과를 base64 data URL 배열(개수 1)로 정규화해 반환 — 삽입/저장 공통.
 //!
+//! 옵션 매핑(두 공급사 구조가 다름 → 공통 입력을 각 API 형식으로 변환):
+//!  - 공통 입력: aspect_ratio(비율) + resolution(1K/2K/4K). OpenAI 만 quality(low/medium/high).
+//!  - Gemini: imageConfig 에 aspectRatio + imageSize(=resolution) 그대로.
+//!  - OpenAI: size(=비율×해상도 환산 WxH) + quality 별개. (gpt-image-2 는 비율·해상도가 size 하나로 통합)
+//!
 //! 에러는 `<provider> HTTP <status> — <snippet>` 형태 String 으로 반환하고,
 //! 사용자용 메시지 변환(humanize)은 프론트(imageGen.ts)에서 수행한다.
 
@@ -27,6 +32,19 @@ fn parse_data_url(s: &str) -> Option<(String, String)> {
     Some((mime.to_string(), b64.to_string()))
 }
 
+/// "16:9" → (16.0, 9.0). 형식 불일치 시 (1,1) 정사각 폴백.
+fn parse_ratio(aspect_ratio: &str) -> (f64, f64) {
+    let dims: Vec<f64> = aspect_ratio
+        .split(':')
+        .filter_map(|x| x.trim().parse().ok())
+        .collect();
+    if dims.len() == 2 && dims[0] > 0.0 && dims[1] > 0.0 {
+        (dims[0], dims[1])
+    } else {
+        (1.0, 1.0)
+    }
+}
+
 fn http_client() -> Result<reqwest::Client, String> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(TIMEOUT_SECS))
@@ -45,13 +63,13 @@ fn prompt_with_refs(prompt: &str, ref_count: usize) -> String {
     }
 }
 
-// ───────────────────────── Gemini 3.1 Flash Image ─────────────────────────
+// ───────────────────────── Gemini (Nano Banana) ─────────────────────────
 
-/// quality → Gemini `imageSize` 매핑.
-fn gemini_image_size(quality: &str) -> &'static str {
-    match quality {
-        "4k" => "4K",
-        "2k" => "2K",
+/// resolution(1K/2K/4K) → Gemini `imageSize`. 대문자 K 필수(소문자는 API 가 거부).
+fn gemini_image_size(resolution: &str) -> &'static str {
+    match resolution.to_uppercase().as_str() {
+        "4K" => "4K",
+        "2K" => "2K",
         _ => "1K",
     }
 }
@@ -80,13 +98,13 @@ struct GeminiInlineData {
     data: String,
 }
 
-/// Gemini 이미지 생성(model = generateContent 모델 ID). 참조 이미지는 `inlineData` 로 포함.
+/// Gemini 이미지 생성. aspectRatio + imageSize(=resolution). 참조 이미지는 `inlineData` 로 포함.
 pub async fn generate_gemini(
     api_key: &str,
     model: &str,
     prompt: &str,
     aspect_ratio: &str,
-    quality: &str,
+    resolution: &str,
     reference_images: &[String],
 ) -> Result<Vec<String>, String> {
     let url = format!(
@@ -112,7 +130,7 @@ pub async fn generate_gemini(
     }
     image_config.insert(
         "imageSize".into(),
-        serde_json::json!(gemini_image_size(quality)),
+        serde_json::json!(gemini_image_size(resolution)),
     );
 
     let body = serde_json::json!({
@@ -162,32 +180,63 @@ pub async fn generate_gemini(
     )])
 }
 
-// ───────────────────────── OpenAI gpt-image-1 ─────────────────────────
+// ───────────────────────── OpenAI gpt-image-2 ─────────────────────────
 
-/// aspect ratio → OpenAI `size`(정사각/가로/세로 3종).
-fn openai_size(aspect_ratio: &str) -> &'static str {
-    let dims: Vec<f64> = aspect_ratio
-        .split(':')
-        .filter_map(|x| x.trim().parse().ok())
-        .collect();
-    if dims.len() == 2 && dims[0] > 0.0 && dims[1] > 0.0 {
-        let ratio = dims[0] / dims[1];
-        if (ratio - 1.0).abs() < 0.05 {
-            "1024x1024"
-        } else if ratio > 1.0 {
-            "1536x1024"
-        } else {
-            "1024x1536"
-        }
-    } else {
-        "1024x1024"
+/// resolution(1K/2K/4K) + aspect → OpenAI `size` "WxH".
+/// gpt-image-2 제약: 양변 16 배수, 최대 변 3840, 총 픽셀 655,360~8,294,400, 비율 3:1 이내.
+/// 비율을 유지하며 목표 해상도(픽셀)에 맞춰 계산 후 제약을 만족하도록 보정한다.
+fn openai_size(aspect_ratio: &str, resolution: &str) -> String {
+    const MIN_PX: i64 = 655_360;
+    const MAX_PX: i64 = 8_294_400;
+    const MAX_EDGE: i64 = 3840;
+    let (rw, rh) = parse_ratio(aspect_ratio);
+    let target = match resolution.to_uppercase().as_str() {
+        "4K" => MAX_PX as f64,    // 4K — 제약상 최대 픽셀
+        "2K" => 4_194_304.0,      // 2K ≈ 2048²
+        _ => 1_048_576.0,         // 1K ≈ 1024²
+    };
+    // 비율 유지하며 목표 픽셀에 맞는 실수 변 길이
+    let mut h = (target * rh / rw).sqrt();
+    let mut w = h * rw / rh;
+    // 최대 변 clamp(비율 유지)
+    let max_edge = MAX_EDGE as f64;
+    if w > max_edge {
+        w = max_edge;
+        h = w * rh / rw;
     }
+    if h > max_edge {
+        h = max_edge;
+        w = h * rw / rh;
+    }
+    // 16 배수로 반올림(최소 16)
+    let round16 = |v: f64| (((v / 16.0).round() as i64) * 16).max(16);
+    let mut wi = round16(w);
+    let mut hi = round16(h);
+    // 최소 픽셀 보장(짧은 변부터 키움)
+    while wi * hi < MIN_PX {
+        if wi <= hi {
+            wi += 16;
+        } else {
+            hi += 16;
+        }
+    }
+    // 최대 픽셀/최대 변 보장(긴 변부터 줄임)
+    while wi * hi > MAX_PX || wi > MAX_EDGE || hi > MAX_EDGE {
+        if wi >= hi {
+            wi -= 16;
+        } else {
+            hi -= 16;
+        }
+    }
+    format!("{wi}x{hi}")
 }
 
-/// quality → OpenAI `quality`(standard=medium / 2k·4k=high).
+/// quality 입력 검증 — low/medium/high/auto 만 허용, 그 외 medium.
 fn openai_quality(quality: &str) -> &'static str {
-    match quality {
-        "2k" | "4k" => "high",
+    match quality.to_lowercase().as_str() {
+        "low" => "low",
+        "high" => "high",
+        "auto" => "auto",
         _ => "medium",
     }
 }
@@ -202,16 +251,18 @@ struct OpenAiImageItem {
     url: Option<String>,
 }
 
-/// OpenAI 이미지 생성(model = gpt-image-2 등). 참조 有 → `/v1/images/edits`(multipart), 無 → `/v1/images/generations`(JSON).
+/// OpenAI 이미지 생성(model = gpt-image-2 등). size(비율×해상도 환산) + quality 별개.
+/// 참조 有 → `/v1/images/edits`(multipart), 無 → `/v1/images/generations`(JSON).
 pub async fn generate_openai(
     api_key: &str,
     model: &str,
     prompt: &str,
     aspect_ratio: &str,
+    resolution: &str,
     quality: &str,
     reference_images: &[String],
 ) -> Result<Vec<String>, String> {
-    let size = openai_size(aspect_ratio);
+    let size = openai_size(aspect_ratio, resolution);
     let oai_quality = openai_quality(quality);
     let has_refs = !reference_images.is_empty();
     let client = http_client()?;
@@ -281,7 +332,7 @@ pub async fn generate_openai(
     if items.is_empty() {
         return Err("OpenAI에서 이미지를 생성하지 못했습니다.".to_string());
     }
-    // gpt-image-1 은 항상 b64_json. url 폴백도 일단 수용.
+    // gpt-image-2 는 항상 b64_json. url 폴백도 일단 수용.
     let urls: Vec<String> = items
         .into_iter()
         .filter_map(|item| {
@@ -315,27 +366,45 @@ mod tests {
     }
 
     #[test]
-    fn gemini_size_mapping() {
-        assert_eq!(gemini_image_size("4k"), "4K");
-        assert_eq!(gemini_image_size("2k"), "2K");
-        assert_eq!(gemini_image_size("standard"), "1K");
+    fn gemini_image_size_normalizes() {
+        assert_eq!(gemini_image_size("4K"), "4K");
+        assert_eq!(gemini_image_size("2k"), "2K"); // 소문자 입력도 대문자로
+        assert_eq!(gemini_image_size("1K"), "1K");
         assert_eq!(gemini_image_size(""), "1K");
     }
 
     #[test]
-    fn openai_size_mapping() {
-        assert_eq!(openai_size("1:1"), "1024x1024");
-        assert_eq!(openai_size("16:9"), "1536x1024");
-        assert_eq!(openai_size("9:16"), "1024x1536");
-        assert_eq!(openai_size("4:3"), "1536x1024");
-        assert_eq!(openai_size("garbage"), "1024x1024");
+    fn openai_quality_validates() {
+        assert_eq!(openai_quality("low"), "low");
+        assert_eq!(openai_quality("medium"), "medium");
+        assert_eq!(openai_quality("HIGH"), "high");
+        assert_eq!(openai_quality("garbage"), "medium");
     }
 
+    /// openai_size: 제약(16배수·최대변3840·픽셀 655360~8294400)을 항상 만족해야.
     #[test]
-    fn openai_quality_mapping() {
-        assert_eq!(openai_quality("standard"), "medium");
-        assert_eq!(openai_quality("2k"), "high");
-        assert_eq!(openai_quality("4k"), "high");
+    fn openai_size_satisfies_constraints() {
+        for ar in ["1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "21:9", "garbage"] {
+            for res in ["1K", "2K", "4K"] {
+                let s = openai_size(ar, res);
+                let (w, h): (i64, i64) = {
+                    let mut it = s.split('x').map(|x| x.parse::<i64>().unwrap());
+                    (it.next().unwrap(), it.next().unwrap())
+                };
+                assert_eq!(w % 16, 0, "{ar}/{res}={s}: width not /16");
+                assert_eq!(h % 16, 0, "{ar}/{res}={s}: height not /16");
+                assert!(w <= 3840 && h <= 3840, "{ar}/{res}={s}: edge > 3840");
+                let px = w * h;
+                assert!((655_360..=8_294_400).contains(&px), "{ar}/{res}={s}: px {px} out of range");
+            }
+        }
+    }
+
+    /// 대표 케이스의 기대 해상도(비율·목표 픽셀 반영).
+    #[test]
+    fn openai_size_expected() {
+        assert_eq!(openai_size("1:1", "1K"), "1024x1024");
+        assert_eq!(openai_size("16:9", "4K"), "3840x2160");
     }
 
     #[test]

--- a/src-tauri/src/converters/llm/image_gen.rs
+++ b/src-tauri/src/converters/llm/image_gen.rs
@@ -1,0 +1,343 @@
+//! 이미지 생성 — Gemini 3.1 Flash Image / OpenAI gpt-image-1.
+//!
+//! lumina-studio `imageGen.ts` 의 handleGemini/handleOpenAI 를 Rust(reqwest)로 포팅.
+//! WKWebView 의 fetch CORS 제약을 피하려 네이티브 HTTP 로 호출(텍스트 LLM 과 동일 경로).
+//! 참조 이미지는 프론트에서 `data:image/...;base64,...` 문자열로 전달.
+//! 두 공급사 모두 결과를 base64 data URL 배열(개수 1)로 정규화해 반환 — 삽입/저장 공통.
+//!
+//! 에러는 `<provider> HTTP <status> — <snippet>` 형태 String 으로 반환하고,
+//! 사용자용 메시지 변환(humanize)은 프론트(imageGen.ts)에서 수행한다.
+
+use base64::Engine;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// 이미지 생성은 4K/참조 등으로 텍스트보다 느릴 수 있어 넉넉히.
+const TIMEOUT_SECS: u64 = 180;
+
+/// data URL(`data:{mime};base64,{data}`) → (mime, base64) 분리. 형식 불일치 시 None.
+fn parse_data_url(s: &str) -> Option<(String, String)> {
+    let rest = s.strip_prefix("data:")?;
+    let (mime, b64) = rest.split_once(";base64,")?;
+    if mime.is_empty() || b64.is_empty() {
+        return None;
+    }
+    Some((mime.to_string(), b64.to_string()))
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("HTTP 클라이언트 생성 실패: {e}"))
+}
+
+/// 참조 이미지가 붙은 경우 프롬프트 앞에 사용 지시를 덧붙인다(lumina 와 동일 문구).
+fn prompt_with_refs(prompt: &str, ref_count: usize) -> String {
+    if ref_count == 0 {
+        prompt.to_string()
+    } else {
+        format!(
+            "Using the {ref_count} attached reference image(s), generate a photograph with the following specifications:\n\n{prompt}"
+        )
+    }
+}
+
+// ───────────────────────── Gemini 3.1 Flash Image ─────────────────────────
+
+/// quality → Gemini `imageSize` 매핑.
+fn gemini_image_size(quality: &str) -> &'static str {
+    match quality {
+        "4k" => "4K",
+        "2k" => "2K",
+        _ => "1K",
+    }
+}
+
+#[derive(Deserialize)]
+struct GeminiResponse {
+    candidates: Option<Vec<GeminiCandidate>>,
+}
+#[derive(Deserialize)]
+struct GeminiCandidate {
+    content: Option<GeminiContent>,
+}
+#[derive(Deserialize)]
+struct GeminiContent {
+    parts: Option<Vec<GeminiPart>>,
+}
+#[derive(Deserialize)]
+struct GeminiPart {
+    #[serde(rename = "inlineData")]
+    inline_data: Option<GeminiInlineData>,
+}
+#[derive(Deserialize)]
+struct GeminiInlineData {
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    data: String,
+}
+
+/// Gemini 이미지 생성. 참조 이미지는 `inlineData` 로 본문에 포함.
+pub async fn generate_gemini(
+    api_key: &str,
+    prompt: &str,
+    aspect_ratio: &str,
+    quality: &str,
+    reference_images: &[String],
+) -> Result<Vec<String>, String> {
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent?key={api_key}"
+    );
+
+    // parts: 참조 이미지(inlineData) 먼저, 그 다음 text.
+    let mut parts: Vec<serde_json::Value> = Vec::new();
+    for img in reference_images {
+        if let Some((mime, b64)) = parse_data_url(img) {
+            parts.push(serde_json::json!({
+                "inlineData": { "mimeType": mime, "data": b64 }
+            }));
+        }
+    }
+    parts.push(serde_json::json!({
+        "text": prompt_with_refs(prompt, reference_images.len())
+    }));
+
+    let mut image_config = serde_json::Map::new();
+    if !aspect_ratio.is_empty() {
+        image_config.insert("aspectRatio".into(), serde_json::json!(aspect_ratio));
+    }
+    image_config.insert(
+        "imageSize".into(),
+        serde_json::json!(gemini_image_size(quality)),
+    );
+
+    let body = serde_json::json!({
+        "contents": [{ "parts": parts }],
+        "generationConfig": {
+            "responseModalities": ["IMAGE"],
+            "imageConfig": image_config,
+        }
+    });
+
+    let client = http_client()?;
+    let resp = client
+        .post(&url)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Gemini 네트워크 오류: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        let snippet: String = raw.chars().take(400).collect();
+        return Err(format!("Gemini HTTP {} — {}", status.as_u16(), snippet));
+    }
+
+    let parsed: GeminiResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Gemini 응답 파싱 실패: {e}"))?;
+
+    let first = parsed
+        .candidates
+        .unwrap_or_default()
+        .into_iter()
+        .next()
+        .ok_or_else(|| "Gemini에서 이미지를 생성하지 못했습니다.".to_string())?;
+    let part_list = first.content.and_then(|c| c.parts).unwrap_or_default();
+    let image = part_list
+        .into_iter()
+        .find_map(|p| p.inline_data)
+        .ok_or_else(|| "Gemini 응답에 이미지가 포함되지 않았습니다.".to_string())?;
+
+    Ok(vec![format!(
+        "data:{};base64,{}",
+        image.mime_type, image.data
+    )])
+}
+
+// ───────────────────────── OpenAI gpt-image-1 ─────────────────────────
+
+/// aspect ratio → OpenAI `size`(정사각/가로/세로 3종).
+fn openai_size(aspect_ratio: &str) -> &'static str {
+    let dims: Vec<f64> = aspect_ratio
+        .split(':')
+        .filter_map(|x| x.trim().parse().ok())
+        .collect();
+    if dims.len() == 2 && dims[0] > 0.0 && dims[1] > 0.0 {
+        let ratio = dims[0] / dims[1];
+        if (ratio - 1.0).abs() < 0.05 {
+            "1024x1024"
+        } else if ratio > 1.0 {
+            "1536x1024"
+        } else {
+            "1024x1536"
+        }
+    } else {
+        "1024x1024"
+    }
+}
+
+/// quality → OpenAI `quality`(standard=medium / 2k·4k=high).
+fn openai_quality(quality: &str) -> &'static str {
+    match quality {
+        "2k" | "4k" => "high",
+        _ => "medium",
+    }
+}
+
+#[derive(Deserialize)]
+struct OpenAiImageResponse {
+    data: Option<Vec<OpenAiImageItem>>,
+}
+#[derive(Deserialize)]
+struct OpenAiImageItem {
+    b64_json: Option<String>,
+    url: Option<String>,
+}
+
+/// OpenAI 이미지 생성. 참조 有 → `/v1/images/edits`(multipart), 無 → `/v1/images/generations`(JSON).
+pub async fn generate_openai(
+    api_key: &str,
+    prompt: &str,
+    aspect_ratio: &str,
+    quality: &str,
+    reference_images: &[String],
+) -> Result<Vec<String>, String> {
+    let size = openai_size(aspect_ratio);
+    let oai_quality = openai_quality(quality);
+    let has_refs = !reference_images.is_empty();
+    let client = http_client()?;
+
+    let resp = if has_refs {
+        // 참조 이미지 → /v1/images/edits (multipart/form-data)
+        let mut form = reqwest::multipart::Form::new();
+        for (i, img) in reference_images.iter().enumerate() {
+            if let Some((mime, b64)) = parse_data_url(img) {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&b64)
+                    .map_err(|e| format!("참조 이미지 디코딩 실패: {e}"))?;
+                let ext = mime.split('/').nth(1).unwrap_or("png");
+                let part = reqwest::multipart::Part::bytes(bytes)
+                    .file_name(format!("reference_{}.{}", i + 1, ext))
+                    .mime_str(&mime)
+                    .map_err(|e| format!("참조 이미지 MIME 오류: {e}"))?;
+                form = form.part("image[]", part);
+            }
+        }
+        form = form
+            .text("model", "gpt-image-1")
+            .text("prompt", prompt_with_refs(prompt, reference_images.len()))
+            .text("n", "1")
+            .text("size", size)
+            .text("quality", oai_quality);
+
+        client
+            .post("https://api.openai.com/v1/images/edits")
+            .header("authorization", format!("Bearer {api_key}"))
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| format!("OpenAI 네트워크 오류: {e}"))?
+    } else {
+        // 텍스트만 → /v1/images/generations (JSON)
+        let body = serde_json::json!({
+            "model": "gpt-image-1",
+            "prompt": prompt,
+            "n": 1,
+            "size": size,
+            "quality": oai_quality,
+            "moderation": "low",
+        });
+        client
+            .post("https://api.openai.com/v1/images/generations")
+            .header("authorization", format!("Bearer {api_key}"))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("OpenAI 네트워크 오류: {e}"))?
+    };
+
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        let snippet: String = raw.chars().take(400).collect();
+        return Err(format!("OpenAI HTTP {} — {}", status.as_u16(), snippet));
+    }
+
+    let parsed: OpenAiImageResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("OpenAI 응답 파싱 실패: {e}"))?;
+    let items = parsed.data.unwrap_or_default();
+    if items.is_empty() {
+        return Err("OpenAI에서 이미지를 생성하지 못했습니다.".to_string());
+    }
+    // gpt-image-1 은 항상 b64_json. url 폴백도 일단 수용.
+    let urls: Vec<String> = items
+        .into_iter()
+        .filter_map(|item| {
+            item.b64_json
+                .map(|b64| format!("data:image/png;base64,{b64}"))
+                .or(item.url)
+        })
+        .collect();
+    if urls.is_empty() {
+        return Err("OpenAI 응답에 이미지가 포함되지 않았습니다.".to_string());
+    }
+    Ok(urls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_data_url_ok() {
+        let (mime, b64) = parse_data_url("data:image/png;base64,AAAA").unwrap();
+        assert_eq!(mime, "image/png");
+        assert_eq!(b64, "AAAA");
+    }
+
+    #[test]
+    fn parse_data_url_rejects_malformed() {
+        assert!(parse_data_url("https://example.com/a.png").is_none());
+        assert!(parse_data_url("data:image/png;base64,").is_none());
+        assert!(parse_data_url("data:;base64,AAAA").is_none());
+    }
+
+    #[test]
+    fn gemini_size_mapping() {
+        assert_eq!(gemini_image_size("4k"), "4K");
+        assert_eq!(gemini_image_size("2k"), "2K");
+        assert_eq!(gemini_image_size("standard"), "1K");
+        assert_eq!(gemini_image_size(""), "1K");
+    }
+
+    #[test]
+    fn openai_size_mapping() {
+        assert_eq!(openai_size("1:1"), "1024x1024");
+        assert_eq!(openai_size("16:9"), "1536x1024");
+        assert_eq!(openai_size("9:16"), "1024x1536");
+        assert_eq!(openai_size("4:3"), "1536x1024");
+        assert_eq!(openai_size("garbage"), "1024x1024");
+    }
+
+    #[test]
+    fn openai_quality_mapping() {
+        assert_eq!(openai_quality("standard"), "medium");
+        assert_eq!(openai_quality("2k"), "high");
+        assert_eq!(openai_quality("4k"), "high");
+    }
+
+    #[test]
+    fn prompt_refs_prefix() {
+        assert_eq!(prompt_with_refs("a cat", 0), "a cat");
+        assert!(prompt_with_refs("a cat", 2).contains("2 attached reference"));
+        assert!(prompt_with_refs("a cat", 2).ends_with("a cat"));
+    }
+}

--- a/src-tauri/src/converters/llm/image_gen.rs
+++ b/src-tauri/src/converters/llm/image_gen.rs
@@ -1,5 +1,7 @@
-//! 이미지 생성 — Gemini 3.1 Flash Image / OpenAI gpt-image-1.
+//! 이미지 생성 — Gemini(Nano Banana 계열) / OpenAI(gpt-image-2).
 //!
+//! 모델 ID 는 호출부(Settings 의 전역 이미지 모델 선택)에서 인자로 전달받는다 —
+//! Gemini 는 generateContent URL 에, OpenAI 는 요청 body 의 model 에 사용.
 //! lumina-studio `imageGen.ts` 의 handleGemini/handleOpenAI 를 Rust(reqwest)로 포팅.
 //! WKWebView 의 fetch CORS 제약을 피하려 네이티브 HTTP 로 호출(텍스트 LLM 과 동일 경로).
 //! 참조 이미지는 프론트에서 `data:image/...;base64,...` 문자열로 전달.
@@ -78,16 +80,17 @@ struct GeminiInlineData {
     data: String,
 }
 
-/// Gemini 이미지 생성. 참조 이미지는 `inlineData` 로 본문에 포함.
+/// Gemini 이미지 생성(model = generateContent 모델 ID). 참조 이미지는 `inlineData` 로 포함.
 pub async fn generate_gemini(
     api_key: &str,
+    model: &str,
     prompt: &str,
     aspect_ratio: &str,
     quality: &str,
     reference_images: &[String],
 ) -> Result<Vec<String>, String> {
     let url = format!(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent?key={api_key}"
+        "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={api_key}"
     );
 
     // parts: 참조 이미지(inlineData) 먼저, 그 다음 text.
@@ -199,9 +202,10 @@ struct OpenAiImageItem {
     url: Option<String>,
 }
 
-/// OpenAI 이미지 생성. 참조 有 → `/v1/images/edits`(multipart), 無 → `/v1/images/generations`(JSON).
+/// OpenAI 이미지 생성(model = gpt-image-2 등). 참조 有 → `/v1/images/edits`(multipart), 無 → `/v1/images/generations`(JSON).
 pub async fn generate_openai(
     api_key: &str,
+    model: &str,
     prompt: &str,
     aspect_ratio: &str,
     quality: &str,
@@ -229,7 +233,7 @@ pub async fn generate_openai(
             }
         }
         form = form
-            .text("model", "gpt-image-1")
+            .text("model", model.to_string())
             .text("prompt", prompt_with_refs(prompt, reference_images.len()))
             .text("n", "1")
             .text("size", size)
@@ -245,7 +249,7 @@ pub async fn generate_openai(
     } else {
         // 텍스트만 → /v1/images/generations (JSON)
         let body = serde_json::json!({
-            "model": "gpt-image-1",
+            "model": model,
             "prompt": prompt,
             "n": 1,
             "size": size,

--- a/src-tauri/src/converters/llm/mod.rs
+++ b/src-tauri/src/converters/llm/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod anthropic;
 pub mod gemini;
+pub mod image_gen;
 pub mod openai_api;
 pub mod openai_codex;

--- a/src-tauri/src/converters/llm/openai_api.rs
+++ b/src-tauri/src/converters/llm/openai_api.rs
@@ -88,7 +88,7 @@ pub async fn generate_text(
     if !status.is_success() {
         let raw = resp.text().await.unwrap_or_default();
         let snippet: String = raw.chars().take(400).collect();
-        return Err(ConverterError::Codex(format!(
+        return Err(ConverterError::OpenAi(format!(
             "OpenAI HTTP {} — {}",
             status.as_u16(),
             snippet
@@ -98,7 +98,7 @@ pub async fn generate_text(
     let parsed: ChatResponse = resp
         .json()
         .await
-        .map_err(|e| ConverterError::Codex(format!("OpenAI 응답 파싱 실패: {e}")))?;
+        .map_err(|e| ConverterError::OpenAi(format!("OpenAI 응답 파싱 실패: {e}")))?;
     let text = parsed
         .choices
         .into_iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,6 +320,8 @@ pub fn run() {
             converters::commands::ai_generate_claude,
             converters::commands::ai_generate_codex,
             converters::commands::ai_generate_openai,
+            converters::commands::generate_image_gemini,
+            converters::commands::generate_image_openai,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,

--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,27 @@
   box-sizing: border-box;
 }
 
+/* ---------- Scrollbar (전역 통일 — 얇은 회색. AI 패널·Settings 모달 등 커스텀 없던 영역 포함) ---------- */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-primary);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-tertiary);
+}
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-primary) transparent;
+}
+
 :root {
   /* Spacing */
   --toolbar-height: 44px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -387,6 +387,8 @@ function App() {
   // AI 패널(stt/ocr 모드)로 drop된 파일을 자식 컴포넌트에 전달하기 위한 state
   const [audioDropped, setAudioDropped] = useState<DroppedFile | null>(null);
   const [ocrDropped, setOcrDropped] = useState<DroppedFile | null>(null);
+  // 이미지 생성 모드에서 OS 드롭으로 들어온 참조 이미지 경로(ImageGenPanel 이 소비).
+  const [imageGenRefDropped, setImageGenRefDropped] = useState<string[] | null>(null);
   const [dragActive, setDragActive] = useState(false); // #14 파일 드롭 시각 피드백
 
   // 최신 AI 패널 state 를 ref 로 유지 — 드롭 라우팅이 stt/ocr 모드를 참조 (listener 등록/해제 빈도 ↓)
@@ -445,6 +447,20 @@ function App() {
               else editorRef.current?.insertAtCursor(`\n![](${absPath})\n`);
             }
           };
+
+          // AI '이미지 생성' 모드: 드롭한 이미지는 에디터가 아니라 패널의 '참조 이미지'로 보낸다.
+          // (dragDropEnabled=true 라 webview HTML5 onDrop 이 억제돼 OS 드롭을 패널로 위임 →
+          //  에디터 이중 삽입 방지. 이 모드에서 비이미지 드롭은 무시.)
+          {
+            const ps = panelStateRef.current;
+            if (ps.aiVisible && ps.aiMode === 'image-gen') {
+              const imgs = paths.filter(
+                (fp) => imageExts.includes(fp.split('.').pop()?.toLowerCase() ?? ''),
+              );
+              if (imgs.length > 0) setImageGenRefDropped(imgs);
+              return;
+            }
+          }
 
           // 여러 파일 동시 드롭: 마크다운은 새 창, 이미지는 전부 삽입(#56), 나머지 무시.
           if (paths.length > 1) {
@@ -630,6 +646,25 @@ function App() {
       editorRef.current?.insertAtCursor(`\n![](${path})\n`);
     } catch (err) {
       console.error('[App] 클립보드 이미지 첨부 실패:', err);
+    }
+  }, []);
+
+  // AI 이미지 생성 결과를 현재 문서에 삽입(ImageGenPanel "문서에 삽입" 버튼).
+  // base64 data URL → temp 파일 → 활성 에디터(viewMode 분기)에 `![](temp경로)`.
+  // 저장(⌘S) 시 flushImagesOnSave 가 assets/ 로 복사·상대경로 치환(#56 인프라 재사용).
+  const handleInsertGeneratedImage = useCallback(async (dataUrl: string) => {
+    try {
+      const { writeTempImage, extFromMime } = await import('./lib/imageAttach');
+      const mime = dataUrl.match(/^data:([^;]+);base64,/)?.[1] ?? 'image/png';
+      const b64 = dataUrl.split(',')[1] ?? '';
+      const raw = atob(b64);
+      const bytes = new Uint8Array(raw.length);
+      for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+      const path = await writeTempImage(bytes, extFromMime(mime));
+      if (viewModeRef.current === 'preview') previewRef.current?.insertImageMarkdown(path);
+      else editorRef.current?.insertAtCursor(`\n![](${path})\n`);
+    } catch (err) {
+      console.error('[App] 생성 이미지 삽입 실패:', err);
     }
   }, []);
 
@@ -1598,6 +1633,9 @@ function App() {
           onExportPptx={handleExportPptx}
           pptxAvailable={pptxAiReady}
           pptxBusy={pptxBusy}
+          onInsertGeneratedImage={handleInsertGeneratedImage}
+          imageGenRefDropped={imageGenRefDropped}
+          onConsumeImageGenRefDropped={() => setImageGenRefDropped(null)}
         />
 
       </div>

--- a/src/components/AIPanel.css
+++ b/src/components/AIPanel.css
@@ -8,7 +8,9 @@
     background: var(--bg-secondary);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    /* 모드 메뉴를 고정하지 않고 본문과 함께 스크롤 — 패널 전체가 스크롤 컨테이너.
+       (제목 헤더만 sticky 로 고정. 모드별 자체 스크롤 영역[diff 등]은 flex:1 로 내부 스크롤 유지) */
+    overflow-y: auto;
 }
 
 .ai-panel-header {
@@ -18,6 +20,11 @@
     padding: 10px 12px;
     gap: 8px;
     flex-shrink: 0;
+    /* 스크롤해도 제목은 상단 고정 */
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-secondary);
 }
 
 .ai-panel-title {

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -179,9 +179,6 @@ export function AIPanel({
 
             {isPptxMode && (
                 <div className="ai-pptx-mode">
-                    <p className="ai-pptx-desc">
-                        현재 문서를 AI 레이아웃으로 분석해 PowerPoint(.pptx) 슬라이드로 내보냅니다.
-                    </p>
                     {!pptxAvailable ? (
                         <div className="ai-no-key">
                             <AlertCircle size={20} />

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -18,6 +18,7 @@ import { initSecureStorage } from '../services/secureStorage';
 import { ModeSelector } from './ai/ModeSelector';
 import { NotesOptions } from './ai/NotesOptions';
 import { NotesResultCard } from './ai/NotesResultCard';
+import { ImageGenPanel } from './ai/ImageGenPanel';
 import { AudioTab } from './convert/AudioTab';
 import { OcrTab } from './convert/OcrTab';
 import './AIPanel.css';
@@ -50,6 +51,10 @@ interface AIPanelProps {
     onExportPptx: () => void;
     pptxAvailable: boolean;
     pptxBusy: string | null;
+    // ── 이미지 생성(image-gen) ──
+    onInsertGeneratedImage: (dataUrl: string) => void;
+    imageGenRefDropped: string[] | null;
+    onConsumeImageGenRefDropped: () => void;
 }
 
 /** stt/ocr 모드 본문 — secureStorage 초기화 가드(기존 ConvertSidebar 패턴). */
@@ -97,6 +102,9 @@ export function AIPanel({
     onExportPptx,
     pptxAvailable,
     pptxBusy,
+    onInsertGeneratedImage,
+    imageGenRefDropped,
+    onConsumeImageGenRefDropped,
 }: AIPanelProps) {
     const [prompt, setPrompt] = useState('');
     const promptRef = useRef<HTMLTextAreaElement>(null);
@@ -130,10 +138,12 @@ export function AIPanel({
         (mode === 'improve' && !prompt.trim()) ||
         (mode === 'meeting-notes' && content.trim().length < 100);
 
-    // stt/ocr/pptx 는 AI 에이전트 키(apiKeySet)와 무관 — 키 게이트를 적용하지 않는다.
+    // stt/ocr/pptx/image-gen 은 AI 에이전트 키(apiKeySet)와 무관 — 키 게이트를 적용하지 않는다.
+    // (image-gen 은 ImageGenPanel 이 gemini/openai 키를 자체 검사한다.)
     const isConvertMode = mode === 'stt' || mode === 'ocr';
     const isPptxMode = mode === 'pptx';
-    const keyGated = !isConvertMode && !isPptxMode && !apiKeySet;
+    const isImageGenMode = mode === 'image-gen';
+    const keyGated = !isConvertMode && !isPptxMode && !isImageGenMode && !apiKeySet;
 
     return (
         <div className="ai-panel">
@@ -197,6 +207,17 @@ export function AIPanel({
                 </div>
             )}
 
+            {isImageGenMode && (
+                <ConvertModeBody visible={visible}>
+                    <ImageGenPanel
+                        onInsertImage={onInsertGeneratedImage}
+                        onShowSettings={onShowSettings}
+                        refDropped={imageGenRefDropped}
+                        onConsumeRefDropped={onConsumeImageGenRefDropped}
+                    />
+                </ConvertModeBody>
+            )}
+
             {keyGated && (
                 <div className="ai-no-key">
                     <AlertCircle size={20} />
@@ -207,7 +228,7 @@ export function AIPanel({
                 </div>
             )}
 
-            {!isConvertMode && !isPptxMode && !keyGated && (
+            {!isConvertMode && !isPptxMode && !isImageGenMode && !keyGated && (
                 <>
                     {mode === 'translate' && (
                         <div className="ai-language-select">

--- a/src/components/ai/ImageGenPanel.css
+++ b/src/components/ai/ImageGenPanel.css
@@ -1,0 +1,239 @@
+/* ─── Image Generation Panel (AIPanel 'image-gen' 모드) ─────────────── */
+
+.imggen {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+/* 공급사 토글 */
+.imggen-providers {
+    display: flex;
+    gap: 6px;
+    padding: 8px;
+    flex-shrink: 0;
+}
+
+.imggen-provider {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.imggen-provider:hover {
+    border-color: var(--accent, #3b82f6);
+    color: var(--text-primary);
+}
+
+.imggen-provider.active {
+    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
+    border-color: var(--accent, #3b82f6);
+    color: var(--accent, #3b82f6);
+    font-weight: 600;
+}
+
+.imggen-provider.nokey {
+    opacity: 0.6;
+}
+
+.imggen-provider-badge {
+    font-size: 9px;
+    font-weight: 500;
+    color: var(--text-tertiary);
+    background: var(--bg-hover);
+    padding: 1px 5px;
+    border-radius: 8px;
+}
+
+/* 섹션 공통 */
+.imggen-section {
+    padding: 4px 8px 8px;
+    flex-shrink: 0;
+}
+
+.imggen-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.imggen-label-hint {
+    font-weight: 400;
+    color: var(--text-tertiary);
+}
+
+/* 참조 이미지 썸네일 */
+.imggen-refs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.imggen-ref {
+    position: relative;
+    width: 56px;
+    height: 56px;
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid var(--border-primary);
+}
+
+.imggen-ref img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.imggen-ref-remove {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    cursor: pointer;
+    padding: 0;
+}
+
+.imggen-ref-remove:hover {
+    background: rgba(239, 68, 68, 0.9);
+}
+
+.imggen-ref-drop {
+    width: 56px;
+    height: 56px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    border: 1px dashed var(--border-primary);
+    border-radius: 6px;
+    color: var(--text-tertiary);
+    font-size: 9px;
+    text-align: center;
+}
+
+/* 비율 그리드 */
+.imggen-aspects {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+}
+
+.imggen-aspect {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    height: 52px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.imggen-aspect:hover {
+    border-color: var(--accent, #3b82f6);
+    color: var(--text-primary);
+}
+
+.imggen-aspect.active {
+    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
+    border-color: var(--accent, #3b82f6);
+    color: var(--accent, #3b82f6);
+}
+
+.imggen-aspect-box {
+    border: 1.5px solid currentColor;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.imggen-aspect-label {
+    font-size: 10px;
+    font-weight: 500;
+}
+
+/* 품질 토글 */
+.imggen-qualities {
+    display: flex;
+    gap: 6px;
+}
+
+.imggen-quality {
+    flex: 1;
+    padding: 7px 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.imggen-quality:hover {
+    border-color: var(--accent, #3b82f6);
+    color: var(--text-primary);
+}
+
+.imggen-quality.active {
+    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
+    border-color: var(--accent, #3b82f6);
+    color: var(--accent, #3b82f6);
+    font-weight: 600;
+}
+
+/* 결과 미리보기 */
+.imggen-result {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px;
+    flex-shrink: 0;
+}
+
+.imggen-result-img {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--border-primary);
+    display: block;
+}
+
+.imggen-result-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.imggen-result-actions .ai-btn {
+    flex: 1;
+    justify-content: center;
+    padding: 9px 12px;
+    font-size: 12px;
+    font-weight: 600;
+}

--- a/src/components/ai/ImageGenPanel.css
+++ b/src/components/ai/ImageGenPanel.css
@@ -3,7 +3,8 @@
 .imggen {
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
+    /* 자체 스크롤하지 않고 AI 패널 전체 스크롤에 맡김(모드 메뉴와 함께 스크롤). */
+    flex-shrink: 0;
 }
 
 /* 현재 이미지 모델 표시 (Settings 에서 변경) */

--- a/src/components/ai/ImageGenPanel.css
+++ b/src/components/ai/ImageGenPanel.css
@@ -6,55 +6,48 @@
     overflow-y: auto;
 }
 
-/* 공급사 토글 */
-.imggen-providers {
-    display: flex;
-    gap: 6px;
-    padding: 8px;
-    flex-shrink: 0;
-}
-
-.imggen-provider {
-    flex: 1;
-    position: relative;
+/* 현재 이미지 모델 표시 (Settings 에서 변경) */
+.imggen-model-info {
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 4px;
+    justify-content: space-between;
+    gap: 8px;
     padding: 8px 10px;
+    margin: 8px;
     border: 1px solid var(--border-primary);
     border-radius: 6px;
     background: var(--bg-primary);
-    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.imggen-model-name {
     font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s ease;
+    color: var(--text-secondary);
 }
 
-.imggen-provider:hover {
-    border-color: var(--accent, #3b82f6);
+.imggen-model-name strong {
     color: var(--text-primary);
-}
-
-.imggen-provider.active {
-    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
-    border-color: var(--accent, #3b82f6);
-    color: var(--accent, #3b82f6);
     font-weight: 600;
 }
 
-.imggen-provider.nokey {
-    opacity: 0.6;
+.imggen-model-change {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 5px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
 }
 
-.imggen-provider-badge {
-    font-size: 9px;
-    font-weight: 500;
-    color: var(--text-tertiary);
-    background: var(--bg-hover);
-    padding: 1px 5px;
-    border-radius: 8px;
+.imggen-model-change:hover {
+    border-color: var(--accent, #3b82f6);
+    color: var(--accent, #3b82f6);
 }
 
 /* 섹션 공통 */

--- a/src/components/ai/ImageGenPanel.tsx
+++ b/src/components/ai/ImageGenPanel.tsx
@@ -1,0 +1,321 @@
+/**
+ * 이미지 생성 패널 — AIPanel 의 'image-gen' 모드 본문.
+ *
+ * 프롬프트(+참조 이미지)로 이미지를 생성 → 패널에 미리보기 → "문서에 삽입" 또는 "파일로 저장".
+ * 공급사(Gemini/OpenAI)는 패널 안 토글로 선택하고, 키는 기존 Settings(Keychain)를 재사용한다.
+ * 실제 API 호출은 Rust(reqwest) 경유(services/imageGen.ts). 상태는 이 컴포넌트 로컬(diff 흐름 아님).
+ *
+ * 참조 이미지는 OS 드롭(App onDragDropEvent → refDropped prop)으로만 추가한다 —
+ * dragDropEnabled=true 라 webview HTML5 onDrop 이 억제되기 때문(클릭 파일선택 없음).
+ */
+
+import { useState, useEffect } from 'react';
+import { Loader2, AlertCircle, Sparkles, FileInput, Download, X, ImageIcon } from 'lucide-react';
+import { hasKey } from '../../services/secureStorage';
+import {
+    generateImage,
+    humanizeImageGenError,
+    compressImageIfNeeded,
+    ASPECT_RATIOS,
+    IMAGE_QUALITIES,
+    getPreviewDimensions,
+    type ImageProvider,
+    type ImageQuality,
+} from '../../services/imageGen';
+import './ImageGenPanel.css';
+
+interface ImageGenPanelProps {
+    /** 생성 이미지를 현재 문서에 삽입(App 이 writeTempImage→커서 삽입). */
+    onInsertImage: (dataUrl: string) => void;
+    onShowSettings: () => void;
+    /** OS 드롭으로 들어온 참조 이미지 경로 배열(App 라우팅). 소비 후 onConsumeRefDropped. */
+    refDropped: string[] | null;
+    onConsumeRefDropped: () => void;
+}
+
+const MAX_REFS = 4;
+
+const PROVIDERS: { id: ImageProvider; label: string }[] = [
+    { id: 'gemini', label: 'Gemini' },
+    { id: 'openai', label: 'ChatGPT' },
+];
+
+/** 확장자 → MIME(참조 이미지 readFile 용). */
+const EXT_MIME: Record<string, string> = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    webp: 'image/webp',
+    gif: 'image/gif',
+    heic: 'image/heic',
+    heif: 'image/heif',
+};
+
+/** Uint8Array → base64 data URL(큰 파일 stack overflow 회피 위해 청크 처리). */
+function bytesToDataUrl(bytes: Uint8Array, mime: string): string {
+    let binary = '';
+    const chunk = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+    }
+    return `data:${mime};base64,${btoa(binary)}`;
+}
+
+export function ImageGenPanel({
+    onInsertImage,
+    onShowSettings,
+    refDropped,
+    onConsumeRefDropped,
+}: ImageGenPanelProps) {
+    const [provider, setProvider] = useState<ImageProvider>(() =>
+        hasKey('gemini') ? 'gemini' : hasKey('openai') ? 'openai' : 'gemini',
+    );
+    const [prompt, setPrompt] = useState('');
+    const [aspectRatio, setAspectRatio] = useState('1:1');
+    const [quality, setQuality] = useState<ImageQuality>('standard');
+    const [refs, setRefs] = useState<string[]>([]);
+    const [status, setStatus] = useState<'idle' | 'generating' | 'done' | 'error'>('idle');
+    const [result, setResult] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
+
+    const providerHasKey = hasKey(provider);
+
+    // 참조 이미지 드롭 소비: 경로 → readFile → dataUrl → 압축 → refs 추가.
+    useEffect(() => {
+        if (!refDropped || refDropped.length === 0) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const { readFile } = await import('@tauri-apps/plugin-fs');
+                const added: string[] = [];
+                for (const path of refDropped) {
+                    const ext = path.split('.').pop()?.toLowerCase() ?? 'png';
+                    const mime = EXT_MIME[ext] ?? 'image/png';
+                    const bytes = await readFile(path);
+                    const dataUrl = bytesToDataUrl(bytes, mime);
+                    added.push(await compressImageIfNeeded(dataUrl));
+                }
+                if (!cancelled && added.length > 0) {
+                    setRefs((prev) => [...prev, ...added].slice(0, MAX_REFS));
+                }
+            } catch (err) {
+                console.error('[ImageGenPanel] 참조 이미지 읽기 실패:', err);
+            } finally {
+                if (!cancelled) onConsumeRefDropped();
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+        // refDropped 변경 시에만 — refs 는 setRefs(prev) 로 최신 반영(stale 무관).
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [refDropped]);
+
+    const handleGenerate = async () => {
+        if (!providerHasKey) {
+            onShowSettings();
+            return;
+        }
+        if (!prompt.trim() || status === 'generating') return;
+        setStatus('generating');
+        setError(null);
+        setResult(null);
+        try {
+            const urls = await generateImage({
+                provider,
+                prompt: prompt.trim(),
+                aspectRatio,
+                quality,
+                referenceImages: refs,
+            });
+            if (urls.length === 0) throw new Error('이미지를 생성하지 못했습니다.');
+            setResult(urls[0]);
+            setStatus('done');
+        } catch (err) {
+            setError(humanizeImageGenError(err, provider));
+            setStatus('error');
+        }
+    };
+
+    const handleSaveFile = async () => {
+        if (!result || saving) return;
+        setSaving(true);
+        try {
+            const [{ save }, { writeFile }] = await Promise.all([
+                import('@tauri-apps/plugin-dialog'),
+                import('@tauri-apps/plugin-fs'),
+            ]);
+            const path = await save({
+                defaultPath: `markmind-image-${Date.now()}.png`,
+                filters: [{ name: 'Image', extensions: ['png', 'jpg', 'jpeg', 'webp'] }],
+            });
+            if (!path) return;
+            const b64 = result.split(',')[1] ?? '';
+            const raw = atob(b64);
+            const bytes = new Uint8Array(raw.length);
+            for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+            await writeFile(path, bytes);
+        } catch (err) {
+            console.error('[ImageGenPanel] 파일 저장 실패:', err);
+            setError('파일 저장에 실패했습니다.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const removeRef = (idx: number) => setRefs((prev) => prev.filter((_, i) => i !== idx));
+
+    return (
+        <div className="imggen">
+            {/* 공급사 토글 */}
+            <div className="imggen-providers">
+                {PROVIDERS.map((p) => {
+                    const keyed = hasKey(p.id);
+                    return (
+                        <button
+                            key={p.id}
+                            className={`imggen-provider${provider === p.id ? ' active' : ''}${keyed ? '' : ' nokey'}`}
+                            onClick={() => setProvider(p.id)}
+                            title={keyed ? p.label : `${p.label} — API 키 필요`}
+                        >
+                            {p.label}
+                            {!keyed && <span className="imggen-provider-badge">키 필요</span>}
+                        </button>
+                    );
+                })}
+            </div>
+
+            {!providerHasKey ? (
+                <div className="ai-no-key">
+                    <AlertCircle size={20} />
+                    <p>{provider === 'gemini' ? 'Gemini' : 'OpenAI'} API 키를 설정해주세요</p>
+                    <button className="ai-btn primary" onClick={onShowSettings}>
+                        설정하기
+                    </button>
+                </div>
+            ) : (
+                <>
+                    {/* 프롬프트 */}
+                    <div className="ai-prompt-area">
+                        <textarea
+                            className="ai-prompt-input"
+                            placeholder="생성할 이미지를 설명하세요... (예: 노을 진 해변의 수채화)"
+                            value={prompt}
+                            onChange={(e) => setPrompt(e.target.value)}
+                            rows={4}
+                        />
+                    </div>
+
+                    {/* 참조 이미지 (드롭으로 추가) */}
+                    <div className="imggen-section">
+                        <div className="imggen-label">
+                            참조 이미지 <span className="imggen-label-hint">선택 · 드래그해서 추가</span>
+                        </div>
+                        <div className="imggen-refs">
+                            {refs.map((src, i) => (
+                                <div key={i} className="imggen-ref">
+                                    <img src={src} alt={`참조 ${i + 1}`} />
+                                    <button
+                                        className="imggen-ref-remove"
+                                        onClick={() => removeRef(i)}
+                                        title="참조 이미지 제거"
+                                    >
+                                        <X size={11} />
+                                    </button>
+                                </div>
+                            ))}
+                            {refs.length < MAX_REFS && (
+                                <div className="imggen-ref-drop">
+                                    <ImageIcon size={16} />
+                                    <span>여기로 드롭</span>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* 비율 */}
+                    <div className="imggen-section">
+                        <div className="imggen-label">비율</div>
+                        <div className="imggen-aspects">
+                            {ASPECT_RATIOS.map((r) => {
+                                const { w, h } = getPreviewDimensions(r.id);
+                                return (
+                                    <button
+                                        key={r.id}
+                                        className={`imggen-aspect${aspectRatio === r.id ? ' active' : ''}`}
+                                        onClick={() => setAspectRatio(r.id)}
+                                        title={r.desc}
+                                    >
+                                        <span className="imggen-aspect-box" style={{ width: w, height: h }} />
+                                        <span className="imggen-aspect-label">{r.label}</span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+
+                    {/* 품질 */}
+                    <div className="imggen-section">
+                        <div className="imggen-label">품질</div>
+                        <div className="imggen-qualities">
+                            {IMAGE_QUALITIES.map((q) => (
+                                <button
+                                    key={q.id}
+                                    className={`imggen-quality${quality === q.id ? ' active' : ''}`}
+                                    onClick={() => setQuality(q.id)}
+                                >
+                                    {q.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* 생성 버튼 */}
+                    <div className="ai-prompt-actions">
+                        <button
+                            className="ai-btn primary"
+                            onClick={handleGenerate}
+                            disabled={status === 'generating' || !prompt.trim()}
+                            title="이미지 생성"
+                        >
+                            {status === 'generating' ? (
+                                <Loader2 size={14} className="spinning" />
+                            ) : (
+                                <Sparkles size={14} />
+                            )}
+                            {status === 'generating' ? '생성 중...' : '이미지 생성'}
+                        </button>
+                    </div>
+
+                    {error && (
+                        <div className="ai-error">
+                            <AlertCircle size={14} />
+                            {error}
+                        </div>
+                    )}
+
+                    {/* 결과 미리보기 + 삽입/저장 */}
+                    {result && (
+                        <div className="imggen-result">
+                            <img className="imggen-result-img" src={result} alt="생성된 이미지" />
+                            <div className="imggen-result-actions">
+                                <button className="ai-btn primary" onClick={() => onInsertImage(result)}>
+                                    <FileInput size={14} /> 문서에 삽입
+                                </button>
+                                <button
+                                    className="ai-btn secondary"
+                                    onClick={handleSaveFile}
+                                    disabled={saving}
+                                >
+                                    {saving ? <Loader2 size={14} className="spinning" /> : <Download size={14} />}
+                                    파일로 저장
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/components/ai/ImageGenPanel.tsx
+++ b/src/components/ai/ImageGenPanel.tsx
@@ -19,8 +19,10 @@ import {
     humanizeImageGenError,
     compressImageIfNeeded,
     ASPECT_RATIOS,
+    IMAGE_RESOLUTIONS,
     IMAGE_QUALITIES,
     getPreviewDimensions,
+    type ImageResolution,
     type ImageQuality,
 } from '../../services/imageGen';
 import './ImageGenPanel.css';
@@ -71,10 +73,15 @@ export function ImageGenPanel({
     );
     const provider = imgModel.company; // 'gemini' | 'openai'
     const providerHasKey = hasKey(provider);
+    // 패널 상단엔 회사명이 아니라 선택된 모델명(예: Nano Banana 2 / GPT Image 2)을 표시.
+    const imgModelLabel =
+        IMAGE_AI_CATALOG[provider].models[imgModel.auth]?.find((m) => m.id === imgModel.model)?.label ??
+        imgModel.model;
 
     const [prompt, setPrompt] = useState('');
     const [aspectRatio, setAspectRatio] = useState('1:1');
-    const [quality, setQuality] = useState<ImageQuality>('standard');
+    const [resolution, setResolution] = useState<ImageResolution>('1K');
+    const [quality, setQuality] = useState<ImageQuality>('high'); // OpenAI 전용
     const [refs, setRefs] = useState<string[]>([]);
     const [status, setStatus] = useState<'idle' | 'generating' | 'done' | 'error'>('idle');
     const [result, setResult] = useState<string | null>(null);
@@ -127,7 +134,8 @@ export function ImageGenPanel({
                 model: imgModel.model,
                 prompt: prompt.trim(),
                 aspectRatio,
-                quality,
+                resolution,
+                quality: provider === 'openai' ? quality : undefined,
                 referenceImages: refs,
             });
             if (urls.length === 0) throw new Error('이미지를 생성하지 못했습니다.');
@@ -172,7 +180,7 @@ export function ImageGenPanel({
             {/* 현재 이미지 모델 — Settings "이미지 AI 모델"에서 변경 */}
             <div className="imggen-model-info">
                 <span className="imggen-model-name">
-                    이미지 모델: <strong>{IMAGE_AI_CATALOG[provider].label}</strong>
+                    이미지 모델: <strong>{imgModelLabel}</strong>
                 </span>
                 <button className="imggen-model-change" onClick={onShowSettings} title="설정에서 변경">
                     <SettingsIcon size={12} /> 변경
@@ -248,21 +256,39 @@ export function ImageGenPanel({
                         </div>
                     </div>
 
-                    {/* 품질 */}
+                    {/* 해상도 (공통 — Gemini imageSize / OpenAI size 환산) */}
                     <div className="imggen-section">
-                        <div className="imggen-label">품질</div>
+                        <div className="imggen-label">해상도</div>
                         <div className="imggen-qualities">
-                            {IMAGE_QUALITIES.map((q) => (
+                            {IMAGE_RESOLUTIONS.map((r) => (
                                 <button
-                                    key={q.id}
-                                    className={`imggen-quality${quality === q.id ? ' active' : ''}`}
-                                    onClick={() => setQuality(q.id)}
+                                    key={r.id}
+                                    className={`imggen-quality${resolution === r.id ? ' active' : ''}`}
+                                    onClick={() => setResolution(r.id)}
                                 >
-                                    {q.label}
+                                    {r.label}
                                 </button>
                             ))}
                         </div>
                     </div>
+
+                    {/* 품질 (OpenAI 전용 — gpt-image-2 quality. Gemini 는 해당 파라미터 없음) */}
+                    {provider === 'openai' && (
+                        <div className="imggen-section">
+                            <div className="imggen-label">품질</div>
+                            <div className="imggen-qualities">
+                                {IMAGE_QUALITIES.map((q) => (
+                                    <button
+                                        key={q.id}
+                                        className={`imggen-quality${quality === q.id ? ' active' : ''}`}
+                                        onClick={() => setQuality(q.id)}
+                                    >
+                                        {q.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
 
                     {/* 생성 버튼 */}
                     <div className="ai-prompt-actions">

--- a/src/components/ai/ImageGenPanel.tsx
+++ b/src/components/ai/ImageGenPanel.tsx
@@ -2,16 +2,18 @@
  * 이미지 생성 패널 — AIPanel 의 'image-gen' 모드 본문.
  *
  * 프롬프트(+참조 이미지)로 이미지를 생성 → 패널에 미리보기 → "문서에 삽입" 또는 "파일로 저장".
- * 공급사(Gemini/OpenAI)는 패널 안 토글로 선택하고, 키는 기존 Settings(Keychain)를 재사용한다.
- * 실제 API 호출은 Rust(reqwest) 경유(services/imageGen.ts). 상태는 이 컴포넌트 로컬(diff 흐름 아님).
+ * 공급사/모델은 Settings 의 "이미지 AI 모델" 전역 선택을 따른다(기본 AI 모델과 동일 방식 —
+ * 패널엔 별도 토글 없음). 키는 기존 Settings(Keychain)를 재사용. 실제 API 호출은 Rust 경유
+ * (services/imageGen.ts). 상태는 이 컴포넌트 로컬(diff 흐름 아님).
  *
  * 참조 이미지는 OS 드롭(App onDragDropEvent → refDropped prop)으로만 추가한다 —
  * dragDropEnabled=true 라 webview HTML5 onDrop 이 억제되기 때문(클릭 파일선택 없음).
  */
 
 import { useState, useEffect } from 'react';
-import { Loader2, AlertCircle, Sparkles, FileInput, Download, X, ImageIcon } from 'lucide-react';
+import { Loader2, AlertCircle, Sparkles, FileInput, Download, X, ImageIcon, Settings as SettingsIcon } from 'lucide-react';
 import { hasKey } from '../../services/secureStorage';
+import { getImageAIModelSelection, IMAGE_AI_CATALOG } from '../../services/aiModelConfig';
 import {
     generateImage,
     humanizeImageGenError,
@@ -19,7 +21,6 @@ import {
     ASPECT_RATIOS,
     IMAGE_QUALITIES,
     getPreviewDimensions,
-    type ImageProvider,
     type ImageQuality,
 } from '../../services/imageGen';
 import './ImageGenPanel.css';
@@ -34,11 +35,6 @@ interface ImageGenPanelProps {
 }
 
 const MAX_REFS = 4;
-
-const PROVIDERS: { id: ImageProvider; label: string }[] = [
-    { id: 'gemini', label: 'Gemini' },
-    { id: 'openai', label: 'ChatGPT' },
-];
 
 /** 확장자 → MIME(참조 이미지 readFile 용). */
 const EXT_MIME: Record<string, string> = {
@@ -67,9 +63,11 @@ export function ImageGenPanel({
     refDropped,
     onConsumeRefDropped,
 }: ImageGenPanelProps) {
-    const [provider, setProvider] = useState<ImageProvider>(() =>
-        hasKey('gemini') ? 'gemini' : hasKey('openai') ? 'openai' : 'gemini',
-    );
+    // 전역 이미지 모델 선택(Settings) — 매 렌더 읽어 설정 변경을 즉시 반영.
+    const imgModel = getImageAIModelSelection();
+    const provider = imgModel.company; // 'gemini' | 'openai'
+    const providerHasKey = hasKey(provider);
+
     const [prompt, setPrompt] = useState('');
     const [aspectRatio, setAspectRatio] = useState('1:1');
     const [quality, setQuality] = useState<ImageQuality>('standard');
@@ -78,8 +76,6 @@ export function ImageGenPanel({
     const [result, setResult] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [saving, setSaving] = useState(false);
-
-    const providerHasKey = hasKey(provider);
 
     // 참조 이미지 드롭 소비: 경로 → readFile → dataUrl → 압축 → refs 추가.
     useEffect(() => {
@@ -124,6 +120,7 @@ export function ImageGenPanel({
         try {
             const urls = await generateImage({
                 provider,
+                model: imgModel.model,
                 prompt: prompt.trim(),
                 aspectRatio,
                 quality,
@@ -168,28 +165,20 @@ export function ImageGenPanel({
 
     return (
         <div className="imggen">
-            {/* 공급사 토글 */}
-            <div className="imggen-providers">
-                {PROVIDERS.map((p) => {
-                    const keyed = hasKey(p.id);
-                    return (
-                        <button
-                            key={p.id}
-                            className={`imggen-provider${provider === p.id ? ' active' : ''}${keyed ? '' : ' nokey'}`}
-                            onClick={() => setProvider(p.id)}
-                            title={keyed ? p.label : `${p.label} — API 키 필요`}
-                        >
-                            {p.label}
-                            {!keyed && <span className="imggen-provider-badge">키 필요</span>}
-                        </button>
-                    );
-                })}
+            {/* 현재 이미지 모델 — Settings "이미지 AI 모델"에서 변경 */}
+            <div className="imggen-model-info">
+                <span className="imggen-model-name">
+                    이미지 모델: <strong>{IMAGE_AI_CATALOG[provider].label}</strong>
+                </span>
+                <button className="imggen-model-change" onClick={onShowSettings} title="설정에서 변경">
+                    <SettingsIcon size={12} /> 변경
+                </button>
             </div>
 
             {!providerHasKey ? (
                 <div className="ai-no-key">
                     <AlertCircle size={20} />
-                    <p>{provider === 'gemini' ? 'Gemini' : 'OpenAI'} API 키를 설정해주세요</p>
+                    <p>{IMAGE_AI_CATALOG[provider].label} API 키를 설정해주세요</p>
                     <button className="ai-btn primary" onClick={onShowSettings}>
                         설정하기
                     </button>

--- a/src/components/ai/ImageGenPanel.tsx
+++ b/src/components/ai/ImageGenPanel.tsx
@@ -13,7 +13,7 @@
 import { useState, useEffect } from 'react';
 import { Loader2, AlertCircle, Sparkles, FileInput, Download, X, ImageIcon, Settings as SettingsIcon } from 'lucide-react';
 import { hasKey } from '../../services/secureStorage';
-import { getImageAIModelSelection, IMAGE_AI_CATALOG } from '../../services/aiModelConfig';
+import { getImageAIModelSelection, IMAGE_AI_CATALOG, resolveUsableSelection } from '../../services/aiModelConfig';
 import {
     generateImage,
     humanizeImageGenError,
@@ -63,8 +63,12 @@ export function ImageGenPanel({
     refDropped,
     onConsumeRefDropped,
 }: ImageGenPanelProps) {
-    // 전역 이미지 모델 선택(Settings) — 매 렌더 읽어 설정 변경을 즉시 반영.
-    const imgModel = getImageAIModelSelection();
+    // 전역 이미지 모델 선택(Settings) — 매 렌더 읽고, 가용한 공급사로 보정(callAI 와 동일
+    // resolveUsableSelection). 이미지는 구독 미지원이라 API 키(hasKey)만으로 가용성 판정.
+    // 한쪽 키만 있어도 자동 선택되고, 둘 다 없으면 원본 유지 → providerHasKey 가 false 로 안내.
+    const imgModel = resolveUsableSelection(IMAGE_AI_CATALOG, getImageAIModelSelection(), (c) =>
+        hasKey(c),
+    );
     const provider = imgModel.company; // 'gemini' | 'openai'
     const providerHasKey = hasKey(provider);
 

--- a/src/components/ai/ModeSelector.tsx
+++ b/src/components/ai/ModeSelector.tsx
@@ -4,7 +4,7 @@
  * 'structurize'(마인드맵 정리)는 마인드맵 뷰 상단 버튼으로 이동(#60).
  */
 
-import { Mic, ScanText, FileText, Presentation, Wand2, SpellCheck, Languages } from 'lucide-react';
+import { Mic, ScanText, FileText, Presentation, ImagePlus, Wand2, SpellCheck, Languages } from 'lucide-react';
 import { LucideIcon } from 'lucide-react';
 import { AIMode } from '../../types/ai';
 
@@ -18,6 +18,7 @@ const MODES: { value: AIMode; label: string; Icon: LucideIcon }[] = [
     { value: 'ocr', label: '이미지 인식', Icon: ScanText },
     { value: 'meeting-notes', label: '회의록 작성', Icon: FileText },
     { value: 'pptx', label: '슬라이드 만들기', Icon: Presentation },
+    { value: 'image-gen', label: '이미지 생성', Icon: ImagePlus },
     { value: 'improve', label: '문서 개선', Icon: Wand2 },
     { value: 'grammar', label: '문법 교정', Icon: SpellCheck },
     { value: 'translate', label: '번역', Icon: Languages },

--- a/src/components/convert/AIModelPicker.tsx
+++ b/src/components/convert/AIModelPicker.tsx
@@ -1,84 +1,82 @@
 /**
- * 전역 AI 모델 선택 — 회사 → 인증 → 모델 단계형.
- * 카탈로그(aiModelConfig)를 그대로 읽어 렌더하므로 회사가 늘면 자동 확장된다.
- * 인증 단계는 회사가 2가지 이상 인증을 지원할 때만 노출(Gemini 는 API 고정 → 숨김).
+ * 모델 선택 picker — 회사 → 방식 → 모델 단계형 (controlled).
+ * 카탈로그(prop)를 그대로 읽어 렌더하므로 회사가 늘면 자동 확장된다.
+ * 텍스트(AI_CATALOG)·이미지(IMAGE_AI_CATALOG) 모두 이 컴포넌트를 재사용한다.
+ * 방식(인증) 단계는 회사가 2가지 이상 방식을 지원할 때만 노출(API 키만이면 숨김).
  */
 
-import { useEffect, useState } from 'react';
-import {
-    AI_CATALOG,
-    AICompany,
-    AIAuthMode,
-    AIModelSelection,
-    getAIModelSelection,
-    setAIModelSelection,
-    selectCompany,
-    selectAuth,
-    normalizeSelection,
-} from '../../services/aiModelConfig';
-import { detectSubscriptionLogins, SubscriptionStatus } from '../../services/subscriptionService';
+import { AICompanyDef, AIAuthMode, normalizeWithCatalog } from '../../services/aiModelConfig';
 
-export function AIModelPicker() {
-    const [sel, setSel] = useState<AIModelSelection>(getAIModelSelection());
-    const [sub, setSub] = useState<SubscriptionStatus>({ claude: false, codex: false });
+export interface ModelPickerSelection<C extends string = string> {
+    company: C;
+    auth: AIAuthMode;
+    model: string;
+}
 
-    useEffect(() => {
-        detectSubscriptionLogins().then(setSub);
-    }, []);
+interface AIModelPickerProps<C extends string> {
+    /** 섹션 제목 (예: "기본 AI 모델" / "이미지 AI 모델"). */
+    title: string;
+    catalog: Record<C, AICompanyDef>;
+    selection: ModelPickerSelection<C>;
+    onChange: (next: ModelPickerSelection<C>) => void;
+    /** 회사별 구독(OAuth) 가용 여부. 미제공 시 구독은 항상 비활성. */
+    subscriptionAvailable?: (company: C) => boolean;
+}
 
-    const apply = (next: Partial<AIModelSelection>) => {
-        const n = normalizeSelection({ ...sel, ...next });
-        setSel(n);
-        setAIModelSelection(n);
-    };
+export function AIModelPicker<C extends string>({
+    title,
+    catalog,
+    selection,
+    onChange,
+    subscriptionAvailable,
+}: AIModelPickerProps<C>) {
+    const apply = (next: Partial<ModelPickerSelection<C>>) =>
+        onChange(normalizeWithCatalog(catalog, { ...selection, ...next }));
 
-    const def = AI_CATALOG[sel.company];
-    const models = def.models[sel.auth] ?? [];
+    const def = catalog[selection.company];
+    const models = def.models[selection.auth] ?? [];
 
-    // 구독 인증 가용성 — 해당 회사의 CLI 로그인이 감지돼야 활성.
-    const subAvailable = (company: AICompany): boolean =>
-        company === 'claude' ? sub.claude : company === 'openai' ? sub.codex : false;
+    const subAvailable = (company: C): boolean => subscriptionAvailable?.(company) ?? false;
     const authEnabled = (auth: AIAuthMode): boolean =>
-        auth === 'api_key' ? true : subAvailable(sel.company);
-
-    const authLabel = (auth: AIAuthMode): string => (auth === 'api_key' ? 'API 키' : '구독');
+        auth === 'api_key' ? true : subAvailable(selection.company);
+    const authLabel = (auth: AIAuthMode): string => (auth === 'api_key' ? 'API 키' : '구독 OAuth');
 
     return (
         <section className="convert-settings-section">
-            <label>AI 모델</label>
+            <label>{title}</label>
 
             {/* 회사 */}
             <div className="ai-model-row">
                 <span className="ai-model-key">회사</span>
                 <div className="ai-seg">
-                    {(Object.keys(AI_CATALOG) as AICompany[]).map((key) => (
+                    {(Object.keys(catalog) as C[]).map((key) => (
                         <button
                             key={key}
                             type="button"
-                            className={`ai-seg-btn${sel.company === key ? ' active' : ''}`}
-                            onClick={() => apply(selectCompany(key))}
+                            className={`ai-seg-btn${selection.company === key ? ' active' : ''}`}
+                            onClick={() => apply({ company: key })}
                         >
-                            {AI_CATALOG[key].label}
+                            {catalog[key].label}
                         </button>
                     ))}
                 </div>
             </div>
 
-            {/* 인증 — 둘 이상 지원하는 회사에서만 노출 */}
+            {/* 방식 — 둘 이상 지원하는 회사에서만 노출 */}
             {def.auths.length > 1 && (
                 <div className="ai-model-row">
-                    <span className="ai-model-key">인증</span>
+                    <span className="ai-model-key">방식</span>
                     <div className="ai-seg">
                         {def.auths.map((auth) => (
                             <button
                                 key={auth}
                                 type="button"
-                                className={`ai-seg-btn${sel.auth === auth ? ' active' : ''}`}
+                                className={`ai-seg-btn${selection.auth === auth ? ' active' : ''}`}
                                 disabled={!authEnabled(auth)}
-                                onClick={() => apply(selectAuth(sel.company, auth))}
+                                onClick={() => apply({ auth })}
                             >
                                 {authLabel(auth)}
-                                {auth === 'subscription' && !subAvailable(sel.company) ? ' (미연결)' : ''}
+                                {auth === 'subscription' && !subAvailable(selection.company) ? ' (미연결)' : ''}
                             </button>
                         ))}
                     </div>
@@ -88,7 +86,7 @@ export function AIModelPicker() {
             {/* 모델 */}
             <div className="ai-model-row">
                 <span className="ai-model-key">모델</span>
-                <select value={sel.model} onChange={(e) => apply({ model: e.target.value })}>
+                <select value={selection.model} onChange={(e) => apply({ model: e.target.value })}>
                     {models.map((m) => (
                         <option key={m.id} value={m.id}>
                             {m.label}
@@ -96,10 +94,6 @@ export function AIModelPicker() {
                     ))}
                 </select>
             </div>
-
-            <p className="convert-key-note">
-                모든 AI 작업(문법·번역·개선·구조화·회의록)에 이 모델이 사용됩니다.
-            </p>
         </section>
     );
 }

--- a/src/components/convert/AIModelPicker.tsx
+++ b/src/components/convert/AIModelPicker.tsx
@@ -5,7 +5,13 @@
  * 방식(인증) 단계는 회사가 2가지 이상 방식을 지원할 때만 노출(API 키만이면 숨김).
  */
 
-import { AICompanyDef, AIAuthMode, normalizeWithCatalog } from '../../services/aiModelConfig';
+import { useEffect } from 'react';
+import {
+    AICompanyDef,
+    AIAuthMode,
+    normalizeWithCatalog,
+    resolveUsableSelection,
+} from '../../services/aiModelConfig';
 
 export interface ModelPickerSelection<C extends string = string> {
     company: C;
@@ -19,6 +25,8 @@ interface AIModelPickerProps<C extends string> {
     catalog: Record<C, AICompanyDef>;
     selection: ModelPickerSelection<C>;
     onChange: (next: ModelPickerSelection<C>) => void;
+    /** 회사별 API 키 보유 여부. 미제공 시 항상 보유로 간주. */
+    apiKeyAvailable?: (company: C) => boolean;
     /** 회사별 구독(OAuth) 가용 여부. 미제공 시 구독은 항상 비활성. */
     subscriptionAvailable?: (company: C) => boolean;
 }
@@ -28,6 +36,7 @@ export function AIModelPicker<C extends string>({
     catalog,
     selection,
     onChange,
+    apiKeyAvailable,
     subscriptionAvailable,
 }: AIModelPickerProps<C>) {
     const apply = (next: Partial<ModelPickerSelection<C>>) =>
@@ -36,10 +45,34 @@ export function AIModelPicker<C extends string>({
     const def = catalog[selection.company];
     const models = def.models[selection.auth] ?? [];
 
+    const apiKeyAvail = (company: C): boolean => apiKeyAvailable?.(company) ?? true;
     const subAvailable = (company: C): boolean => subscriptionAvailable?.(company) ?? false;
-    const authEnabled = (auth: AIAuthMode): boolean =>
-        auth === 'api_key' ? true : subAvailable(selection.company);
+    // 특정 회사+방식이 실제 사용 가능한지(API 키 보유 / 구독 연동). 카탈로그 유효성과 별개.
+    const authUsable = (company: C, auth: AIAuthMode): boolean =>
+        auth === 'subscription' ? subAvailable(company) : apiKeyAvail(company);
+    const authEnabled = (auth: AIAuthMode): boolean => authUsable(selection.company, auth);
     const authLabel = (auth: AIAuthMode): string => (auth === 'api_key' ? 'API 키' : '구독 OAuth');
+
+    // 회사 버튼 활성 = 그 회사가 지원하는 인증(API 키/구독) 중 하나라도 사용 가능할 때.
+    // 둘 다 없으면 disabled — AI 등록 탭에서 키 등록 또는 구독 연동이 필요.
+    const companyEnabled = (company: C): boolean =>
+        catalog[company].auths.some((auth) => authUsable(company, auth));
+    const companyTitle = (company: C): string | undefined => {
+        if (companyEnabled(company)) return undefined;
+        const def = catalog[company];
+        return def.auths.includes('subscription')
+            ? `${def.label} API 키 또는 구독 연동이 필요합니다`
+            : `${def.label} API 키가 필요합니다`;
+    };
+
+    // 저장된 선택이 현재 사용 불가하면(키 삭제·구독만 있음 등) 가용한 회사·방식으로 자동 보정.
+    // 예: 구독만 있는 Claude 가 'api_key' 로 저장돼 있으면 → 'subscription'(구독 OAuth)로 교정.
+    // callAI 와 동일한 resolveUsableSelection 으로 보정(가용 회사 전무면 그대로 — 키 등록 안내).
+    useEffect(() => {
+        const next = resolveUsableSelection(catalog, selection, authUsable);
+        if (next !== selection) onChange(next);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selection, apiKeyAvailable, subscriptionAvailable, catalog]);
 
     return (
         <section className="convert-settings-section">
@@ -53,7 +86,10 @@ export function AIModelPicker<C extends string>({
                         <button
                             key={key}
                             type="button"
-                            className={`ai-seg-btn${selection.company === key ? ' active' : ''}`}
+                            // 비가용(키·구독 없음) 회사는 active 강조하지 않음 — 선택된 듯 보이지 않게.
+                            className={`ai-seg-btn${selection.company === key && companyEnabled(key) ? ' active' : ''}`}
+                            disabled={!companyEnabled(key)}
+                            title={companyTitle(key)}
                             onClick={() => apply({ company: key })}
                         >
                             {catalog[key].label}
@@ -83,10 +119,14 @@ export function AIModelPicker<C extends string>({
                 </div>
             )}
 
-            {/* 모델 */}
+            {/* 모델 — 현재 회사가 비가용이면 선택 불가(disabled) */}
             <div className="ai-model-row">
                 <span className="ai-model-key">모델</span>
-                <select value={selection.model} onChange={(e) => apply({ model: e.target.value })}>
+                <select
+                    value={selection.model}
+                    disabled={!companyEnabled(selection.company)}
+                    onChange={(e) => apply({ model: e.target.value })}
+                >
                     {models.map((m) => (
                         <option key={m.id} value={m.id}>
                             {m.label}
@@ -94,6 +134,11 @@ export function AIModelPicker<C extends string>({
                     ))}
                 </select>
             </div>
+
+            {/* 가용한 회사가 하나도 없으면(키·구독 전무) 안내 — 이미지 AI 가 키 없을 때 등 */}
+            {!(Object.keys(catalog) as C[]).some(companyEnabled) && (
+                <p className="convert-key-note">AI 등록 탭에서 설정 후 사용할 수 있습니다.</p>
+            )}
         </section>
     );
 }

--- a/src/components/convert/LanShareSection.tsx
+++ b/src/components/convert/LanShareSection.tsx
@@ -122,7 +122,7 @@ export function LanShareSection() {
     return (
         <section className="convert-settings-section">
             <label>
-                아이폰 연결{' '}
+                iOS 디바이스 연결{' '}
                 {info.running ? (
                     <span className="badge badge-ok">연결됨</span>
                 ) : (
@@ -225,7 +225,7 @@ export function LanShareSection() {
             )}
 
             <p className="convert-key-note">
-                신뢰할 수 있는 네트워크에서만 사용하세요. 공용 또는 공유 네트워크에서는 보안상
+                신뢰할 수 있는 네트워크에서만 사용하세요. 공용 네트워크 등에서는 보안상
                 위험이 있을 수 있습니다.
             </p>
 

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -83,7 +83,7 @@ const KEY_SPECS: KeySpec[] = [
 ];
 
 type SettingsTab = 'basic' | 'ai' | 'extra';
-/** AI 설정 탭에 노출할 API 키 (나머지 키는 추가 기능 탭). */
+/** AI 등록 탭에 노출할 API 키 (나머지 키는 추가 기능 탭). */
 const AI_PROVIDERS: Provider[] = ['gemini', 'claude', 'openai'];
 
 function maskClientId(id: string): string {
@@ -114,12 +114,13 @@ export function SettingsView({ onDone }: SettingsViewProps) {
         openai: false,
         pyannoteai: false,
     });
-    const [stored, setStored] = useState<Record<Provider, boolean>>({
-        gemini: false,
-        claude: false,
-        openai: false,
-        pyannoteai: false,
-    });
+    // lazy init — 첫 렌더부터 키 보유 반영(회사 버튼 disabled 깜빡임 방지). useEffect 가 재확인.
+    const [stored, setStored] = useState<Record<Provider, boolean>>(() => ({
+        gemini: hasKey('gemini'),
+        claude: hasKey('claude'),
+        openai: hasKey('openai'),
+        pyannoteai: hasKey('pyannoteai'),
+    }));
     const [validation, setValidation] = useState<Record<Provider | 'gdrive', ValidationResult | null>>({
         gemini: null,
         claude: null,
@@ -153,8 +154,8 @@ export function SettingsView({ onDone }: SettingsViewProps) {
     const [aiSel, setAiSel] = useState<AIModelSelection>(getAIModelSelection());
     const [imgSel, setImgSel] = useState<ImageAIModelSelection>(getImageAIModelSelection());
 
-    // 설정 탭 (기본 / AI / 추가 기능). AI 가 가장 자주 쓰이므로 기본 진입 탭.
-    const [activeTab, setActiveTab] = useState<SettingsTab>('ai');
+    // 설정 탭 (기본 / AI / 추가 기능). 기본 설정(모델·연결)이 첫 진입 탭.
+    const [activeTab, setActiveTab] = useState<SettingsTab>('basic');
 
     useEffect(() => {
         setValues({
@@ -449,7 +450,7 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     className={`settings-tab${activeTab === 'ai' ? ' active' : ''}`}
                     onClick={() => setActiveTab('ai')}
                 >
-                    AI 설정
+                    AI 등록
                 </button>
                 <button
                     type="button"
@@ -720,13 +721,14 @@ export function SettingsView({ onDone }: SettingsViewProps) {
             {activeTab === 'basic' && (
                 <>
                     <AIModelPicker
-                        title="기본 AI 모델"
+                        title="기본 AI 선택"
                         catalog={AI_CATALOG}
                         selection={aiSel}
                         onChange={(s) => {
                             setAiSel(s);
                             setAIModelSelection(s);
                         }}
+                        apiKeyAvailable={(c) => stored[c as Provider]}
                         subscriptionAvailable={(c) =>
                             c === 'claude' ? subStatus.claude : c === 'openai' ? subStatus.codex : false
                         }
@@ -735,13 +737,14 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     <hr className="settings-divider" />
 
                     <AIModelPicker
-                        title="이미지 AI 모델"
+                        title="이미지 AI 선택"
                         catalog={IMAGE_AI_CATALOG}
                         selection={imgSel}
                         onChange={(s) => {
                             setImgSel(s);
                             setImageAIModelSelection(s);
                         }}
+                        apiKeyAvailable={(c) => stored[c as Provider]}
                     />
 
                     <hr className="settings-divider" />
@@ -751,7 +754,7 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                     ) : (
                         <section className="convert-settings-section">
                             <p className="convert-key-note">
-                                아이폰 연결은 데스크탑 앱에서만 사용할 수 있습니다.
+                                iOS 디바이스 연결은 데스크탑 앱에서만 사용할 수 있습니다.
                             </p>
                         </section>
                     )}

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -19,6 +19,16 @@ import { confirmAction } from '../../services/dialogService';
 import { isTauri } from '../../services/platform';
 import { LanShareSection } from './LanShareSection';
 import { AIModelPicker } from './AIModelPicker';
+import {
+    AI_CATALOG,
+    getAIModelSelection,
+    setAIModelSelection,
+    AIModelSelection,
+    IMAGE_AI_CATALOG,
+    getImageAIModelSelection,
+    setImageAIModelSelection,
+    ImageAIModelSelection,
+} from '../../services/aiModelConfig';
 import { loadUserMemory, saveUserMemory, USER_MEMORY_MAX_CHARS } from '../../services/userMemory';
 import {
     ValidationResult,
@@ -138,6 +148,10 @@ export function SettingsView({ onDone }: SettingsViewProps) {
 
     // 구독 연동 — 로컬 Claude Code / Codex CLI 로그인 감지 현황
     const [subStatus, setSubStatus] = useState<SubscriptionStatus>({ claude: false, codex: false });
+
+    // 전역 모델 선택 — 기본 AI(텍스트) / 이미지 AI. 기본 설정 탭의 picker 와 연동.
+    const [aiSel, setAiSel] = useState<AIModelSelection>(getAIModelSelection());
+    const [imgSel, setImgSel] = useState<ImageAIModelSelection>(getImageAIModelSelection());
 
     // 설정 탭 (기본 / AI / 추가 기능). AI 가 가장 자주 쓰이므로 기본 진입 탭.
     const [activeTab, setActiveTab] = useState<SettingsTab>('ai');
@@ -702,10 +716,33 @@ export function SettingsView({ onDone }: SettingsViewProps) {
                 </>
             )}
 
-            {/* === 기본 설정 — AI 모델 + 아이폰 연결 === */}
+            {/* === 기본 설정 — 기본/이미지 AI 모델 + 아이폰 연결 === */}
             {activeTab === 'basic' && (
                 <>
-                    <AIModelPicker />
+                    <AIModelPicker
+                        title="기본 AI 모델"
+                        catalog={AI_CATALOG}
+                        selection={aiSel}
+                        onChange={(s) => {
+                            setAiSel(s);
+                            setAIModelSelection(s);
+                        }}
+                        subscriptionAvailable={(c) =>
+                            c === 'claude' ? subStatus.claude : c === 'openai' ? subStatus.codex : false
+                        }
+                    />
+
+                    <hr className="settings-divider" />
+
+                    <AIModelPicker
+                        title="이미지 AI 모델"
+                        catalog={IMAGE_AI_CATALOG}
+                        selection={imgSel}
+                        onChange={(s) => {
+                            setImgSel(s);
+                            setImageAIModelSelection(s);
+                        }}
+                    />
 
                     <hr className="settings-divider" />
 

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -575,6 +575,25 @@
 }
 .ai-model-row select {
     flex: 1;
+    /* text input / 버튼과 동일한 높이로 맞춤. native menulist 는 padding 반영이 제한적이라
+       appearance:none + 커스텀 화살표로 input(convert-key-row)과 같은 padding·테두리·폰트 적용. */
+    padding: 8px 32px 8px 10px;
+    background-color: var(--bg-secondary);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    appearance: none;
+    -webkit-appearance: none;
+}
+.ai-model-row select:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
 }
 
 /* 구독 연동 — provider 별 행 */

--- a/src/hooks/useAI.ts
+++ b/src/hooks/useAI.ts
@@ -1,6 +1,6 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { AIMode, AIResponse, TranslateLanguage } from '../types/ai';
-import { callAI, hasApiKey, getApiKey, setApiKey, removeApiKey, applyDiff, isAuthError } from '../services/aiService';
+import { callAI, hasApiKey, isTextAIUsable, getApiKey, setApiKey, removeApiKey, applyDiff, isAuthError } from '../services/aiService';
 import { getAIModelSelection } from '../services/aiModelConfig';
 import { setValidationStatus } from '../services/apiValidation';
 import type { NotesJobResult } from '../types/converter';
@@ -17,6 +17,19 @@ export function useAI() {
     // 회의록 작성 (mode === 'meeting-notes') 전용 옵션/결과
     const [notesTemplate, setNotesTemplate] = useState<string>('general');
     const [notesResult, setNotesResult] = useState<NotesJobResult | null>(null);
+
+    // 패널 열림/모드 변경 시 현재 기본 AI 선택의 가용성(API 키 OR 구독)을 재확인 →
+    // keyGate 정확화. (hasApiKey 초기값은 현재 회사 키 동기 판정, 구독은 여기서 보강.)
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            const usable = await isTextAIUsable();
+            if (!cancelled) setApiKeySet(usable);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [panelVisible, mode]);
 
     // Toggle AI panel
     const togglePanel = useCallback(() => {

--- a/src/hooks/useNativeMenu.ts
+++ b/src/hooks/useNativeMenu.ts
@@ -79,11 +79,10 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
             const sep = () => PredefinedMenuItem.new({ item: 'Separator' });
 
             // App menu (first submenu → macOS application menu, titled by app name).
+            // Settings 는 File 메뉴로 옮김(사용자 선호 — File 이 더 직관적). 앱 메뉴엔 Hide/Quit 만.
             const appMenu = await Submenu.new({
                 text: 'MarkMind',
                 items: [
-                    await MenuItem.new({ id: 'settings', text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h().onShowSettings() }),
-                    await sep(),
                     await PredefinedMenuItem.new({ item: 'Hide' }),
                     await PredefinedMenuItem.new({ item: 'Quit' }),
                 ],
@@ -121,6 +120,10 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
                     await sep(),
                     await MenuItem.new({ id: 'drive-open', text: 'Open from Google Drive…', action: () => h().onOpenFromDrive() }),
                     await MenuItem.new({ id: 'drive-save', text: 'Save to Google Drive…', action: () => h().onSaveToDrive() }),
+                    await sep(),
+                    // Settings — 앱 메뉴(MarkMind) 대신 File 메뉴에 배치(사용자 선호: File 이 직관적).
+                    // ⌘, 단축키도 함께 이동(앱 메뉴 항목을 제거해 중복 없음).
+                    await MenuItem.new({ id: 'file-settings', text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h().onShowSettings() }),
                 ],
             });
 

--- a/src/services/aiModelConfig.ts
+++ b/src/services/aiModelConfig.ts
@@ -100,17 +100,27 @@ export const DEFAULT_SELECTION: AIModelSelection = {
     model: 'gemini-3.1-pro-preview',
 };
 
-/** 선택이 카탈로그상 유효한지(회사·인증·모델 조합) 검사 후 보정. */
-export function normalizeSelection(sel: Partial<AIModelSelection> | null): AIModelSelection {
-    const company: AICompany =
-        sel?.company && sel.company in AI_CATALOG ? sel.company : DEFAULT_SELECTION.company;
-    const def = AI_CATALOG[company];
+/**
+ * 카탈로그 기반 선택 정규화(제네릭) — 회사/인증/모델이 카탈로그상 유효한지 검사 후 보정.
+ * 텍스트(AI_CATALOG)·이미지(IMAGE_AI_CATALOG) 모두 이 한 함수로 처리(단일 로직).
+ * 무효 시 카탈로그의 첫 회사 · 그 회사의 첫 인증 · 첫 모델로 폴백.
+ */
+export function normalizeWithCatalog<C extends string>(
+    catalog: Record<C, AICompanyDef>,
+    sel: Partial<{ company: C; auth: AIAuthMode; model: string }> | null,
+): { company: C; auth: AIAuthMode; model: string } {
+    const companies = Object.keys(catalog) as C[];
+    const company: C = sel?.company && catalog[sel.company] ? sel.company : companies[0];
+    const def = catalog[company];
     const auth: AIAuthMode = sel?.auth && def.auths.includes(sel.auth) ? sel.auth : def.auths[0];
     const models = def.models[auth] ?? [];
-    const model = models.some((m) => m.id === sel?.model)
-        ? (sel!.model as string)
-        : (models[0]?.id ?? DEFAULT_SELECTION.model);
+    const model = models.some((m) => m.id === sel?.model) ? (sel!.model as string) : (models[0]?.id ?? '');
     return { company, auth, model };
+}
+
+/** 선택이 카탈로그상 유효한지(회사·인증·모델 조합) 검사 후 보정. */
+export function normalizeSelection(sel: Partial<AIModelSelection> | null): AIModelSelection {
+    return normalizeWithCatalog(AI_CATALOG, sel);
 }
 
 export function getAIModelSelection(): AIModelSelection {
@@ -134,4 +144,70 @@ export function selectCompany(company: AICompany): AIModelSelection {
 /** 인증 변경 시 모델을 그 인증의 첫 유효값으로 재설정해 반환. */
 export function selectAuth(company: AICompany, auth: AIAuthMode): AIModelSelection {
     return normalizeSelection({ company, auth });
+}
+
+// ─── 이미지 생성 전용 모델 (텍스트와 별개 — Settings "이미지 AI 모델") ──────────
+//
+// 이미지 생성이 가능한 공급사(Gemini / OpenAI). 현재는 API 키만 노출:
+//  - Gemini: 구독 OAuth 연동을 제공사가 차단(텍스트 포함) → API 키 전용.
+//  - OpenAI: ChatGPT 구독(Codex OAuth)으로도 이미지 생성이 가능하나(Codex Responses API
+//    의 image_generation 툴) 구현이 별개라 보류(GitHub 이슈). 현재는 API 키(/v1/images)만.
+// 둘 다 auths=['api_key'] → 방식 토글 자동 숨김(AIModelPicker "2가지 이상일 때만").
+// 모델 ID 는 공식 문서 기준(2026-06): Gemini 2종(generateContent), OpenAI 1종(gpt-image-2).
+// UI 표시는 별칭(Gemini 이미지 = "Nano Banana" 브랜드).
+
+/** 이미지 생성 가능 공급사. */
+export type ImageAICompany = 'gemini' | 'openai';
+
+export const IMAGE_AI_CATALOG: Record<ImageAICompany, AICompanyDef> = {
+    gemini: {
+        label: 'Gemini',
+        auths: ['api_key'],
+        models: {
+            api_key: [
+                { id: 'gemini-3.1-flash-image', label: 'Nano Banana 2' },
+                { id: 'gemini-3-pro-image', label: 'Nano Banana Pro' },
+            ],
+        },
+    },
+    openai: {
+        label: 'ChatGPT',
+        auths: ['api_key'],
+        models: {
+            api_key: [{ id: 'gpt-image-2', label: 'GPT Image 2' }],
+        },
+    },
+};
+
+/** 전역 이미지 모델 선택 (회사 + 인증 + 모델 ID). */
+export interface ImageAIModelSelection {
+    company: ImageAICompany;
+    auth: AIAuthMode;
+    model: string;
+}
+
+const IMAGE_STORAGE_KEY = 'markmind-image-ai-model-selection';
+
+/** 기본값 — Nano Banana 2 (Gemini 3.1 Flash Image, API). */
+export const IMAGE_DEFAULT_SELECTION: ImageAIModelSelection = {
+    company: 'gemini',
+    auth: 'api_key',
+    model: 'gemini-3.1-flash-image',
+};
+
+export function normalizeImageSelection(sel: Partial<ImageAIModelSelection> | null): ImageAIModelSelection {
+    return normalizeWithCatalog(IMAGE_AI_CATALOG, sel);
+}
+
+export function getImageAIModelSelection(): ImageAIModelSelection {
+    try {
+        const raw = localStorage.getItem(IMAGE_STORAGE_KEY);
+        return normalizeImageSelection(raw ? (JSON.parse(raw) as ImageAIModelSelection) : null);
+    } catch {
+        return IMAGE_DEFAULT_SELECTION;
+    }
+}
+
+export function setImageAIModelSelection(sel: ImageAIModelSelection): void {
+    localStorage.setItem(IMAGE_STORAGE_KEY, JSON.stringify(sel));
 }

--- a/src/services/aiModelConfig.ts
+++ b/src/services/aiModelConfig.ts
@@ -123,6 +123,34 @@ export function normalizeSelection(sel: Partial<AIModelSelection> | null): AIMod
     return normalizeWithCatalog(AI_CATALOG, sel);
 }
 
+/**
+ * 저장된 선택을 "실제 사용 가능한" 회사·방식으로 보정. 가용성은 호출부가 `isUsable` 로 주입
+ * (API 키 보유 / 구독 연동 — Settings 는 stored·subStatus, callAI 는 hasKey·구독감지).
+ * - 현재 선택이 가용하면 **그대로(동일 참조)** 반환 → 호출부가 `===` 로 변경 여부 판단.
+ * - 비가용이면: 현재 회사가 가용하면 방식만 교정(구독만 있으면 subscription 으로),
+ *   아니면 첫 가용 회사로 전환(모델은 회사 유지 시 보존, 바뀌면 그 회사 첫 모델).
+ * - 가용한 회사가 하나도 없으면(키·구독 전무) 원본 그대로(키 등록 안내 상태).
+ * AIModelPicker(Settings UI)와 callAI(실제 호출)가 이 함수로 동일하게 보정한다.
+ */
+export function resolveUsableSelection<C extends string>(
+    catalog: Record<C, AICompanyDef>,
+    sel: { company: C; auth: AIAuthMode; model: string },
+    isUsable: (company: C, auth: AIAuthMode) => boolean,
+): { company: C; auth: AIAuthMode; model: string } {
+    const companyOk = (c: C): boolean => catalog[c].auths.some((a) => isUsable(c, a));
+    if (companyOk(sel.company) && isUsable(sel.company, sel.auth)) return sel;
+    const company = companyOk(sel.company)
+        ? sel.company
+        : (Object.keys(catalog) as C[]).find(companyOk);
+    if (!company) return sel;
+    const auth = catalog[company].auths.find((a) => isUsable(company, a)) ?? catalog[company].auths[0];
+    return normalizeWithCatalog(catalog, {
+        company,
+        auth,
+        model: company === sel.company ? sel.model : undefined,
+    });
+}
+
 export function getAIModelSelection(): AIModelSelection {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);

--- a/src/services/aiModelConfig.ts
+++ b/src/services/aiModelConfig.ts
@@ -202,6 +202,7 @@ export const IMAGE_AI_CATALOG: Record<ImageAICompany, AICompanyDef> = {
         label: 'ChatGPT',
         auths: ['api_key'],
         models: {
+            // alias(자동 최신 스냅샷) — 차후 모델 갱신 자동 추적. dated 스냅샷도 유효.
             api_key: [{ id: 'gpt-image-2', label: 'GPT Image 2' }],
         },
     },

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -4,7 +4,8 @@ import type { FlowchartNode, FlowchartEdge } from '../types/flowchart';
 import { layoutFlowchart } from '../lib/dagre-layout';
 import { getKey, hasKey, setKey, removeKey } from './secureStorage';
 import { getCachedUserMemory } from './userMemory';
-import { getAIModelSelection } from './aiModelConfig';
+import { getAIModelSelection, AI_CATALOG, resolveUsableSelection, type AIModelSelection } from './aiModelConfig';
+import { detectSubscriptionLogins } from './subscriptionService';
 import FLOWCHART_SYSTEM_PROMPT from './flowchartPrompt.txt?raw';
 
 // ─── API Key Management ───────────────────────────────────
@@ -353,12 +354,33 @@ export function isAuthError(err: unknown): boolean {
     );
 }
 
+/**
+ * 전역 텍스트 AI 선택을 실제 가용한 회사·방식으로 보정(callAI 용). API 키(hasKey)와
+ * 구독 연동(detectSubscriptionLogins)을 함께 보고 결정 — Settings 의 AIModelPicker 와
+ * 동일한 resolveUsableSelection 을 써서 UI 와 호출이 같은 규칙으로 동작한다.
+ * 예: API 키 없이 구독만 있는 Claude 가 저장돼 있으면 'subscription' 으로 보정 → 호출 성공.
+ */
+async function resolveUsableTextSelection(): Promise<AIModelSelection> {
+    const raw = getAIModelSelection();
+    const sub = await detectSubscriptionLogins();
+    return resolveUsableSelection(AI_CATALOG, raw, (company, auth) =>
+        auth === 'subscription'
+            ? company === 'claude'
+                ? sub.claude
+                : company === 'openai'
+                  ? sub.codex
+                  : false
+            : hasKey(company),
+    );
+}
+
 export async function callAI(
     request: AIRequest,
     onStream?: (text: string) => void,
 ): Promise<AIResponse> {
     // 전역 AI 모델 설정(설정 > 기본 설정)에 따라 회사·인증·모델 결정.
-    const sel = getAIModelSelection();
+    // 저장된 선택이 비가용(키 삭제·구독만)이면 가용한 회사·방식으로 보정 후 호출.
+    const sel = await resolveUsableTextSelection();
     const hasPrompt = !!request.prompt?.trim();
     const systemPrompt = getSystemPrompt(request);
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -24,8 +24,23 @@ export async function removeApiKey(): Promise<void> {
     await removeKey('gemini');
 }
 
+/** 현재 선택된 기본 AI 회사의 키 보유 여부(동기). 구독 가용성은 isTextAIUsable 로 별도 확인. */
 export function hasApiKey(): boolean {
-    return hasKey('gemini');
+    return hasKey(getAIModelSelection().company);
+}
+
+/**
+ * 현재 기본 AI 선택이 실제 사용 가능한지 — API 키 OR 구독 연동(async). AIPanel keyGate 판정용.
+ * (예: 키 없이 Claude/ChatGPT 구독만 연동돼도 사용 가능 → keyGate 풀림.)
+ */
+export async function isTextAIUsable(): Promise<boolean> {
+    const sel = getAIModelSelection();
+    if (hasKey(sel.company)) return true;
+    if (AI_CATALOG[sel.company]?.auths.includes('subscription')) {
+        const sub = await detectSubscriptionLogins();
+        return sel.company === 'claude' ? sub.claude : sel.company === 'openai' ? sub.codex : false;
+    }
+    return false;
 }
 
 // ─── System Prompts ───────────────────────────────────────

--- a/src/services/imageGen.ts
+++ b/src/services/imageGen.ts
@@ -93,6 +93,14 @@ export function humanizeImageGenError(err: unknown, provider: ImageProvider): st
     // Rust command 의 "API 키가 없습니다 ..." 안내는 그대로 노출(설정 유도).
     if (body.includes('api 키가 없습니다')) return raw;
 
+    // GPT Image 모델(gpt-image-2 등)은 API 키와 별개로 "조직 인증"이 필요 — 미인증 시 거부됨.
+    if (body.includes('verif') || body.includes('organization must') || body.includes('must be verified'))
+        return `${label} 조직 인증(Organization Verification)이 필요합니다. platform.openai.com → 설정 → 조직(General)에서 인증을 완료한 뒤 다시 시도해주세요. (GPT Image 모델 공통 요건)`;
+
+    // 결제 한도(billing hard limit) 도달 — OpenAI 계정 측 한도/크레딧 문제(코드·요청 무관).
+    if (body.includes('billing') || body.includes('hard limit'))
+        return `${label} 결제 한도에 도달했습니다. platform.openai.com → Settings → Limits 에서 사용 한도를 상향하거나 결제(크레딧)를 확인해주세요.`;
+
     const statusMatch = raw.match(/http\s+(\d{3})/i);
     const status = statusMatch ? Number(statusMatch[1]) : 0;
 
@@ -106,13 +114,17 @@ export function humanizeImageGenError(err: unknown, provider: ImageProvider): st
         return '콘텐츠 안전 정책에 의해 차단되었습니다. 프롬프트를 수정해주세요.';
     if (body.includes('invalid_image') || body.includes('could not process image') || body.includes('참조 이미지'))
         return '참조 이미지를 처리할 수 없습니다. 다른 이미지를 사용해주세요.';
-    if (body.includes('네트워크') || body.includes('network') || body.includes('failed to fetch') || body.includes('timeout') || body.includes('dns'))
+    if (body.includes('timed out') || body.includes('timeout') || body.includes('시간 초과'))
+        return `${label} 응답 시간 초과 — 이미지 생성이 오래 걸리고 있습니다(특히 2K/4K·high 품질). 품질·크기를 낮추거나 잠시 후 다시 시도해주세요.`;
+    if (body.includes('네트워크') || body.includes('network') || body.includes('failed to fetch') || body.includes('dns'))
         return '네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요.';
     if (status >= 500)
         return `${label} 서버에 일시적 오류가 발생했습니다. 잠시 후 다시 시도해주세요.`;
     if (status === 400) {
         if (body.includes('prompt')) return '프롬프트에 문제가 있습니다. 내용을 확인하고 다시 시도해주세요.';
-        return `${label} 요청이 거부되었습니다. 설정을 확인해주세요.`;
+        // 원인 미상 400 — OpenAI 원본 메시지를 노출해 진단(파라미터/모델/정책 등 구분).
+        const detail = (raw.includes('—') ? raw.split('—').slice(1).join('—') : raw).trim();
+        return `${label} 요청 거부: ${detail.slice(0, 400)}`;
     }
     // 폴백 — Rust 가 만든 한국어 메시지("...생성하지 못했습니다." 등)는 그대로 노출.
     return raw;

--- a/src/services/imageGen.ts
+++ b/src/services/imageGen.ts
@@ -50,6 +50,8 @@ export function getPreviewDimensions(ratio: string, maxDim = 28): { w: number; h
 
 export interface GenerateImageOptions {
     provider: ImageProvider;
+    /** 호출에 쓸 모델 ID (예: gemini-3.1-flash-image / gpt-image-2). */
+    model: string;
     prompt: string;
     aspectRatio: string;
     quality: ImageQuality;
@@ -62,12 +64,13 @@ export interface GenerateImageOptions {
  * Tauri 가 인자명을 camelCase→snake_case 자동 매핑한다(aspectRatio → aspect_ratio 등).
  */
 export async function generateImage(opts: GenerateImageOptions): Promise<string[]> {
-    const { provider, prompt, aspectRatio, quality, referenceImages } = opts;
+    const { provider, model, prompt, aspectRatio, quality, referenceImages } = opts;
     if (!prompt.trim()) throw new Error('프롬프트를 입력해주세요.');
 
     const { invoke } = await import('@tauri-apps/api/core');
     const command = provider === 'gemini' ? 'generate_image_gemini' : 'generate_image_openai';
     return invoke<string[]>(command, {
+        model,
         prompt,
         aspectRatio,
         quality,

--- a/src/services/imageGen.ts
+++ b/src/services/imageGen.ts
@@ -1,0 +1,175 @@
+/**
+ * 이미지 생성 클라이언트 — Rust command(generate_image_gemini/openai) 호출 래퍼.
+ *
+ * 실제 API 호출은 Rust(reqwest)가 담당한다(WKWebView fetch 의 CORS 제약 회피 — 텍스트
+ * LLM 과 동일 경로). 키는 기존 Settings 의 Keychain(gemini/openai)을 Rust 가 직접 읽으므로
+ * 여기서 전달하지 않는다. 반환은 base64 data URL 배열(개수 1) — 삽입/저장이 공급사와 무관.
+ *
+ * 참조 이미지 압축(compressImageIfNeeded)은 lumina-studio 에서 그대로 가져옴(canvas 기반).
+ */
+
+export type ImageProvider = 'gemini' | 'openai';
+export type ImageQuality = 'standard' | '2k' | '4k';
+
+export interface AspectRatioDef {
+    id: string;
+    label: string;
+    desc: string;
+}
+
+/** 선택 가능한 비율(가로:세로). UI 그리드가 이 목록을 그대로 렌더. */
+export const ASPECT_RATIOS: readonly AspectRatioDef[] = [
+    { id: '1:1', label: '1:1', desc: '정사각' },
+    { id: '3:2', label: '3:2', desc: '가로' },
+    { id: '2:3', label: '2:3', desc: '세로' },
+    { id: '4:3', label: '4:3', desc: '표준' },
+    { id: '3:4', label: '3:4', desc: '세로' },
+    { id: '16:9', label: '16:9', desc: '와이드' },
+    { id: '9:16', label: '9:16', desc: '수직' },
+    { id: '21:9', label: '21:9', desc: '울트라' },
+] as const;
+
+export interface ImageQualityDef {
+    id: ImageQuality;
+    label: string;
+}
+
+export const IMAGE_QUALITIES: readonly ImageQualityDef[] = [
+    { id: 'standard', label: '표준' },
+    { id: '2k', label: '2K' },
+    { id: '4k', label: '4K' },
+] as const;
+
+/** 비율 미리보기 박스 크기(최대 변 maxDim px). */
+export function getPreviewDimensions(ratio: string, maxDim = 28): { w: number; h: number } {
+    const [rw, rh] = ratio.split(':').map(Number);
+    if (!rw || !rh) return { w: maxDim, h: maxDim };
+    if (rw >= rh) return { w: maxDim, h: Math.round(maxDim * (rh / rw)) };
+    return { w: Math.round(maxDim * (rw / rh)), h: maxDim };
+}
+
+export interface GenerateImageOptions {
+    provider: ImageProvider;
+    prompt: string;
+    aspectRatio: string;
+    quality: ImageQuality;
+    /** base64 data URL 배열. 비우면 텍스트→이미지. */
+    referenceImages?: string[];
+}
+
+/**
+ * 이미지 생성 — provider 에 따라 Rust command 호출. 반환은 base64 data URL 배열(보통 1장).
+ * Tauri 가 인자명을 camelCase→snake_case 자동 매핑한다(aspectRatio → aspect_ratio 등).
+ */
+export async function generateImage(opts: GenerateImageOptions): Promise<string[]> {
+    const { provider, prompt, aspectRatio, quality, referenceImages } = opts;
+    if (!prompt.trim()) throw new Error('프롬프트를 입력해주세요.');
+
+    const { invoke } = await import('@tauri-apps/api/core');
+    const command = provider === 'gemini' ? 'generate_image_gemini' : 'generate_image_openai';
+    return invoke<string[]>(command, {
+        prompt,
+        aspectRatio,
+        quality,
+        referenceImages: referenceImages ?? [],
+    });
+}
+
+// ===== 사용자 친화적 에러 메시지 =====
+
+/**
+ * Rust 가 던진 에러 문자열(`Gemini HTTP 401 — ...`, `OpenAI 네트워크 오류: ...`,
+ * `... API 키가 없습니다 ...` 등)을 한국어 메시지로 변환. raw 는 콘솔에 남긴다.
+ */
+export function humanizeImageGenError(err: unknown, provider: ImageProvider): string {
+    const label = provider === 'gemini' ? 'Gemini' : 'OpenAI';
+    const raw = err instanceof Error ? err.message : String(err);
+    const body = raw.toLowerCase();
+    console.error(`[imageGen/${provider}]`, raw.slice(0, 500));
+
+    // Rust command 의 "API 키가 없습니다 ..." 안내는 그대로 노출(설정 유도).
+    if (body.includes('api 키가 없습니다')) return raw;
+
+    const statusMatch = raw.match(/http\s+(\d{3})/i);
+    const status = statusMatch ? Number(statusMatch[1]) : 0;
+
+    if (status === 401 || status === 403 || body.includes('invalid api key') || body.includes('unauthorized') || body.includes('invalid_api_key'))
+        return `${label} API 키가 유효하지 않습니다. 설정에서 키를 확인해주세요.`;
+    if (status === 429 || body.includes('rate limit') || body.includes('quota') || body.includes('insufficient_quota'))
+        return `${label} 요청 한도를 초과했습니다. 잠시 후 다시 시도해주세요.`;
+    if (status === 413 || body.includes('too large') || body.includes('entity too large'))
+        return '요청 데이터가 너무 큽니다. 참조 이미지를 줄이거나 해상도를 낮춰주세요.';
+    if (body.includes('safety') || body.includes('blocked') || body.includes('content_policy') || body.includes('moderation') || body.includes('violat'))
+        return '콘텐츠 안전 정책에 의해 차단되었습니다. 프롬프트를 수정해주세요.';
+    if (body.includes('invalid_image') || body.includes('could not process image') || body.includes('참조 이미지'))
+        return '참조 이미지를 처리할 수 없습니다. 다른 이미지를 사용해주세요.';
+    if (body.includes('네트워크') || body.includes('network') || body.includes('failed to fetch') || body.includes('timeout') || body.includes('dns'))
+        return '네트워크 연결에 실패했습니다. 인터넷 연결을 확인해주세요.';
+    if (status >= 500)
+        return `${label} 서버에 일시적 오류가 발생했습니다. 잠시 후 다시 시도해주세요.`;
+    if (status === 400) {
+        if (body.includes('prompt')) return '프롬프트에 문제가 있습니다. 내용을 확인하고 다시 시도해주세요.';
+        return `${label} 요청이 거부되었습니다. 설정을 확인해주세요.`;
+    }
+    // 폴백 — Rust 가 만든 한국어 메시지("...생성하지 못했습니다." 등)는 그대로 노출.
+    return raw;
+}
+
+// ===== 참조 이미지 압축 (lumina-studio 이식, canvas 기반) =====
+
+const REF_MAX_BYTES = 4 * 1024 * 1024; // 4MB/이미지 — OpenAI edits 하드리밋 + IPC 페이로드 절감
+const REF_MAX_DIMENSION = 4096; // 최대 변(px)
+
+/**
+ * base64 data URL 이미지를 크기/해상도 한도 안으로 압축. 이미 한도 내면 원본 그대로 반환.
+ */
+export async function compressImageIfNeeded(dataUrl: string): Promise<string> {
+    const base64Part = dataUrl.split(',')[1] || '';
+    const estimatedBytes = Math.round((base64Part.length * 3) / 4);
+
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+            const withinBytes = estimatedBytes <= REF_MAX_BYTES;
+            const withinDims = img.width <= REF_MAX_DIMENSION && img.height <= REF_MAX_DIMENSION;
+            if (withinBytes && withinDims) {
+                resolve(dataUrl); // 한도 내 — 원본 유지
+                return;
+            }
+            resolve(resizeAndCompress(img));
+        };
+        img.onerror = () => resolve(dataUrl); // 폴백: 원본 그대로
+        img.src = dataUrl;
+    });
+}
+
+function resizeAndCompress(img: HTMLImageElement): string {
+    let { width, height } = img;
+
+    if (width > REF_MAX_DIMENSION || height > REF_MAX_DIMENSION) {
+        const scale = Math.min(REF_MAX_DIMENSION / width, REF_MAX_DIMENSION / height);
+        width = Math.round(width * scale);
+        height = Math.round(height * scale);
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return canvas.toDataURL('image/jpeg', 0.85);
+    ctx.drawImage(img, 0, 0, width, height);
+
+    // JPEG 품질을 낮춰가며 4MB 이하 달성 시도
+    for (const q of [0.92, 0.85, 0.75, 0.6, 0.45]) {
+        const result = canvas.toDataURL('image/jpeg', q);
+        const size = Math.round(((result.split(',')[1]?.length || 0) * 3) / 4);
+        if (size <= REF_MAX_BYTES) return result;
+    }
+
+    // 최후: 절반으로 추가 축소
+    canvas.width = Math.round(width * 0.5);
+    canvas.height = Math.round(height * 0.5);
+    const ctx2 = canvas.getContext('2d');
+    if (ctx2) ctx2.drawImage(img, 0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL('image/jpeg', 0.7);
+}

--- a/src/services/imageGen.ts
+++ b/src/services/imageGen.ts
@@ -9,7 +9,10 @@
  */
 
 export type ImageProvider = 'gemini' | 'openai';
-export type ImageQuality = 'standard' | '2k' | '4k';
+/** 해상도 — 공통 축. Gemini=imageSize 직접, OpenAI=비율과 함께 size(WxH)로 환산. */
+export type ImageResolution = '1K' | '2K' | '4K';
+/** 렌더 품질 — OpenAI(gpt-image-2)의 quality 파라미터 전용(Gemini 는 해당 없음). */
+export type ImageQuality = 'low' | 'medium' | 'high';
 
 export interface AspectRatioDef {
     id: string;
@@ -29,15 +32,18 @@ export const ASPECT_RATIOS: readonly AspectRatioDef[] = [
     { id: '21:9', label: '21:9', desc: '울트라' },
 ] as const;
 
-export interface ImageQualityDef {
-    id: ImageQuality;
-    label: string;
-}
+/** 해상도 선택지(공통 — 두 공급사 모두 노출). */
+export const IMAGE_RESOLUTIONS: readonly { id: ImageResolution; label: string }[] = [
+    { id: '1K', label: '1K' },
+    { id: '2K', label: '2K' },
+    { id: '4K', label: '4K' },
+] as const;
 
-export const IMAGE_QUALITIES: readonly ImageQualityDef[] = [
-    { id: 'standard', label: '표준' },
-    { id: '2k', label: '2K' },
-    { id: '4k', label: '4K' },
+/** 품질 선택지(OpenAI 전용 — gpt-image-2 quality). */
+export const IMAGE_QUALITIES: readonly { id: ImageQuality; label: string }[] = [
+    { id: 'low', label: '낮음' },
+    { id: 'medium', label: '보통' },
+    { id: 'high', label: '높음' },
 ] as const;
 
 /** 비율 미리보기 박스 크기(최대 변 maxDim px). */
@@ -54,7 +60,9 @@ export interface GenerateImageOptions {
     model: string;
     prompt: string;
     aspectRatio: string;
-    quality: ImageQuality;
+    resolution: ImageResolution;
+    /** OpenAI 전용 렌더 품질. Gemini 는 무시. */
+    quality?: ImageQuality;
     /** base64 data URL 배열. 비우면 텍스트→이미지. */
     referenceImages?: string[];
 }
@@ -62,19 +70,25 @@ export interface GenerateImageOptions {
 /**
  * 이미지 생성 — provider 에 따라 Rust command 호출. 반환은 base64 data URL 배열(보통 1장).
  * Tauri 가 인자명을 camelCase→snake_case 자동 매핑한다(aspectRatio → aspect_ratio 등).
+ * - Gemini: aspectRatio + resolution(=imageSize) 만 전달(품질 파라미터 없음).
+ * - OpenAI: aspectRatio + resolution(→ size WxH 환산) + quality 전달.
  */
 export async function generateImage(opts: GenerateImageOptions): Promise<string[]> {
-    const { provider, model, prompt, aspectRatio, quality, referenceImages } = opts;
+    const { provider, model, prompt, aspectRatio, resolution, quality, referenceImages } = opts;
     if (!prompt.trim()) throw new Error('프롬프트를 입력해주세요.');
 
     const { invoke } = await import('@tauri-apps/api/core');
-    const command = provider === 'gemini' ? 'generate_image_gemini' : 'generate_image_openai';
-    return invoke<string[]>(command, {
+    const refs = referenceImages ?? [];
+    if (provider === 'gemini') {
+        return invoke<string[]>('generate_image_gemini', { model, prompt, aspectRatio, resolution, referenceImages: refs });
+    }
+    return invoke<string[]>('generate_image_openai', {
         model,
         prompt,
         aspectRatio,
-        quality,
-        referenceImages: referenceImages ?? [],
+        resolution,
+        quality: quality ?? 'high',
+        referenceImages: refs,
     });
 }
 

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -4,6 +4,8 @@
  *  - meeting-notes: 현재 문서를 transcript 로 보고 회의록 .md 새 파일 생성 → ResultCard
  *  - stt/ocr: 입력(음성/이미지)을 텍스트로 변환 — converter 가 자체 키로 처리(AI 에이전트 키 무관)
  *  - pptx(라벨 "슬라이드 만들기"): 현재 문서를 AI 레이아웃으로 .pptx 내보내기
+ *  - image-gen(라벨 "이미지 생성"): 프롬프트(+참조 이미지)로 이미지 생성 → 미리보기 → 문서 삽입/파일 저장.
+ *    Gemini/OpenAI 자체 키 사용(diff 흐름 아님, ImageGenPanel 로컬 상태).
  */
 export type AIMode =
     | 'grammar'
@@ -13,7 +15,8 @@ export type AIMode =
     | 'meeting-notes'
     | 'stt'
     | 'ocr'
-    | 'pptx';
+    | 'pptx'
+    | 'image-gen';
 
 /** 번역 대상 언어 */
 export type TranslateLanguage = 'ko' | 'en' | 'ja';


### PR DESCRIPTION
## Summary
AI 에이전트에 **이미지 생성**(Gemini Nano Banana / OpenAI gpt-image-2) 모드를 추가하고, 그 과정에서 드러난 Settings·AI 선택 전반의 UX·버그를 정비했습니다.

## Changes
- **이미지 생성**: AIPanel `image-gen` 모드. Rust reqwest 경유(WKWebView CORS 회피), 생성→미리보기→문서 삽입(#56 인프라 재사용)/파일 저장, 참조 이미지(OS 드롭).
- **이미지 옵션 3축**: 비율 + 해상도(1K/2K/4K, 공통) + 품질(OpenAI 전용). Gemini=`imageSize`, OpenAI=`size`(WxH 환산, gpt-image-2 제약 충족)+`quality`. 공식 모델 ID(`gpt-image-2`, `gemini-3.1-flash-image`/`gemini-3-pro-image`).
- **Settings**: 기본/이미지 AI 모델 분리, `AIModelPicker` 제네릭화, 진입 탭=기본 설정, 인증 없는 회사 비활성 + 비가용 선택 자동 보정(`resolveUsableSelection` — Settings·callAI·이미지 공유).
- **버그 수정**: keyGate가 항상 gemini 키만 확인하던 문제(→ 현재 회사 키+구독). 타임아웃 300초 상향, OpenAI 에러 사유별 안내(결제/인증/시간초과), `Codex`→`OpenAI` 에러 라벨 정정.
- **UI**: Settings를 File 메뉴로 이동, 스크롤바 전역 통일(얇은 회색), AI 패널 헤더 고정·모드 메뉴 함께 스크롤, 라벨 정리(기본/이미지 AI 선택, 방식·구독 OAuth, iOS 디바이스 연결).

## Test plan
- [ ] 이미지 생성: Gemini/OpenAI 각 비율·해상도·품질, 참조 이미지, 문서 삽입/파일 저장
- [ ] keyGate: API 키/구독에 따라 텍스트 모드(회의록·문서개선·번역 등) 정상 해제
- [ ] Settings: 기본/이미지 모델 선택·비활성·자동 보정, File 메뉴 Settings, 스크롤바
- [ ] 빌드: cargo check + cargo test + npm run build(tsc)

관련 이슈: #73 (ChatGPT 구독 OAuth 이미지 생성 — 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)