### PR TITLE
feat(ui): 프레임워크 패널 개편 + 모달 UI 통일 + AI 아이콘 (v0.8.1)

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "markmind",
   "display_name": "MarkMind",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Connect Claude to your open MarkMind documents — read and edit live editor content (including unsaved changes) via the in-app MCP server.",
   "author": {
     "name": "KnowAI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "0.8.0"
+version = "0.8.1"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -916,7 +916,8 @@ body {
   font-weight: 600;
   color: var(--text-primary);
 }
-.settings-modal-close {
+/* === 공통 모달 UI — 닫기 X 버튼 · 푸터 액션 버튼 통일 (모달 일관성) === */
+.modal-close {
   width: 32px;
   height: 32px;
   border: 1px solid var(--border-primary);
@@ -928,11 +929,72 @@ body {
   align-items: center;
   justify-content: center;
   transition: var(--transition-fast);
+  flex-shrink: 0;
 }
-.settings-modal-close:hover {
+.modal-close:hover {
   background: rgba(239, 68, 68, 0.1);
   color: #ef4444;
   border-color: #ef4444;
+}
+
+/* 보조 아이콘 버튼(새로고침 등) — modal-close 박스, hover 는 중립(빨강 아님) */
+.modal-icon-btn {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-fast);
+  flex-shrink: 0;
+}
+.modal-icon-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* 푸터 액션 영역 — 우측 정렬 취소(secondary) + 확인(primary) */
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.modal-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border: 1px solid var(--border-primary);
+  border-radius: 7px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 13px;
+  transition: var(--transition-fast);
+}
+.modal-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+.modal-btn-primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+.modal-btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
+.modal-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+/* 단독 액션(취소 없이 confirm 한 개)일 때 — 가로 꽉 채움 */
+.modal-btn-full {
+  width: 100%;
+  justify-content: center;
 }
 .settings-modal-note {
   margin: 0;
@@ -992,24 +1054,6 @@ body {
   font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
-}
-.drive-browser-close {
-  width: 32px;
-  height: 32px;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: var(--transition-fast);
-}
-.drive-browser-close:hover {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
-  border-color: #ef4444;
 }
 .drive-browser-saverow {
   display: flex;
@@ -1250,20 +1294,6 @@ body {
   display: flex; align-items: center; gap: 8px;
   font-size: 14px; font-weight: 600; color: var(--text-primary);
 }
-.speaker-editor-close {
-  width: 32px; height: 32px;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-}
-.speaker-editor-close:hover {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
-  border-color: #ef4444;
-}
 .speaker-editor-desc {
   margin: 0; padding: 10px 18px 6px;
   font-size: 12px; color: var(--text-secondary);
@@ -1328,26 +1358,6 @@ body {
   border-radius: 6px;
   color: #ff6b6b; font-size: 12px;
 }
-.speaker-editor-actions {
-  display: flex; gap: 8px; justify-content: flex-end;
-  padding: 12px 18px;
-  border-top: 1px solid var(--border-primary);
-}
-.speaker-editor-actions button {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 7px 14px;
-  border: 1px solid var(--border-primary);
-  border-radius: 6px;
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  cursor: pointer;
-  font-size: 13px;
-}
-.speaker-editor-actions button.primary {
-  background: var(--accent); color: white; border-color: var(--accent);
-}
-.speaker-editor-actions button:hover:not(:disabled) { filter: brightness(1.08); }
-.speaker-editor-actions button:disabled { opacity: 0.45; cursor: not-allowed; }
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
@@ -2876,8 +2886,7 @@ code.hljs {
   gap: 4px;
 }
 
-.recent-clear-btn,
-.recent-close-btn {
+.recent-clear-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2891,8 +2900,7 @@ code.hljs {
   transition: all var(--transition-fast);
 }
 
-.recent-clear-btn:hover,
-.recent-close-btn:hover {
+.recent-clear-btn:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
 }

--- a/src/components/DriveBrowser.tsx
+++ b/src/components/DriveBrowser.tsx
@@ -156,7 +156,7 @@ export function DriveBrowser({
                         <span>{mode === 'open' ? 'Open from Google Drive' : 'Save to Google Drive'}</span>
                     </div>
                     <button
-                        className="drive-browser-close"
+                        className="modal-close"
                         onClick={onClose}
                         aria-label="닫기"
                         title="닫기 (Esc)"
@@ -175,7 +175,7 @@ export function DriveBrowser({
                             disabled={busy}
                         />
                         <button
-                            className="primary"
+                            className="modal-btn modal-btn-primary"
                             onClick={handleSave}
                             disabled={busy || !saveName.trim()}
                         >

--- a/src/components/FrameworkPanel.css
+++ b/src/components/FrameworkPanel.css
@@ -34,20 +34,6 @@
     color: var(--text-primary, #222222);
 }
 
-.fw-x {
-    display: inline-flex;
-    padding: 4px;
-    border: none;
-    background: transparent;
-    color: var(--text-secondary, #888888);
-    cursor: pointer;
-    border-radius: 6px;
-}
-
-.fw-x:hover:not(:disabled) {
-    background: var(--bg-hover, #ececec);
-}
-
 .fw-field {
     display: flex;
     flex-direction: column;
@@ -70,34 +56,12 @@
     border-color: var(--accent, #6366f1);
 }
 
-.fw-suggest-row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-wrap: wrap;
-}
-
-.fw-suggest {
+/* AI 추천 카드 — 이름에 아이콘 + accent 강조 (갤러리 첫 카드, 기본 선택). */
+.fw-card-suggest .fw-card-name {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 6px 12px;
-    border: 1px solid var(--border-primary, #cccccc);
-    border-radius: 6px;
-    background: var(--bg-secondary, #f5f5f5);
-    color: var(--text-primary, #222222);
-    cursor: pointer;
-    font-size: 13px;
-}
-
-.fw-suggest:disabled {
-    opacity: 0.55;
-    cursor: default;
-}
-
-.fw-suggest-reason {
-    font-size: 12px;
-    color: var(--text-secondary, #888888);
+    gap: 5px;
+    color: var(--accent, #6366f1);
 }
 
 .fw-gallery {
@@ -191,32 +155,3 @@
     font-size: 13px;
 }
 
-.fw-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-}
-
-.fw-actions button {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 7px 16px;
-    border: 1px solid var(--border-primary, #cccccc);
-    border-radius: 7px;
-    background: var(--bg-secondary, #f5f5f5);
-    color: var(--text-primary, #222222);
-    cursor: pointer;
-    font-size: 13px;
-}
-
-.fw-go {
-    border-color: var(--accent, #6366f1) !important;
-    background: var(--accent, #6366f1) !important;
-    color: #ffffff !important;
-}
-
-.fw-actions button:disabled {
-    opacity: 0.55;
-    cursor: default;
-}

--- a/src/components/FrameworkPanel.tsx
+++ b/src/components/FrameworkPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * 프레임워크로 마인드맵 생성 패널 (MindBusiness 이식).
  *
- * 주제 + 프레임워크(범용 갤러리 + 비즈니스 접기) 선택 → generateFrameworkMindmap 으로 채운 뒤
+ * 주제 + 프레임워크(기본 갤러리 + 고급 접기) 선택 → generateFrameworkMindmap 으로 채운 뒤
  * onApply(tree, mode) 로 부모(MindmapView)에 넘긴다(쓰기=교체/이어붙이기, 모두 마크다운 SSOT 경유).
  * AI 추천(suggestFramework)은 선택을 하이라이트만 — 차단하지 않고 오버라이드 가능.
  */
@@ -30,46 +30,29 @@ function FwCard({ fw, selected, onClick }: { fw: Framework; selected: boolean; o
     );
 }
 
+/** AI 추천 카드의 sentinel — 실제 프레임워크가 아니라 "생성 시 LLM 이 주제 보고 선택" 표시. */
+const SUGGEST_ID = '__suggest__';
+
 export function FrameworkPanel({ initialTopic, docNonEmpty, onApply, onClose }: FrameworkPanelProps) {
     const list = frameworkList();
-    const general = list.filter((f) => f.general);
-    const business = list.filter((f) => !f.general);
+    const basicList = list.filter((f) => f.basic);
+    const advanced = list.filter((f) => !f.basic);
 
     const [topic, setTopic] = useState(initialTopic);
-    const [selectedId, setSelectedId] = useState<string>(general[0]?.id ?? business[0]?.id ?? '');
-    const [showBusiness, setShowBusiness] = useState(false);
+    const [selectedId, setSelectedId] = useState<string>(SUGGEST_ID); // 기본 = AI 추천
+    const [showAdvanced, setShowBusiness] = useState(false);
     const [mode, setMode] = useState<'replace' | 'append'>(docNonEmpty ? 'append' : 'replace');
     const [loading, setLoading] = useState(false);
-    const [suggesting, setSuggesting] = useState(false);
-    const [suggestReason, setSuggestReason] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     const selected = FRAMEWORKS[selectedId];
+    const isSuggest = selectedId === SUGGEST_ID;
 
-    const pick = (id: string) => {
-        setSelectedId(id);
-        setSuggestReason(null);
-    };
-
-    const runSuggest = async () => {
-        const t = topic.trim() || initialTopic;
-        setSuggesting(true);
-        setError(null);
-        try {
-            const { frameworkId, reason } = await suggestFramework(t);
-            setSelectedId(frameworkId);
-            setSuggestReason(reason || null);
-            if (!FRAMEWORKS[frameworkId]?.general) setShowBusiness(true);
-        } catch (e) {
-            setError(e instanceof Error ? e.message : 'AI 추천에 실패했습니다.');
-        } finally {
-            setSuggesting(false);
-        }
-    };
+    const pick = (id: string) => setSelectedId(id);
 
     const runGenerate = async () => {
         const t = topic.trim();
-        if (!selected || !t) return;
+        if (!t) return;
         if (mode === 'replace' && docNonEmpty) {
             const ok = window.confirm('현재 문서 내용을 교체합니다. 계속할까요? (⌘Z 로 되돌릴 수 있습니다)');
             if (!ok) return;
@@ -77,7 +60,14 @@ export function FrameworkPanel({ initialTopic, docNonEmpty, onApply, onClose }: 
         setLoading(true);
         setError(null);
         try {
-            const tree = await generateFrameworkMindmap(t, selected, selected.intent);
+            // AI 추천 선택이면 먼저 주제에 맞는 프레임워크를 LLM 이 결정한 뒤 생성.
+            let fw = selected;
+            if (isSuggest) {
+                const { frameworkId } = await suggestFramework(t);
+                fw = FRAMEWORKS[frameworkId] ?? FRAMEWORKS.LOGIC;
+            }
+            if (!fw) { setLoading(false); return; }
+            const tree = await generateFrameworkMindmap(t, fw, fw.intent);
             onApply(tree, mode);
             onClose();
         } catch (e) {
@@ -90,9 +80,9 @@ export function FrameworkPanel({ initialTopic, docNonEmpty, onApply, onClose }: 
         <div className="fw-backdrop" onClick={loading ? undefined : onClose} aria-hidden>
             <div className="fw-panel" role="dialog" aria-modal onClick={(e) => e.stopPropagation()}>
                 <div className="fw-head">
-                    <span>프레임워크로 마인드맵 생성</span>
-                    <button type="button" className="fw-x" onClick={onClose} title="닫기" disabled={loading}>
-                        <X size={16} />
+                    <span>마인드맵 자동 생성</span>
+                    <button type="button" className="modal-close" onClick={onClose} title="닫기" disabled={loading}>
+                        <X size={18} />
                     </button>
                 </div>
 
@@ -105,37 +95,39 @@ export function FrameworkPanel({ initialTopic, docNonEmpty, onApply, onClose }: 
                     />
                 </label>
 
-                <div className="fw-suggest-row">
-                    <button type="button" className="fw-suggest" onClick={runSuggest} disabled={suggesting || loading || !topic.trim()}>
-                        {suggesting ? <Loader2 size={13} className="spinning" /> : <Sparkles size={13} />}
-                        AI 추천
-                    </button>
-                    {suggestReason && <span className="fw-suggest-reason">✨ {suggestReason}</span>}
-                </div>
-
-                <div className="fw-gallery">
-                    {general.map((f) => (
-                        <FwCard key={f.id} fw={f} selected={f.id === selectedId} onClick={() => pick(f.id)} />
-                    ))}
-                </div>
-
-                <button type="button" className="fw-biz-toggle" onClick={() => setShowBusiness((v) => !v)}>
-                    {showBusiness ? <ChevronDown size={14} /> : <ChevronRight size={14} />} 비즈니스 프레임워크
-                </button>
-                {showBusiness && (
-                    <div className="fw-gallery">
-                        {business.map((f) => (
-                            <FwCard key={f.id} fw={f} selected={f.id === selectedId} onClick={() => pick(f.id)} />
-                        ))}
-                    </div>
-                )}
-
+                {/* 슬롯 미리보기 — 선택한 프레임워크의 L1 골격(주제 바로 아래). AI 추천 선택 시엔 미정이라 숨김. */}
                 {selected && (
                     <div className="fw-slots">
                         {selected.slots.map((s) => (
                             <span key={s.label} className="fw-slot-chip" title={s.display}>
                                 {s.label}
                             </span>
+                        ))}
+                    </div>
+                )}
+
+                <div className="fw-gallery">
+                    {/* AI 추천 — 첫 카드, 기본 선택. 생성 시 LLM 이 주제에 맞는 프레임워크를 골라 만든다. */}
+                    <button
+                        type="button"
+                        className={`fw-card fw-card-suggest${isSuggest ? ' fw-card-sel' : ''}`}
+                        onClick={() => setSelectedId(SUGGEST_ID)}
+                    >
+                        <span className="fw-card-name"><Sparkles size={13} /> AI 추천</span>
+                        <span className="fw-card-desc">주제에 맞는 프레임워크를 AI가 골라 생성</span>
+                    </button>
+                    {basicList.map((f) => (
+                        <FwCard key={f.id} fw={f} selected={f.id === selectedId} onClick={() => pick(f.id)} />
+                    ))}
+                </div>
+
+                <button type="button" className="fw-biz-toggle" onClick={() => setShowBusiness((v) => !v)}>
+                    {showAdvanced ? <ChevronDown size={14} /> : <ChevronRight size={14} />} 더 많은 프레임워크
+                </button>
+                {showAdvanced && (
+                    <div className="fw-gallery">
+                        {advanced.map((f) => (
+                            <FwCard key={f.id} fw={f} selected={f.id === selectedId} onClick={() => pick(f.id)} />
                         ))}
                     </div>
                 )}
@@ -155,11 +147,8 @@ export function FrameworkPanel({ initialTopic, docNonEmpty, onApply, onClose }: 
 
                 {error && <div className="fw-error">{error}</div>}
 
-                <div className="fw-actions">
-                    <button type="button" onClick={onClose} disabled={loading}>
-                        취소
-                    </button>
-                    <button type="button" className="fw-go" onClick={runGenerate} disabled={loading || !selected || !topic.trim()}>
+                <div className="modal-actions">
+                    <button type="button" className="modal-btn modal-btn-primary modal-btn-full" onClick={runGenerate} disabled={loading || !topic.trim()}>
                         {loading ? (
                             <>
                                 <Loader2 size={14} className="spinning" /> 생성 중…

--- a/src/components/LanFileBrowser.tsx
+++ b/src/components/LanFileBrowser.tsx
@@ -57,7 +57,7 @@ export function LanFileBrowser({ visible, onClose, onSelect }: LanFileBrowserPro
                     <span className="settings-modal-title">파일 열기</span>
                     <div style={{ display: 'flex', gap: 4 }}>
                         <button
-                            className="settings-modal-close"
+                            className="modal-icon-btn"
                             onClick={load}
                             title="새로고침"
                             aria-label="새로고침"
@@ -65,7 +65,7 @@ export function LanFileBrowser({ visible, onClose, onSelect }: LanFileBrowserPro
                             <RefreshCw size={16} />
                         </button>
                         <button
-                            className="settings-modal-close"
+                            className="modal-close"
                             onClick={onClose}
                             title="닫기"
                             aria-label="닫기"

--- a/src/components/RecentFilesPanel.tsx
+++ b/src/components/RecentFilesPanel.tsx
@@ -65,8 +65,8 @@ export function RecentFilesPanel({
                                 <Trash2 size={12} strokeWidth={1.5} />
                             </button>
                         )}
-                        <button className="recent-close-btn" onClick={onClose}>
-                            <X size={14} strokeWidth={1.5} />
+                        <button className="modal-close" onClick={onClose}>
+                            <X size={18} />
                         </button>
                     </div>
                 </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -23,7 +23,7 @@ export function SettingsModal({ visible, onClose, viewer }: SettingsModalProps) 
                 <div className="settings-modal-header">
                     <span className="settings-modal-title">Settings</span>
                     <button
-                        className="settings-modal-close"
+                        className="modal-close"
                         onClick={onClose}
                         title="닫기 (Esc)"
                         aria-label="설정 닫기"

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -4,7 +4,7 @@ import {
     FilePlus, FolderOpen, Save, Download, FileDown,
     BookMarked, Clock, History,
     Search, ChevronRight, ChevronDown, Sparkles, Check, X,
-    Settings, LayoutTemplate,
+    Settings, Bot,
     FileCode, FileText,
     Network, Share2, ChartBarStacked, type LucideIcon,
 } from 'lucide-react';
@@ -516,8 +516,8 @@ export function Toolbar({
                         onClick={onOpenFramework}
                         title="프레임워크(SWOT·5Whys 등)로 마인드맵 생성"
                     >
-                        <LayoutTemplate size={14} strokeWidth={1.5} />
-                        <span>마인드맵 AI 변환</span>
+                        <Sparkles size={14} strokeWidth={1.5} />
+                        <span>마인드맵 자동 생성</span>
                     </button>
                 )}
                 {viewMode === 'flowchart' && (
@@ -526,12 +526,12 @@ export function Toolbar({
                         onClick={onGenerateFlowchart}
                         title="문서를 BPMN-lite 플로우차트로 AI 변환"
                     >
-                        <Network size={14} strokeWidth={1.5} />
+                        <Sparkles size={14} strokeWidth={1.5} />
                         <span>플로우차트 AI 변환</span>
                     </button>
                 )}
                 <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘⇧I)">
-                    <Sparkles size={14} strokeWidth={1.5} />
+                    <Bot size={14} strokeWidth={1.5} />
                     <span>AI 에이전트</span>
                 </button>
             </div>

--- a/src/components/convert/SpeakerEditor.tsx
+++ b/src/components/convert/SpeakerEditor.tsx
@@ -107,7 +107,7 @@ export function SpeakerEditor({ visible, onClose, paths, onApplied }: SpeakerEdi
                         <span>화자 라벨 정리</span>
                     </div>
                     <button
-                        className="speaker-editor-close"
+                        className="modal-close"
                         onClick={onClose}
                         aria-label="닫기"
                         title="닫기 (Esc)"
@@ -158,12 +158,9 @@ export function SpeakerEditor({ visible, onClose, paths, onApplied }: SpeakerEdi
 
                 {error && <div className="speaker-editor-error">{error}</div>}
 
-                <div className="speaker-editor-actions">
-                    <button onClick={onClose} disabled={busy}>
-                        취소
-                    </button>
+                <div className="modal-actions">
                     <button
-                        className="primary"
+                        className="modal-btn modal-btn-primary modal-btn-full"
                         onClick={handleApply}
                         disabled={busy || loading}
                     >

--- a/src/lib/frameworks.test.ts
+++ b/src/lib/frameworks.test.ts
@@ -3,11 +3,11 @@ import { FRAMEWORKS, frameworkToSkeleton, attachGeneratedSlots, frameworkList } 
 import { treeToMarkdown, documentToTree } from './markdownTree';
 
 describe('frameworks 카탈로그', () => {
-    it('frameworkList — 범용(general) 먼저, 비즈니스 나중', () => {
+    it('frameworkList — 기본(basic) 먼저, 고급 나중', () => {
         const list = frameworkList();
-        const generalIdx = list.map((f, i) => (f.general ? i : -1)).filter((i) => i >= 0);
-        const bizIdx = list.map((f, i) => (!f.general ? i : -1)).filter((i) => i >= 0);
-        expect(Math.max(...generalIdx)).toBeLessThan(Math.min(...bizIdx));
+        const basicIdx = list.map((f, i) => (f.basic ? i : -1)).filter((i) => i >= 0);
+        const advIdx = list.map((f, i) => (!f.basic ? i : -1)).filter((i) => i >= 0);
+        expect(Math.max(...basicIdx)).toBeLessThan(Math.min(...advIdx));
     });
 
     it('모든 프레임워크 — 1개 이상 슬롯 + 슬롯 라벨 고유', () => {

--- a/src/lib/frameworks.ts
+++ b/src/lib/frameworks.ts
@@ -28,18 +28,18 @@ export interface Framework {
     /** 한 줄 설명(피커 + auto-select 프롬프트). */
     description: string;
     slots: FrameworkSlot[];
-    /** true = 범용 사고도구(전면 노출), false = 비즈니스(접기). */
-    general: boolean;
+    /** true = 기본(라벨 없이 노출), false = 고급(접기). */
+    basic: boolean;
 }
 
 export const FRAMEWORKS: Record<string, Framework> = {
-    // ─── 범용 사고도구 (general: true) ───
+    // ─── 기본 (basic: true) — 라벨 없이 노출 ───
     LOGIC: {
         id: 'LOGIC',
-        name: '5W1H (육하원칙)',
+        name: '5W1H',
         intent: 'diagnosis',
         description: '누가·언제·어디서·무엇을·어떻게·왜 — 주제를 육하원칙으로 빠짐없이 분해',
-        general: true,
+        basic: true,
         slots: [
             { label: '누가 (Who)', display: '누가 연관되어 있나?' },
             { label: '언제 (When)', display: '언제 일어나나/끝내나?' },
@@ -51,10 +51,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     FIVE_WHYS: {
         id: 'FIVE_WHYS',
-        name: '5 Whys (근본 원인)',
+        name: '5 Whys',
         intent: 'diagnosis',
         description: '"왜?"를 다섯 번 물어 표면 증상에서 근본 원인까지 파고든다',
-        general: true,
+        basic: true,
         slots: [
             { label: '1차 왜', display: '왜 그런 문제가 생겼나?' },
             { label: '2차 왜', display: '그건 또 왜 그랬나?' },
@@ -65,10 +65,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     CAUSE: {
         id: 'CAUSE',
-        name: '피쉬본 (특성요인도)',
+        name: 'Fishbone',
         intent: 'diagnosis',
         description: '문제의 원인을 사람·방법·환경·자원 네 갈래로 분해',
-        general: true,
+        basic: false,
         slots: [
             { label: '사람 (People)', display: '사람/조직의 문제는?' },
             { label: '방법 (Methods)', display: '프로세스/방식의 문제는?' },
@@ -78,10 +78,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     PROS_CONS: {
         id: 'PROS_CONS',
-        name: '장단점 분석',
+        name: 'Pros & Cons',
         intent: 'choice',
         description: '선택지의 이득·손해·보완책·결론을 정리',
-        general: true,
+        basic: true,
         slots: [
             { label: '장점 (Pros)', display: '선택하면 무엇이 좋은가?' },
             { label: '단점 (Cons)', display: '무엇을 감수해야 하나?' },
@@ -91,10 +91,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     SCAMPER: {
         id: 'SCAMPER',
-        name: 'SCAMPER (발상)',
+        name: 'SCAMPER',
         intent: 'creation',
         description: '대체·결합·응용·변형·전용·제거·역발상으로 아이디어 확장',
-        general: true,
+        basic: false,
         slots: [
             { label: '대체 (Substitute)', display: '무엇을 다른 걸로 바꿀까?' },
             { label: '결합 (Combine)', display: '무엇과 합칠까?' },
@@ -107,10 +107,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     EISENHOWER: {
         id: 'EISENHOWER',
-        name: '아이젠하워 매트릭스',
+        name: 'Eisenhower Matrix',
         intent: 'choice',
         description: '긴급도 × 중요도로 할 일을 4분면으로 분류',
-        general: true,
+        basic: false,
         slots: [
             { label: '즉시 (긴급·중요)', display: '지금 당장 할 일은?' },
             { label: '계획 (중요·여유)', display: '미리 챙길 중요한 일은?' },
@@ -120,10 +120,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     KPT: {
         id: 'KPT',
-        name: 'KPT 회고',
+        name: 'KPT',
         intent: 'strategy',
         description: '유지할 것 · 문제점 · 새로 시도할 것으로 회고',
-        general: true,
+        basic: false,
         slots: [
             { label: '유지 (Keep)', display: '잘해서 계속할 것은?' },
             { label: '문제 (Problem)', display: '아쉬웠던 것은?' },
@@ -132,10 +132,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     OKR: {
         id: 'OKR',
-        name: 'OKR (목표·핵심결과)',
+        name: 'OKR',
         intent: 'strategy',
         description: '가슴 뛰는 목표와 그것을 측정할 핵심 결과·실행',
-        general: true,
+        basic: false,
         slots: [
             { label: '목표 (Objective)', display: '도달하고 싶은 정성적 목표는?' },
             { label: '핵심결과 1 (KR)', display: '성공을 보여줄 첫 번째 숫자는?' },
@@ -145,10 +145,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     PERSONA: {
         id: 'PERSONA',
-        name: '페르소나',
+        name: 'Persona',
         intent: 'creation',
         description: '대상 인물의 프로필·니즈·불편·행동·계기를 구체화',
-        general: true,
+        basic: false,
         slots: [
             { label: '프로필 (Profile)', display: '그 사람은 누구인가?' },
             { label: '니즈 (Needs)', display: '간절히 원하는 것은?' },
@@ -159,10 +159,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     DECISION_MATRIX: {
         id: 'DECISION_MATRIX',
-        name: '의사결정 매트릭스',
+        name: 'Decision Matrix',
         intent: 'choice',
         description: '선택지를 비용·효과 기준으로 비교 평가',
-        general: true,
+        basic: false,
         slots: [
             { label: '선택지 A', display: '1안의 장점과 평가는?' },
             { label: '선택지 B', display: '2안의 장점과 평가는?' },
@@ -172,10 +172,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     PROCESS: {
         id: 'PROCESS',
-        name: '프로세스 (PDCA)',
+        name: 'PDCA',
         intent: 'strategy',
         description: '주제를 준비 → 실행 → 점검 → 개선 단계로 분해',
-        general: true,
+        basic: true,
         slots: [
             { label: '준비 (Plan)', display: '무엇을 어떻게 계획하나?' },
             { label: '실행 (Do)', display: '실제로 무엇을 하나?' },
@@ -184,13 +184,13 @@ export const FRAMEWORKS: Record<string, Framework> = {
         ],
     },
 
-    // ─── 비즈니스 (general: false, 접기) ───
+    // ─── 고급 (basic: false, 접기) ───
     SWOT: {
         id: 'SWOT',
-        name: 'SWOT 분석',
+        name: 'SWOT',
         intent: 'diagnosis',
         description: '강점·약점·기회·위협 — 내부/외부 요인 진단',
-        general: false,
+        basic: true,
         slots: [
             { label: '강점 (Strengths)', display: '우리의 확실한 무기는?' },
             { label: '약점 (Weaknesses)', display: '부족하거나 취약한 점은?' },
@@ -200,10 +200,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     BMC: {
         id: 'BMC',
-        name: '비즈니스 모델 캔버스',
+        name: 'Business Model Canvas',
         intent: 'creation',
         description: '9개 블록으로 비즈니스 모델을 한눈에 설계',
-        general: false,
+        basic: false,
         slots: [
             { label: '가치 제안 (Value)', display: '고객에게 줄 핵심 가치는?' },
             { label: '고객 세그먼트', display: '누구를 위한 것인가?' },
@@ -218,10 +218,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     LEAN: {
         id: 'LEAN',
-        name: '린 캔버스',
+        name: 'Lean Canvas',
         intent: 'creation',
         description: '스타트업 아이디어를 9칸으로 빠르게 검증',
-        general: false,
+        basic: false,
         slots: [
             { label: '문제 (Problem)', display: '해결할 진짜 문제 Top 3는?' },
             { label: '고객 세그먼트', display: '누가 가장 힘들어하나?' },
@@ -236,10 +236,10 @@ export const FRAMEWORKS: Record<string, Framework> = {
     },
     PESTEL: {
         id: 'PESTEL',
-        name: 'PESTEL 분석',
+        name: 'PESTEL',
         intent: 'strategy',
         description: '정치·경제·사회·기술·환경·법 거시환경 분석',
-        general: false,
+        basic: false,
         slots: [
             { label: '정치 (Political)', display: '정책/규제 이슈는?' },
             { label: '경제 (Economic)', display: '경기/시장 상황은?' },
@@ -254,7 +254,7 @@ export const FRAMEWORKS: Record<string, Framework> = {
 /** 범용 먼저, 그다음 비즈니스 — 카탈로그를 그룹 순서로 나열(피커용). */
 export function frameworkList(): Framework[] {
     const all = Object.values(FRAMEWORKS);
-    return [...all.filter((f) => f.general), ...all.filter((f) => !f.general)];
+    return [...all.filter((f) => f.basic), ...all.filter((f) => !f.basic)];
 }
 
 /**


### PR DESCRIPTION
## Summary
프레임워크 패널(마인드맵 자동 생성)을 전면 개편하고, 앱 전반의 모달 UI를 통일했습니다.

## Changes
- **AI 아이콘**: AI 에이전트 → `Bot`, 마인드맵/플로우차트 AI 변환 → `Sparkles`
- **프레임워크 패널**: AI 추천을 갤러리 첫 카드·기본 선택으로, 슬롯 칩을 주제 입력 아래로 이동
- **명칭 영어 정식명 통일**: Fishbone · Pros & Cons · Eisenhower Matrix · Persona 등 (괄호 한국어 제거)
- **기본/고급 분류**: 기본 5종(5W1H·5 Whys·Pros & Cons·SWOT·PDCA) + "더 많은 프레임워크" 토글
- **"마인드맵 AI 변환" → "마인드맵 자동 생성"**
- **모달 UI 통일**: 공통 `.modal-close`(박스형 X, size 18)·`.modal-btn`/`.modal-btn-primary` 도입, 주요 6개 모달(Settings·Framework·Speaker·Recent·Drive·Lan) 적용
- **푸터**: 마인드맵 생성·Speaker 적용 → 취소 제거·primary 버튼 full width
- Lan 새로고침 `.modal-icon-btn`(중립 hover) + 미사용 CSS 정리(`.primary` 등 공유 클래스 보존)
- v0.8.1

## Test plan
- [ ] 마인드맵 자동 생성: AI 추천 기본 선택 → 생성 시 LLM이 프레임워크 자동 선택, 카드 선택 시 슬롯 칩 표시, 기본/고급 토글
- [ ] 6개 모달 닫기 X(박스형 size 18) + 푸터 버튼 일관성
- [ ] AI 에이전트/마인드맵/플로우차트 버튼 아이콘
- [ ] 빌드: tsc clean · test 8/8 · vite ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)