### PR TITLE
refactor(flowchart): 편집 UX 개편(노드 클릭 자동편집·서브툴바) + v0.9.1 정정

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "markmind",
   "display_name": "MarkMind",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "description": "Connect Claude to your open MarkMind documents — read and edit live editor content (including unsaved changes) via the in-app MCP server.",
   "author": {
     "name": "KnowAI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.10.0",
+      "version": "0.9.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "0.10.0"
+version = "0.9.1"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -434,6 +434,17 @@ body {
   padding: 0 14px;
   font-weight: 600;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  margin-left: 10px; /* 자동 생성 등 앞 버튼과 간격 (toolbar-group gap 2px 보강) */
+}
+
+/* outlined — border 있는 변형(편집 토글 등). ai-agent solid 강조와 달리 윤곽선만(비강조). */
+.toolbar-text-btn.outlined {
+  border: 1px solid var(--border-primary);
+}
+.toolbar-text-btn.outlined.active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: transparent;
 }
 
 .toolbar-text-btn.ai-agent:hover {

--- a/src/components/FlowchartView.css
+++ b/src/components/FlowchartView.css
@@ -13,31 +13,6 @@
     border: none;
 }
 
-/* 편집 토글 버튼 (React Flow Panel) — AI 흐름도에서 노드 드래그/편집 on/off */
-.flow-edit-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 10px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text-primary, #334155);
-    background: var(--bg-secondary, #ffffff);
-    border: 1px solid var(--border-primary, #e2e8f0);
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-    cursor: pointer;
-    transition: filter 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
-}
-.flow-edit-toggle:hover {
-    filter: brightness(0.97);
-}
-.flow-edit-toggle.is-active {
-    color: #ffffff;
-    background: #4f46e5;
-    border-color: #4f46e5;
-}
-
 /* 노드 라벨 인라인 편집 (더블클릭 → contentEditable) */
 .flow-node__edit {
     min-width: 60px;
@@ -78,38 +53,6 @@
 }
 .flow-node.is-editable:hover .flow-node__del {
     opacity: 1;
-}
-/* 노드 추가 팔레트 (편집 모드, 우상단) */
-.flow-palette {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 8px;
-    background: var(--bg-secondary, #ffffff);
-    border: 1px solid var(--border-primary, #e2e8f0);
-    border-radius: 10px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
-.flow-palette-title {
-    font-size: 11px;
-    font-weight: 700;
-    color: var(--text-secondary, #64748b);
-    padding: 0 2px 2px;
-}
-.flow-palette-btn {
-    padding: 5px 10px;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--text-primary, #334155);
-    background: var(--bg-primary, #f8fafc);
-    border: 1px solid var(--border-primary, #e2e8f0);
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.12s, border-color 0.12s;
-}
-.flow-palette-btn:hover {
-    background: #eef2ff;
-    border-color: #4f46e5;
 }
 
 /* 편집 모드 — handle(연결점) 노출(평소 숨김). 드래그해서 노드끼리 연결. */
@@ -177,12 +120,24 @@
 .flow-node--decision {
     min-width: 200px;
     min-height: 84px;
-    background: #fde68a;
+    background: transparent;
     border: none;
     color: #713f12;
     font-weight: 500;
-    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
     padding: 22px 44px;
+    position: relative;
+}
+/* 마름모는 ::before 로 그린다 — clip-path 를 노드 박스에 직접 주면 박스 변의 React Flow
+   handle(연결점)이 함께 잘려 꼭짓점에서 반쪽만 보인다. ::before 에만 clip 을 줘서 handle 보존. */
+.flow-node--decision::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: #fde68a;
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+.flow-node--decision .flow-node__label {
+    position: relative; /* 마름모(::before) 위에 라벨 */
 }
 
 /* merge — 합류(원형) */
@@ -205,6 +160,44 @@
     flex-direction: column;
     height: 100%;
     position: relative; /* 로딩/에러 오버레이의 위치 기준 */
+}
+
+/* 노드 추가 서브 툴바 — 편집 모드. absolute overlay 로 띄워 캔버스 레이아웃을 안 민다
+   (편집 진입 시 서브툴바가 캔버스를 밀어 플로우차트가 아래로 이동하던 문제 방지).
+   캔버스는 100% 높이 유지 → React Flow 노드 위치/줌/팬 불변. */
+.flowchart-subtoolbar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 5;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--border-secondary, #e2e8f0);
+    background: var(--bg-secondary, #f8fafc);
+}
+/* 리치 텍스트 rich-tool-btn 과 통일 — 투명 배경 + hover 약하게(아이콘+라벨 형태). */
+.flowchart-subtoolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 28px;
+    padding: 0 9px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+}
+.flowchart-subtoolbar-btn:hover {
+    background: var(--bg-tertiary, rgba(0, 0, 0, 0.05));
+    color: var(--text-primary);
 }
 .flowchart-canvas {
     flex: 1;

--- a/src/components/FlowchartView.tsx
+++ b/src/components/FlowchartView.tsx
@@ -5,9 +5,9 @@
  *  1) 저장된 AI 흐름도 — 문서의 ```markmind-flow 코드블록(parseFlowchartBlock).
  *  2) 구조 미러(프리뷰) — 코드블록이 없으면 documentToTree → mindmapToFlowchart.
  *
- * 편집(Phase 1): content→nodes/edges 단방향 동기화 + 편집(드래그/라벨/추가/삭제/연결)은
- * commit→upsert→onChange 로 SSOT(markmind-flow)에 되쓰기. 자기 편집이 일으킨 content
- * 변경은 lastEmittedRef 로 재동기화를 건너뛰고, commit 시 setRf*로 즉시 반영(MindmapView 패턴).
+ * 편집(Phase 1): editMode 는 메인 툴바 토글(App)이 prop 으로 내려준다. 편집(드래그/라벨/
+ * 추가/삭제/연결)은 commit→upsert→onChange 로 SSOT(markmind-flow)에 되쓰기. 노드 추가
+ * 팔레트는 상단 서브 툴바(리치 텍스트 모드와 동형)로 노출.
  */
 
 import { useMemo, useState, useEffect, useRef, useCallback } from 'react';
@@ -16,7 +16,6 @@ import {
     ReactFlowProvider,
     Background,
     Controls,
-    Panel,
     Handle,
     Position,
     MarkerType,
@@ -28,7 +27,7 @@ import {
     type NodeProps,
     type Connection,
 } from '@xyflow/react';
-import { Pencil, Check, Trash2 } from 'lucide-react';
+import { Trash2, Play, Square, Split, ArrowRightLeft, Merge, CircleStop, type LucideIcon } from 'lucide-react';
 import { documentToTree } from '../lib/markdownTree';
 import { mindmapToFlowchart } from '../lib/flowchart-converter';
 import { layoutFlowchart } from '../lib/dagre-layout';
@@ -42,7 +41,7 @@ interface FlowNodeData {
     label: string;
     flowType: string;
     description?: string;
-    // 편집(Phase 1) — editMode 일 때만 주입(displayNodes).
+    // 편집 — canEdit 일 때만 주입(displayNodes).
     editMode?: boolean;
     isEditing?: boolean;
     onStartEdit?: () => void;
@@ -56,8 +55,6 @@ function FlowNode({ data }: NodeProps) {
     const d = data as FlowNodeData;
     const editableRef = useRef<HTMLDivElement>(null);
 
-    // 편집 진입 시 contentEditable 에 현재 라벨 주입 + 포커스/전체선택.
-    // 50ms defer 는 React Flow 노드 포지셔닝 완료를 기다린다(MindBusiness 패턴).
     useEffect(() => {
         if (!d.isEditing) return;
         const el = editableRef.current;
@@ -87,9 +84,7 @@ function FlowNode({ data }: NodeProps) {
             title={d.description || undefined}
             onDoubleClick={d.editMode ? (e) => { e.stopPropagation(); d.onStartEdit?.(); } : undefined}
         >
-            {/* dagre-layout 이 지정하는 source/targetHandle(id) 과 매칭 — forward(LR=right/left)
-                + loop(top). markerLoop(retry)가 top handle 로 위로 빠져나가 arc 가 된다.
-                평소엔 CSS 로 숨기고(연결 위치만), 편집 모드(is-editing)에서만 점을 노출한다. */}
+            {/* dagre-layout 이 지정하는 source/targetHandle(id) 과 매칭. 평소 숨김, 편집 모드에서만 노출. */}
             <Handle type="source" position={Position.Right} id="right-source" />
             <Handle type="target" position={Position.Right} id="right-target" />
             <Handle type="source" position={Position.Left} id="left-source" />
@@ -99,8 +94,7 @@ function FlowNode({ data }: NodeProps) {
             <Handle type="source" position={Position.Bottom} id="bottom-source" />
             <Handle type="target" position={Position.Bottom} id="bottom-target" />
             {d.isEditing ? (
-                // 편집/표시 분기는 서로 다른 key — 같은 div 재사용 시 contentEditable 의 명령형
-                // textContent 잔재가 남아 라벨이 중복되는 React 재조정 함정 방지(COMMON_PATTERNS).
+                // 편집/표시 분기는 서로 다른 key — contentEditable 잔재로 라벨 중복되는 함정 방지(COMMON_PATTERNS).
                 <div
                     key="edit"
                     contentEditable
@@ -144,14 +138,14 @@ function defaultLabelFor(type: FlowNodeType): string {
     }
 }
 
-/** 팔레트(노드 추가) — image 는 1차 미지원이라 제외. */
-const PALETTE: { type: FlowNodeType; label: string }[] = [
-    { type: 'start', label: '시작' },
-    { type: 'process', label: '단계' },
-    { type: 'decision', label: '분기' },
-    { type: 'io', label: '입출력' },
-    { type: 'merge', label: '합류' },
-    { type: 'end', label: '종료' },
+/** 서브 툴바 노드 추가 팔레트 — image 는 1차 미지원이라 제외. 아이콘은 노드 의미에 맞춤. */
+const PALETTE: { type: FlowNodeType; label: string; Icon: LucideIcon }[] = [
+    { type: 'start', label: '시작', Icon: Play },
+    { type: 'process', label: '단계', Icon: Square },
+    { type: 'decision', label: '분기', Icon: Split },
+    { type: 'io', label: '입출력', Icon: ArrowRightLeft },
+    { type: 'merge', label: '합류', Icon: Merge },
+    { type: 'end', label: '종료', Icon: CircleStop },
 ];
 
 /** FlowchartNode/Edge → React Flow Node/Edge. */
@@ -167,11 +161,8 @@ function toReactFlow(nodes: FlowchartNode[], edges: FlowchartEdge[]): { nodes: N
             id: e.id,
             source: e.source,
             target: e.target,
-            // dagre-layout 이 방향에 맞춰 지정한 handle id 를 넘겨야 markerLoop(retry)가 위쪽
-            // handle 로 빠져 arc 가 된다(누락 시 기본 handle 로 떨어져 메인과 겹침).
             sourceHandle: e.sourceHandle,
             targetHandle: e.targetHandle,
-            // smoothstep: 일직선=직선, 분기·loop=직각 ㄷ 자(bezier 곡선 제거).
             type: 'smoothstep',
             pathOptions: e.markerLoop ? { offset: 48 } : undefined,
             label: e.label,
@@ -188,7 +179,7 @@ interface FlowchartViewProps {
     content: string;
     fileName: string;
     onChange: (md: string) => void;
-    /** 모달(FlowchartPanel) 열림 — 메인 툴바 "플로우차트 생성" 클릭을 App 이 토글. */
+    /** 모달(FlowchartPanel) 열림 — 메인 툴바 "자동 생성" 클릭을 App 이 토글. */
     flowchartPanelOpen?: boolean;
     onCloseFlowchartPanel?: () => void;
 }
@@ -200,14 +191,21 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
     const [rfNodes, setRfNodes, onNodesChange] = useNodesState<Node>([]);
     const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<Edge>([]);
     const [isAi, setIsAi] = useState(false);
+    // 편집 모드는 명시적 버튼 없이 자동: 노드/엣지 클릭 시 ON, 빈 캔버스 클릭 시 OFF(보기).
     const [editMode, setEditMode] = useState(false);
     const [editingId, setEditingId] = useState<string | null>(null);
     const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
     const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
     const lastEmittedRef = useRef<string | null>(null);
 
-    // stored 흐름도 → React Flow nodes/edges. dagre 로 handle/배치 계산 후, 수동 저장된
-    // position 이 있으면 그걸로 override(자유 배치 보존). effect·commit 양쪽에서 재사용.
+    // 미러(markmind-flow 블록 없음)에선 편집 불가 → editMode 와 isAi 를 AND.
+    const canEdit = editMode && isAi;
+
+    // 빈 흐름도(노드 0)는 클릭으로 편집 진입할 노드가 없으니 자동 편집(노드 추가 서브툴바 노출).
+    useEffect(() => {
+        if (isAi && rfNodes.length === 0) setEditMode(true);
+    }, [isAi, rfNodes.length]);
+
     const syncFromStored = useCallback((stored: StoredFlowchart) => {
         const seeded = stored.nodes.map((n) => ({ ...n, position: n.position ?? { x: 0, y: 0 } }));
         const lo = layoutFlowchart(seeded, stored.edges, { rankdir: stored.direction ?? 'LR' });
@@ -221,7 +219,7 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
     }, [setRfNodes, setRfEdges]);
 
     useEffect(() => {
-        if (content === lastEmittedRef.current) return; // 자기 편집 echo skip
+        if (content === lastEmittedRef.current) return;
         const stored = parseFlowchartBlock(content);
         if (stored) {
             syncFromStored(stored);
@@ -233,12 +231,15 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
             setRfNodes(rf.nodes);
             setRfEdges(rf.edges);
             setIsAi(false);
-            setEditMode(false); // 미러(블록 없음)는 편집 대상 아님
             setEditingId(null);
         }
     }, [content, stem, syncFromStored, setRfNodes, setRfEdges]);
 
-    // 드래그 종료 → 위치만 저장(자유 배치 보존). stored 기반이라 type/label/edge 보존.
+    // 편집 모드를 벗어나면(또는 미러로 전환) 선택/편집 상태를 정리.
+    useEffect(() => {
+        if (!canEdit) { setEditingId(null); setSelectedNodeId(null); setSelectedEdgeId(null); }
+    }, [canEdit]);
+
     const commitPositions = useCallback((nodes: Node[]) => {
         const stored = parseFlowchartBlock(content);
         if (!stored) return;
@@ -254,14 +255,13 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
         onChange(md);
     }, [content, onChange]);
 
-    // 구조 편집(라벨/삭제/추가/연결) — stored 변형 → upsert(keepPosition) → 즉시 setRf* 반영.
     const commitFlow = useCallback((mutate: (s: StoredFlowchart) => StoredFlowchart) => {
         const stored = parseFlowchartBlock(content);
         if (!stored) return;
         const next = mutate(stored);
         const md = upsertFlowchartBlock(content, next, true);
         lastEmittedRef.current = md;
-        syncFromStored(next); // effect 는 echo skip 되므로 여기서 즉시 반영
+        syncFromStored(next);
         onChange(md);
     }, [content, onChange, syncFromStored]);
 
@@ -276,7 +276,7 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
         commitFlow((s) => ({
             ...s,
             nodes: s.nodes.filter((n) => n.id !== id),
-            edges: s.edges.filter((e) => e.source !== id && e.target !== id), // 연결된 edge 동반 삭제
+            edges: s.edges.filter((e) => e.source !== id && e.target !== id),
         }));
     }, [commitFlow]);
 
@@ -286,7 +286,6 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
     }, [commitFlow]);
 
     const addNode = useCallback((type: FlowNodeType) => {
-        // 캔버스 중심에 배치(겹침 방지 jitter). edge 없는 isolated 라 dagre 가 위치 유지.
         const wrap = document.querySelector('.flowchart-canvas');
         let center = { x: 0, y: 0 };
         if (wrap) {
@@ -300,10 +299,9 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
             ...s,
             nodes: [...s.nodes, { id, type, label: defaultLabelFor(type), position: { x: snap(center.x + jitter), y: snap(center.y + jitter) } }],
         }));
-        setEditingId(id); // 추가 직후 바로 라벨 편집
+        setEditingId(id);
     }, [screenToFlowPosition, commitFlow, rfNodes.length]);
 
-    // handle 드래그로 노드 연결 → edge 추가. handle id(방향)도 보존.
     const onConnect = useCallback((conn: Connection) => {
         if (!conn.source || !conn.target) return;
         const id = `e${Date.now().toString(36)}-${rfEdges.length}`;
@@ -319,10 +317,9 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
         }));
     }, [commitFlow, rfEdges.length]);
 
-    // 선택된 edge/노드 Delete 삭제(편집 모드). contentEditable/input 입력 중엔 제외해
-    // 라벨 편집 중 Backspace 가 노드를 지우지 않게 한다(MindBusiness 패턴).
+    // 선택된 edge/노드 Delete 삭제(편집 모드). contentEditable/input 입력 중엔 제외.
     useEffect(() => {
-        if (!editMode) return;
+        if (!canEdit) return;
         const onKey = (e: KeyboardEvent) => {
             if (e.key !== 'Delete' && e.key !== 'Backspace') return;
             const t = e.target as HTMLElement | null;
@@ -332,23 +329,21 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
         };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [editMode, selectedEdgeId, selectedNodeId, deleteEdge, deleteNode]);
+    }, [canEdit, selectedEdgeId, selectedNodeId, deleteEdge, deleteNode]);
 
-    // editMode/편집 콜백을 노드 data 에 덧입힌다(렌더 직전). 드래그용 rfNodes 는 그대로.
     const displayNodes = useMemo(() => rfNodes.map((n) => ({
         ...n,
         data: {
             ...n.data,
-            editMode,
+            editMode: canEdit,
             isEditing: n.id === editingId,
             onStartEdit: () => setEditingId(n.id),
             onUpdateLabel: (v: string) => updateLabel(n.id, v),
             onCancelEdit: () => setEditingId(null),
             onDelete: () => deleteNode(n.id),
         },
-    })), [rfNodes, editMode, editingId, updateLabel, deleteNode]);
+    })), [rfNodes, canEdit, editingId, updateLabel, deleteNode]);
 
-    // 선택된 edge 강조(편집 시각 피드백).
     const displayEdges = useMemo(() => rfEdges.map((e) => (
         e.id === selectedEdgeId
             ? { ...e, selected: true, style: { stroke: '#4f46e5', strokeWidth: 2 } }
@@ -356,7 +351,20 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
     )), [rfEdges, selectedEdgeId]);
 
     return (
-        <div className={`flowchart-view${editMode ? ' is-editing' : ''}`}>
+        <div className={`flowchart-view${canEdit ? ' is-editing' : ''}`}>
+            {canEdit && (
+                <div className="flowchart-subtoolbar">
+                    {PALETTE.map((p) => {
+                        const Icon = p.Icon;
+                        return (
+                            <button key={p.type} type="button" className="flowchart-subtoolbar-btn" onClick={() => addNode(p.type)} title={`${p.label} 노드 추가`}>
+                                <Icon size={13} strokeWidth={1.5} />
+                                <span>{p.label}</span>
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
             <div className="flowchart-canvas">
                 <ReactFlow
                     key={`${stem}-${isAi}`}
@@ -366,17 +374,16 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
                     onEdgesChange={onEdgesChange}
                     onNodeDragStop={() => commitPositions(rfNodes)}
                     onConnect={onConnect}
-                    onNodeClick={(_e, n) => { setSelectedNodeId(n.id); setSelectedEdgeId(null); }}
-                    onEdgeClick={(_e, ed) => { setSelectedEdgeId(ed.id); setSelectedNodeId(null); }}
-                    onPaneClick={() => { setSelectedNodeId(null); setSelectedEdgeId(null); }}
+                    onNodeClick={(_e, n) => { setEditMode(true); setSelectedNodeId(n.id); setSelectedEdgeId(null); }}
+                    onEdgeClick={(_e, ed) => { setEditMode(true); setSelectedEdgeId(ed.id); setSelectedNodeId(null); }}
+                    onPaneClick={() => { setEditMode(false); setSelectedNodeId(null); setSelectedEdgeId(null); }}
                     nodeTypes={nodeTypes}
                     // dagre-layout 이 position 을 노드 '중심' 으로 계산 → nodeOrigin 도 center.
-                    // 누락 시 노드 높이 다른 연결(process↔decision)에서 handle y 어긋나 edge 가 꺾인다.
                     nodeOrigin={[0.5, 0.5]}
-                    nodesDraggable={editMode}
-                    nodesConnectable={editMode}
+                    nodesDraggable={canEdit}
+                    nodesConnectable={canEdit}
                     elementsSelectable
-                    deleteKeyCode={null} // 삭제는 위 자체 핸들러(contentEditable 가드 포함)로 처리
+                    deleteKeyCode={null}
                     fitView
                     fitViewOptions={{ padding: 0.2, maxZoom: 1.2 }}
                     minZoom={0.1}
@@ -385,31 +392,6 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
                 >
                     <Background gap={20} size={1} />
                     <Controls showInteractive={false} />
-                    {isAi && (
-                        <Panel position="top-left">
-                            <button
-                                type="button"
-                                className={`flow-edit-toggle${editMode ? ' is-active' : ''}`}
-                                onClick={() => { setEditMode((v) => !v); setEditingId(null); setSelectedNodeId(null); setSelectedEdgeId(null); }}
-                                title={editMode ? '편집 완료' : '노드 편집'}
-                            >
-                                {editMode ? <Check size={14} /> : <Pencil size={14} />}
-                                {editMode ? '편집 완료' : '편집'}
-                            </button>
-                        </Panel>
-                    )}
-                    {isAi && editMode && (
-                        <Panel position="top-right">
-                            <div className="flow-palette">
-                                <span className="flow-palette-title">노드 추가</span>
-                                {PALETTE.map((p) => (
-                                    <button key={p.type} type="button" className="flow-palette-btn" onClick={() => addNode(p.type)}>
-                                        {p.label}
-                                    </button>
-                                ))}
-                            </div>
-                        </Panel>
-                    )}
                 </ReactFlow>
             </div>
             {flowchartPanelOpen && (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -512,22 +512,22 @@ export function Toolbar({
             <div className="toolbar-group">
                 {viewMode === 'mindmap' && (
                     <button
-                        className="toolbar-text-btn"
+                        className="toolbar-text-btn outlined"
                         onClick={onOpenFramework}
-                        title="프레임워크(SWOT·5Whys 등)로 마인드맵 생성"
+                        title="프레임워크(SWOT·5Whys 등)로 마인드맵 자동 생성"
                     >
                         <Sparkles size={14} strokeWidth={1.5} />
-                        <span>마인드맵 생성</span>
+                        <span>자동 생성</span>
                     </button>
                 )}
                 {viewMode === 'flowchart' && (
                     <button
-                        className="toolbar-text-btn"
+                        className="toolbar-text-btn outlined"
                         onClick={onGenerateFlowchart}
                         title="문서를 BPMN-lite 플로우차트로 AI 변환"
                     >
                         <Sparkles size={14} strokeWidth={1.5} />
-                        <span>플로우차트 생성</span>
+                        <span>자동 생성</span>
                     </button>
                 )}
                 <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘⇧I)">


### PR DESCRIPTION
## Summary
플로우차트 편집 UX 개편 + **버전 0.9.1 정정**. 노드 클릭으로 자동 편집 진입, 노드 추가는 상단 서브툴바로, decision handle 잘림 fix.

## 버전 정정 (0.10.0 → 0.9.1)
매 기능마다 minor 를 올려(하루+ 만에 0.7→0.10) 0.x 가 너무 빨리 소진됨. **0.x 는 patch 기본, minor 는 마일스톤만**으로 정책 조정. 플로우차트 편집은 생성(0.9.0)의 연장이라 0.9.1(patch)이 적절.

## Changes
### 편집 UX
- 편집 버튼 제거 → **노드/엣지 클릭 시 자동 편집**, 빈 캔버스 클릭 시 보기
- 노드 추가: 플로팅 Panel → **상단 서브툴바**(리치 텍스트 동형). `absolute overlay` 라 편집 진입해도 캔버스가 안 밀림
- 서브툴바 아이콘(Play/Square/Split/ArrowRightLeft/Merge/CircleStop) + `rich-tool-btn` 스타일 통일

### 라벨/스타일
- "플로우차트 생성"·"마인드맵 생성" → **"자동 생성"**(outlined border 통일)
- AI 에이전트 앞 간격 10px

### fix
- decision 다이아 `clip-path` → `::before` 분리 (박스 변의 handle 이 반쪽 잘리던 문제)

### chore
- unused CSS 정리(flow-edit-toggle·flow-palette·subtoolbar-label)

## Test plan
- [ ] 노드 클릭 → 자동 편집(서브툴바), 빈 곳 클릭 → 보기
- [ ] 편집 진입 시 플로우차트 안 밀림(overlay)
- [ ] decision handle 온전한 원(반쪽 잘림 없음)
- [ ] "자동 생성" 라벨/border + AI 에이전트 간격
- [ ] 드래그/라벨편집/추가/삭제/연결 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)