### PR TITLE
[codex] refine slide image assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+MarkMind is a Tauri v2 desktop app with a React 19 + TypeScript frontend and a Rust backend. Frontend code lives in `src/`: UI in `src/components`, hooks in `src/hooks`, parsing/export logic in `src/lib`, editor extensions in `src/extensions`, and shared types/constants in `src/types` and `src/constants`. Rust commands, native services, converters, MCP, Google Drive integration, resources, and icons live under `src-tauri/`. Static assets are in `public/`, docs in `docs/`, MCP packaging in `mcpb/`, and utilities in `scripts/`.
+
+## Build, Test, and Development Commands
+
+- `npm run dev`: start the Vite web app for browser-only development.
+- `npm run tauri dev`: run the native Tauri app with hot reload.
+- `npm test`: run the Vitest suite once.
+- `npm run build`: type-check with `tsc` and build the Vite frontend.
+- `npm run tauri:build`: setup ffmpeg, then build the production native app.
+- `cargo test --manifest-path src-tauri/Cargo.toml --lib`: run Rust library tests.
+- `npm run pack:mcpb`: package the MCP bundle into `markmind.mcpb`.
+
+## Coding Style & Naming Conventions
+
+Use TypeScript with React function components. Name components in PascalCase (`SettingsModal.tsx`), hooks with `use` prefixes (`useTheme.ts`), and library modules in camelCase or descriptive kebab-case matching nearby files (`markdownTree.ts`, `flowchart-converter.ts`). Keep tests colocated as `*.test.ts`. Use 2-space indentation in frontend files and standard `rustfmt` formatting for Rust. Prefer existing CSS files beside components.
+
+## Testing Guidelines
+
+Vitest covers frontend parsing and serialization logic, especially in `src/lib`. Add or update colocated `*.test.ts` files for parser, converter, export, and state-transform changes. For native behavior, add Rust tests near the affected module. Run `npm test` before submitting frontend changes and include `npm run build` when touching shared types, app bootstrapping, or build configuration.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses Conventional Commit-style subjects such as `feat(slideshow): ...`, `fix(preview): ...`, and `chore: ...`. Keep commits focused and include a scope when it clarifies the affected area. Pull requests should describe the user-visible change, list test commands run, link issues, and include screenshots or recordings for UI changes. Note setup-sensitive behavior, such as Keychain, ffmpeg, OAuth, or AI provider configuration.
+
+## Security & Configuration Tips
+
+Do not commit API keys, OAuth secrets, generated credentials, or local media. The desktop app stores provider keys in macOS Keychain; keep configuration examples generic and document required environment variables without real values.
+
+## Agent-Specific Instructions
+
+Respond to the user in Korean unless they explicitly request another language.
+
+## Claude Code Context
+
+This project was originally developed with Claude Code. Before substantial edits, check for Claude-specific guidance and reuse it when present:
+
+- Look for repository-local `CLAUDE.md`, `Claud.md`, `.claude/commands/`, `.claude/skills/`, or any `SKILL.md` files near the repository root.
+- Also check Claude's global folder at `/Users/yuhitomi/.claude` when project history or prior Claude Code decisions may help. Start with `/Users/yuhitomi/.claude/CLAUDE.md`, `COMMON_PATTERNS.md`, `TOOL_GOTCHAS.md`, and this project's memory index at `/Users/yuhitomi/.claude/projects/-Users-yuhitomi-Documents-Antigravity-MarkMind/memory/MEMORY.md`.
+- Use detailed files under that MarkMind `memory/` directory on demand when their titles match the task, for example `project_universal_undo.md`, `project_flowchart_edit.md`, `project_ai_company_unified.md`, or `project_versioning.md`.
+- Use global skills under `/Users/yuhitomi/.claude/skills/<skill>/SKILL.md` only when the task clearly matches that skill. Read the relevant `SKILL.md` before applying it; do not bulk-load unrelated skills.
+- Treat Claude files as complementary project guidance. Follow `AGENTS.md` for Codex-specific behavior and use Claude files for project history, workflows, known pitfalls, and task-specific conventions.
+- If instructions conflict, prefer the more specific file for the touched area. If still ambiguous, follow the newest explicit user request.
+- At the time of writing, this repository only contains `.claude/settings.local.json` with `outputStyle: default`; no Claude guide or skills are present.
+- Do not copy secrets, sessions, telemetry, cache files, or machine-local settings from `.claude/` into commits unless the user explicitly requests it.
+
+## PPTX Design Direction
+
+For slide export work, keep design deterministic instead of letting an LLM freely style slides. Use Anthropic's public `pptx` skill as a design/QA reference only; do not vendor proprietary skill code, scripts, text, or assets. Use Google `DESIGN.md` as the user-facing design-system direction: built-in `SlideTheme` defaults first, `*.theme.json` user themes next, and optional `DESIGN.md` import later. The LLM may choose slide narrative, layout enum, semantic blocks, and image intent, but renderer code must own colors, typography, spacing, coordinates, contrast, and overflow. Support user-added rules through theme rules, `DESIGN.md` prose, and per-export options, with safety/layout rules taking precedence when content would be lost or unreadable.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,302 @@
+---
+version: alpha
+name: MarkMind PPTX
+description: Editable, deterministic, multilingual slide design system for MarkMind PPTX generation.
+colors:
+  primary: "#101827"
+  secondary: "#6A7485"
+  tertiary: "#007294"
+  neutral: "#F7FAFC"
+  surface: "#FFFFFF"
+  surface-alt: "#EAF1F7"
+  on-primary: "#F8FBFF"
+  on-surface: "#283447"
+  accent-secondary: "#6EE7B7"
+  border: "#D3DCE8"
+  code-bg: "#E8EEF5"
+  code-fg: "#172033"
+typography:
+  display:
+    fontFamily: "Noto Sans Display"
+    fontSize: 56px
+    fontWeight: 700
+    lineHeight: 1.05
+    letterSpacing: 0em
+  headline-lg:
+    fontFamily: "Noto Sans Display"
+    fontSize: 36px
+    fontWeight: 700
+    lineHeight: 1.16
+    letterSpacing: 0em
+  headline-md:
+    fontFamily: "Noto Sans Display"
+    fontSize: 28px
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: 0em
+  body-lg:
+    fontFamily: "Noto Sans"
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.45
+    letterSpacing: 0em
+  body-md:
+    fontFamily: "Noto Sans"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.45
+    letterSpacing: 0em
+  body-sm:
+    fontFamily: "Noto Sans"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.4
+    letterSpacing: 0em
+  label-md:
+    fontFamily: "Noto Sans"
+    fontSize: 12px
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: 0em
+  caption:
+    fontFamily: "Noto Sans"
+    fontSize: 11px
+    fontWeight: 400
+    lineHeight: 1.25
+    letterSpacing: 0em
+  code-md:
+    fontFamily: "Noto Sans Mono"
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.35
+    letterSpacing: 0em
+  stat:
+    fontFamily: "Noto Sans Display"
+    fontSize: 64px
+    fontWeight: 800
+    lineHeight: 0.98
+    letterSpacing: 0em
+rounded:
+  none: 0px
+  sm: 4px
+  md: 8px
+  lg: 12px
+  full: 9999px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 40px
+  slide-margin: 56px
+  slide-margin-wide: 72px
+  column-gap: 32px
+  card-padding: 18px
+components:
+  slide-cover:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.display}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.xl}"
+  slide-content:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.slide-margin}"
+  slide-section:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.headline-lg}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.xl}"
+  card-column:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.card-padding}"
+  stat-callout:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.tertiary}"
+    typography: "{typography.stat}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.md}"
+  table-header:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.sm}"
+  code-block:
+    backgroundColor: "{colors.code-bg}"
+    textColor: "{colors.code-fg}"
+    typography: "{typography.code-md}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.md}"
+  image-text-zone:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.headline-md}"
+    rounded: "{rounded.none}"
+    padding: "{spacing.lg}"
+  slide-motif:
+    backgroundColor: "{colors.surface-alt}"
+    textColor: "{colors.primary}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.none}"
+    height: "{spacing.sm}"
+  comparison-rail:
+    backgroundColor: "{colors.accent-secondary}"
+    textColor: "{colors.primary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.none}"
+    width: "{spacing.xs}"
+  divider-line:
+    backgroundColor: "{colors.border}"
+    textColor: "{colors.primary}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.none}"
+    height: "{spacing.xs}"
+---
+
+# MarkMind PPTX Design System
+
+## Overview
+
+MarkMind PPTX output should feel like an intentionally designed presentation,
+not a Markdown outline pasted onto slides. It is a work-focused desktop export
+system for users who need editable, source-faithful, multilingual decks from
+Markdown.
+
+The visual identity is structured and calm: cool neutral surfaces, deep ink text,
+cyan emphasis, and visible layout containers. It should suit executive briefings,
+technical reports, research summaries, lecture decks, and decision documents.
+
+The generation model follows the research direction from PPTAgent,
+Presenton, PPT Master, AutoPresent, and DOC2PPT: use the LLM for slide planning,
+semantic structure, narration, and image intent; use deterministic renderer code
+for design tokens, geometry, contrast, overflow, and editable PowerPoint objects.
+
+## Colors
+
+The palette uses high-contrast neutrals with a single strong accent.
+
+- **Primary (#101827):** deep ink for cover slides, section slides, headlines,
+  overlays, and high-contrast text zones.
+- **Secondary (#6A7485):** quiet metadata color for section trails, captions,
+  slide numbers, and secondary labels.
+- **Tertiary (#007294):** deep cyan accent for side rails, emphasis, table headers,
+  key stats, and limited calls to attention.
+- **Neutral (#F7FAFC):** calm slide background for readable content pages.
+- **Surface (#FFFFFF):** cards, table bodies, and contained evidence blocks.
+- **Surface Alt (#EAF1F7):** subtle motif strips, low-emphasis panels, and
+  non-primary structure.
+- **Accent Secondary (#6EE7B7):** secondary rail or comparison accent, used
+  sparingly beside tertiary.
+
+Do not flood content slides with saturated accent fills. Accent color should
+clarify hierarchy and structure, not decorate.
+
+## Typography
+
+Typography must be free/open, readable, and language-aware. The token defaults
+use Noto families; renderer code may substitute per text run. If the user
+selects an installed font family in the PPTX export UI, that installed family
+takes precedence for headings and body text:
+
+- **Korean:** Pretendard.
+- **Japanese:** Noto Sans JP.
+- **Simplified Chinese:** Noto Sans SC.
+- **Traditional Chinese:** Noto Sans TC.
+- **Pan-CJK fallback:** Noto Sans CJK.
+- **Latin headings:** Noto Sans Display.
+- **Latin body:** Noto Sans.
+- **Editorial serif option:** Noto Serif Display / Noto Serif only when
+  explicitly selected and appropriate for the script.
+- **Code:** Noto Sans Mono.
+
+Use one concrete PowerPoint font name per text run. Do not ask the LLM to output
+CSS-style fallback stacks. Avoid serif display fonts for Korean titles unless
+the title is Latin-only.
+
+## Layout
+
+Slides use a 16:9 canvas with fixed, renderer-owned geometry. Use clear content
+zones and repeatable primitives:
+
+- **Cover:** large title, short subtitle, quiet motif.
+- **Section:** one strong section title and optional context line.
+- **Content:** title plus compact body in a structured block.
+- **Two-column:** two aligned cards with balanced content and thin accent rails.
+- **Comparison:** parallel cards with matching labels and balanced density.
+- **Stat:** one large number or key phrase with concise context.
+- **Quote:** one concise quotation or claim with attribution/context.
+- **Image-focus:** image plus safe text zone.
+- **Evidence/table:** compact table or data block with summary.
+- **Process/timeline:** ordered steps with consistent spacing.
+
+Minimum margin is 0.5 in; preferred slide margin is 0.65-0.9 in. Preferred gaps
+between cards or columns are 0.25-0.45 in. Every content slide needs visible
+structure beyond title plus loose bullet text.
+
+## Elevation & Depth
+
+Depth is mostly flat and structural. Prefer tonal layers, borders, rails, and
+containment over shadows. Content cards should sit on calm neutral backgrounds
+with subtle borders and clear internal padding.
+
+Heavy drop shadows, blurred glass panels, and decorative gradients are not part
+of the MarkMind PPTX identity.
+
+## Shapes
+
+Shapes are restrained and geometric.
+
+- Cards use small radii, usually 4px equivalent.
+- Slide-level frames and rails may be square.
+- The deck uses one motif at a time: side rail, corner block, frame, or subtle
+  band.
+- Motifs must clarify structure. Avoid decorative title underlines and thick
+  full-width footer bars.
+- Slide numbers are small, quiet, and outside major content zones.
+
+## Components
+
+Use components as semantic PPTX primitives, not UI widgets:
+
+- **slide-cover:** dark primary background, large display title, short subtitle.
+- **slide-content:** neutral background, deep text, quiet motif, small page
+  number.
+- **slide-section:** accent-heavy divider with one message.
+- **card-column:** white surface card, thin rail, compact body text.
+- **stat-callout:** large tertiary number or key phrase with short context.
+- **table-header:** tertiary fill with high-contrast label text.
+- **code-block:** muted code background with mono typography.
+- **image-text-zone:** primary overlay or side zone that protects readability on
+  image-focus slides.
+
+All output must remain editable PowerPoint: text boxes, shapes, tables, charts,
+and image objects. Never flatten a complete slide into one generated image.
+
+## Do's and Don'ts
+
+- Do preserve source facts. Never invent numbers, dates, citations, outcomes, or
+  claims.
+- Do let the LLM choose slide role, layout enum, semantic blocks, speaker notes,
+  source paths, and optional image intent.
+- Do let MarkMind renderer own colors, typography, coordinates, dimensions,
+  motif objects, overflow behavior, and final artifact cleanup.
+- Do honor a user-selected installed font family for PPTX headings and body text
+  when one is provided.
+- Do hide implementation artifacts: `(root)`, source IDs such as S1/S2, hidden
+  draft markers, raw JSON fields, renderer notes, and design-token names.
+- Do use stock/logo providers for real-world subjects and image generation for
+  abstract or custom concept visuals.
+- Don't shrink body text until it is unreadable. Split, summarize, or choose a
+  denser layout instead.
+- Don't use decorative underlines, thick footer bars, random gradients, or
+  slide-wide saturated accent washes behind body text.
+- Don't put draft review comments into PPTX slide content unless explicitly
+  requested.

--- a/src-tauri/src/converters/audio_pipeline.rs
+++ b/src-tauri/src/converters/audio_pipeline.rs
@@ -10,16 +10,18 @@
 use super::audio_splitter::{
     cleanup_chunks, probe_duration, probe_recording_time, split_audio_to_chunks, AudioChunk,
 };
+use super::diar::DiarSegment;
+use super::diarize_cloud::diarize_cloud;
+use super::diarize_local::{diarize_local, local_python};
 use super::error::{ConverterError, ConverterResult};
 use super::keychain::{get_key, Provider};
 use super::llm::gemini;
 use super::progress::{fmt_duration, ProgressEmitter};
-use super::templates::{build_evidence_markdown, EvidenceMeta};
-use super::diar::DiarSegment;
-use super::diarize_cloud::diarize_cloud;
-use super::diarize_local::{diarize_local, local_python};
 use super::speaker_dedup::dedup_speakers;
-use super::vad::{cleanup_trimmed, trim_silence, trimmed_to_original, SegmentMap, TrimResult, VadOptions};
+use super::templates::{build_evidence_markdown, EvidenceMeta};
+use super::vad::{
+    cleanup_trimmed, trim_silence, trimmed_to_original, SegmentMap, TrimResult, VadOptions,
+};
 use super::{conversions_dir, CostSummary, EvidenceType, UsageInfo, MODEL_AUDIO};
 use base64::Engine;
 use chrono::{FixedOffset, Utc};
@@ -88,9 +90,17 @@ pub struct AudioJobOptions {
     /// jobs. When both `batch_index` and `batch_total` are set, every
     /// progress message gets a `(i/N)` prefix so the user can tell which
     /// file of the queue is currently being processed.
-    #[serde(default, rename = "batchIndex", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "batchIndex",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub batch_index: Option<usize>,
-    #[serde(default, rename = "batchTotal", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "batchTotal",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub batch_total: Option<usize>,
 }
 
@@ -120,13 +130,15 @@ pub async fn run(
         _ => emitter,
     };
 
-    let api_key = get_key(Provider::Gemini)?
-        .ok_or(ConverterError::MissingApiKey("Gemini"))?;
+    let api_key = get_key(Provider::Gemini)?.ok_or(ConverterError::MissingApiKey("Gemini"))?;
     let file_path = Path::new(&opts.file_path).to_path_buf();
-    let file_name = opts
-        .original_name
-        .clone()
-        .unwrap_or_else(|| file_path.file_name().and_then(|s| s.to_str()).unwrap_or("").to_string());
+    let file_name = opts.original_name.clone().unwrap_or_else(|| {
+        file_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string()
+    });
     let basename = std::path::Path::new(&file_name)
         .file_stem()
         .and_then(|s| s.to_str())
@@ -217,7 +229,9 @@ pub async fn run(
             } else if local_py.is_none() {
                 emitter.emit(
                     "ℹ️ 화자 분리 비활성 — Gemini 자체 라벨로 진행",
-                    Some("로컬: MARKMIND_DIAR_PYTHON / 클라우드: Settings 의 pyannote.ai 키".into()),
+                    Some(
+                        "로컬: MARKMIND_DIAR_PYTHON / 클라우드: Settings 의 pyannote.ai 키".into(),
+                    ),
                 );
             }
         }
@@ -287,10 +301,7 @@ async fn maybe_dedup_speakers(
             outcome.text
         }
         Err(e) => {
-            emitter.emit(
-                "⚠️ 화자 라벨 검토 실패 — 원본 유지",
-                Some(e.to_string()),
-            );
+            emitter.emit("⚠️ 화자 라벨 검토 실패 — 원본 유지", Some(e.to_string()));
             transcript
         }
     }
@@ -370,7 +381,8 @@ async fn run_pipeline_core(
     emitter.emit("✅ 분할 완료", None);
 
     let mut usages: Vec<UsageInfo> = Vec::new();
-    let chunk_results = transcribe_chunks_with_seed_then_parallel(api_key, &chunks, emitter, &mut usages).await;
+    let chunk_results =
+        transcribe_chunks_with_seed_then_parallel(api_key, &chunks, emitter, &mut usages).await;
     cleanup_chunks(&chunks).await;
     let chunk_results = chunk_results?;
 
@@ -501,14 +513,8 @@ async fn run_inline_path(
     // Inline 모드는 단일 LLM 호출이라 chunk-경계 분리 오류는 없지만, LLM이
     // 같은 사람을 다른 라벨로 번갈아 부여하는 케이스는 inline 에서도 발생.
     // dedup 비용이 거의 없으니 동일하게 적용.
-    let body = maybe_dedup_speakers(
-        dedup_speakers_enabled,
-        api_key,
-        body,
-        emitter,
-        &mut usages,
-    )
-    .await;
+    let body =
+        maybe_dedup_speakers(dedup_speakers_enabled, api_key, body, emitter, &mut usages).await;
     save_audio_results(
         emitter,
         body,
@@ -620,7 +626,10 @@ fn apply_diar_labels(text: &str, diar: &[DiarSegment]) -> String {
 
             // 포함 → 허용오차 내 최근접 → 없으면 원본 라벨 유지 (안전 fallback).
             let Some(speaker_id) = find_speaker_for_time(diar, timestamp_sec) else {
-                return caps.get(0).map(|m| m.as_str().to_string()).unwrap_or_default();
+                return caps
+                    .get(0)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default();
             };
 
             let new_label = format!("화자{}", speaker_id);
@@ -636,19 +645,23 @@ fn apply_diar_labels(text: &str, diar: &[DiarSegment]) -> String {
 /// trimmed 시각 기준 [HH:MM:SS] 를 원본 시각으로 역변환.
 /// VAD trim 적용 후 Gemini 응답의 모든 timestamp 에 적용.
 fn map_timestamps_to_original(text: &str, map: &[SegmentMap]) -> String {
-    TS_REMAP_RE.replace_all(text, |caps: &regex::Captures| {
-        let a: f64 = caps[1].parse().unwrap_or(0.0);
-        let b: f64 = caps[2].parse().unwrap_or(0.0);
-        let c: f64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(-1.0);
-        let trimmed = if c >= 0.0 {
-            a * 3600.0 + b * 60.0 + c
-        } else {
-            a * 60.0 + b
-        };
-        let original = trimmed_to_original(trimmed, map);
-        format_ts(original as i64)
-    })
-    .into_owned()
+    TS_REMAP_RE
+        .replace_all(text, |caps: &regex::Captures| {
+            let a: f64 = caps[1].parse().unwrap_or(0.0);
+            let b: f64 = caps[2].parse().unwrap_or(0.0);
+            let c: f64 = caps
+                .get(3)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(-1.0);
+            let trimmed = if c >= 0.0 {
+                a * 3600.0 + b * 60.0 + c
+            } else {
+                a * 60.0 + b
+            };
+            let original = trimmed_to_original(trimmed, map);
+            format_ts(original as i64)
+        })
+        .into_owned()
 }
 
 /// Gemini inline base64 request body 안전 임계.
@@ -780,7 +793,8 @@ async fn transcribe_chunks_with_seed_then_parallel(
             });
         }
 
-        let mut wave_results: Vec<(usize, f64, super::GenerateResult)> = Vec::with_capacity(wave_size);
+        let mut wave_results: Vec<(usize, f64, super::GenerateResult)> =
+            Vec::with_capacity(wave_size);
         let mut first_err: Option<ConverterError> = None;
         while let Some(joined) = set.join_next().await {
             match joined {
@@ -840,18 +854,14 @@ fn extract_last_speaker_lines(text: &str, n: usize) -> String {
     // 1차: 표준 형식 (`**[HH:MM:SS] 화자A:**` 또는 `**[MM:SS] Speaker1:**`)
     // 2차 fallback: bold 마커 없거나 비표준 화자명 (`화자 김철수:`, `Speaker B:` 등) 도 수집.
     // doc-converter 와 동일한 컨텍스트 일관성 유지 + LLM 응답 변형에 견고.
-    let strict = Regex::new(
-        r"\*\*\[\d{1,2}:\d{2}(?::\d{2})?\]\s+[^\*\n]+?:\*\*\s*[^\n]+",
-    )
-    .expect("regex compile");
+    let strict = Regex::new(r"\*\*\[\d{1,2}:\d{2}(?::\d{2})?\]\s+[^\*\n]+?:\*\*\s*[^\n]+")
+        .expect("regex compile");
     let mut matches: Vec<&str> = strict.find_iter(text).map(|m| m.as_str()).collect();
 
     if matches.is_empty() {
         // bold 마커 없는 변형 — `[00:12] 화자A: 발언...`
-        let loose = Regex::new(
-            r"\[\d{1,2}:\d{2}(?::\d{2})?\]\s+[^\*\n:]+?:\s*[^\n]+",
-        )
-        .expect("regex compile");
+        let loose = Regex::new(r"\[\d{1,2}:\d{2}(?::\d{2})?\]\s+[^\*\n:]+?:\s*[^\n]+")
+            .expect("regex compile");
         matches = loose.find_iter(text).map(|m| m.as_str()).collect();
     }
 
@@ -872,7 +882,10 @@ fn offset_timestamps(text: &str, offset_sec: f64, clamp_ceiling_sec: Option<i64>
     re.replace_all(text, |caps: &regex::Captures| {
         let a: i64 = caps[1].parse().unwrap_or(0);
         let b: i64 = caps[2].parse().unwrap_or(0);
-        let c: i64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(-1);
+        let c: i64 = caps
+            .get(3)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(-1);
         let mut total = if c >= 0 {
             a * 3600 + b * 60 + c
         } else {
@@ -899,8 +912,15 @@ fn normalize_lead_timestamps(text: &str) -> String {
         let bold = caps.get(1).map(|m| m.as_str()).unwrap_or("");
         let a: i64 = caps[2].parse().unwrap_or(0);
         let b: i64 = caps[3].parse().unwrap_or(0);
-        let c: i64 = caps.get(4).and_then(|m| m.as_str().parse().ok()).unwrap_or(-1);
-        let total = if c >= 0 { a * 3600 + b * 60 + c } else { a * 60 + b };
+        let c: i64 = caps
+            .get(4)
+            .and_then(|m| m.as_str().parse().ok())
+            .unwrap_or(-1);
+        let total = if c >= 0 {
+            a * 3600 + b * 60 + c
+        } else {
+            a * 60 + b
+        };
         format!("{}{}", bold, format_ts(total))
     })
     .into_owned()
@@ -911,8 +931,8 @@ fn normalize_lead_timestamps(text: &str) -> String {
 /// 내부의 타임스탬프(`회의는 [10:30] 에 ...`)는 라인 선두가 아니므로 건드리지 않는다.
 /// chunk 클램프로도 못 잡는 잔여 드리프트/역행을 산출물 직전에 방어하는 최종 안전망.
 fn enforce_monotonic_timestamps(text: &str) -> String {
-    let lead = Regex::new(r"^\*\*\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]")
-        .expect("monotonic lead regex");
+    let lead =
+        Regex::new(r"^\*\*\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]").expect("monotonic lead regex");
     let mut last: i64 = 0;
     text.lines()
         .map(|line| {
@@ -921,13 +941,22 @@ fn enforce_monotonic_timestamps(text: &str) -> String {
             };
             let a: i64 = caps[1].parse().unwrap_or(0);
             let b: i64 = caps[2].parse().unwrap_or(0);
-            let c: i64 = caps.get(3).and_then(|m| m.as_str().parse().ok()).unwrap_or(-1);
-            let total = if c >= 0 { a * 3600 + b * 60 + c } else { a * 60 + b };
+            let c: i64 = caps
+                .get(3)
+                .and_then(|m| m.as_str().parse().ok())
+                .unwrap_or(-1);
+            let total = if c >= 0 {
+                a * 3600 + b * 60 + c
+            } else {
+                a * 60 + b
+            };
             let fixed = total.max(last);
             last = fixed;
             // 선두 `**[..]` 만 교체 (format_ts 는 브래킷 포함 `[HH:MM:SS]` 반환).
-            lead.replace(line, |_: &regex::Captures| format!("**{}", format_ts(fixed)))
-                .into_owned()
+            lead.replace(line, |_: &regex::Captures| {
+                format!("**{}", format_ts(fixed))
+            })
+            .into_owned()
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -1164,7 +1193,11 @@ mod tests {
         assert!(result.contains("**[00:05:30] 화자A:**"), "got: {}", result);
         assert!(result.contains("[00:07:10] 화자B:"), "got: {}", result);
         // 발화 본문 속 시각은 그대로
-        assert!(result.contains("회의는 [10:30] 에"), "inline ts rewritten: {}", result);
+        assert!(
+            result.contains("회의는 [10:30] 에"),
+            "inline ts rewritten: {}",
+            result
+        );
     }
 
     /// normalize_lead_timestamps — 이미 canonical 인 라인은 변형 없음
@@ -1178,7 +1211,8 @@ mod tests {
     /// enforce_monotonic_timestamps — 역행하는 화자 라인은 직전 값으로 끌어올림
     #[test]
     fn test_enforce_monotonic_fixes_regression() {
-        let text = "**[00:05:00] 화자A:** 첫\n**[00:02:00] 화자B:** 뒤로 튐\n**[00:07:00] 화자A:** 정상";
+        let text =
+            "**[00:05:00] 화자A:** 첫\n**[00:02:00] 화자B:** 뒤로 튐\n**[00:07:00] 화자A:** 정상";
         let result = enforce_monotonic_timestamps(text);
         // 00:02:00 < 00:05:00 → 00:05:00 으로 보정
         assert!(result.contains("**[00:05:00] 화자B:**"), "got: {}", result);
@@ -1201,8 +1235,16 @@ mod tests {
     #[test]
     fn test_find_speaker_contained() {
         let diar = vec![
-            DiarSegment { start_sec: 0.0, end_sec: 10.0, speaker_id: 1 },
-            DiarSegment { start_sec: 12.0, end_sec: 20.0, speaker_id: 2 },
+            DiarSegment {
+                start_sec: 0.0,
+                end_sec: 10.0,
+                speaker_id: 1,
+            },
+            DiarSegment {
+                start_sec: 12.0,
+                end_sec: 20.0,
+                speaker_id: 2,
+            },
         ];
         assert_eq!(find_speaker_for_time(&diar, 5.0), Some(1));
         assert_eq!(find_speaker_for_time(&diar, 15.0), Some(2));
@@ -1211,7 +1253,11 @@ mod tests {
     /// find_speaker_for_time — 허용 오차 이내 최근접 매칭 (드리프트 흡수)
     #[test]
     fn test_find_speaker_nearest_within_tolerance() {
-        let diar = vec![DiarSegment { start_sec: 10.0, end_sec: 20.0, speaker_id: 3 }];
+        let diar = vec![DiarSegment {
+            start_sec: 10.0,
+            end_sec: 20.0,
+            speaker_id: 3,
+        }];
         // 8.5s: 구간 시작(10s)까지 1.5s ≤ 2.0 → 매칭
         assert_eq!(find_speaker_for_time(&diar, 8.5), Some(3));
         // 21.5s: 구간 끝(20s)에서 1.5s ≤ 2.0 → 매칭
@@ -1221,14 +1267,22 @@ mod tests {
     /// find_speaker_for_time — 허용 오차 초과는 매칭 안 함 (원본 라벨 유지)
     #[test]
     fn test_find_speaker_beyond_tolerance_none() {
-        let diar = vec![DiarSegment { start_sec: 10.0, end_sec: 20.0, speaker_id: 3 }];
+        let diar = vec![DiarSegment {
+            start_sec: 10.0,
+            end_sec: 20.0,
+            speaker_id: 3,
+        }];
         assert_eq!(find_speaker_for_time(&diar, 5.0), None); // 5s 거리 > 2.0
     }
 
     /// apply_diar_labels — 드리프트 라인도 최근접 매칭으로 글로벌 ID 적용
     #[test]
     fn test_apply_diar_labels_nearest() {
-        let diar = vec![DiarSegment { start_sec: 10.0, end_sec: 20.0, speaker_id: 2 }];
+        let diar = vec![DiarSegment {
+            start_sec: 10.0,
+            end_sec: 20.0,
+            speaker_id: 2,
+        }];
         // Gemini 가 00:00:09 로 1초 일찍 찍음 → 포함은 아니지만 허용오차 내 → 화자2
         let text = "**[00:00:09] 화자A:** 발언";
         let out = apply_diar_labels(text, &diar);
@@ -1249,7 +1303,11 @@ mod tests {
     fn test_remove_timestamps_tier2_label_only_bold() {
         let text = "[00:00:05] **화자A**: 안녕\n[00:00:10] **화자B**: 네";
         let result = remove_timestamps(text);
-        assert!(!result.contains('['), "expected no timestamps, got: {}", result);
+        assert!(
+            !result.contains('['),
+            "expected no timestamps, got: {}",
+            result
+        );
         assert!(result.contains("**화자A**:"));
         assert!(result.contains("**화자B**:"));
     }
@@ -1259,7 +1317,11 @@ mod tests {
     fn test_remove_timestamps_tier3_no_bold() {
         let text = "[00:00:05] 화자A: 안녕\n[00:00:10] 화자B: 네";
         let result = remove_timestamps(text);
-        assert!(!result.contains('['), "expected no timestamps, got: {}", result);
+        assert!(
+            !result.contains('['),
+            "expected no timestamps, got: {}",
+            result
+        );
         assert!(result.contains("화자A: 안녕"));
         assert!(result.contains("화자B: 네"));
     }
@@ -1271,7 +1333,11 @@ mod tests {
         let result = remove_timestamps(text);
         // 헤더 [00:00:05] 는 제거되지만 발화 내부 [10:30] 은 보존
         assert!(!result.contains("[00:00:05]"));
-        assert!(result.contains("[10:30]"), "inline timestamp lost: {}", result);
+        assert!(
+            result.contains("[10:30]"),
+            "inline timestamp lost: {}",
+            result
+        );
     }
 
     /// format_ts — i64 초 → [HH:MM:SS]

--- a/src-tauri/src/converters/audio_splitter.rs
+++ b/src-tauri/src/converters/audio_splitter.rs
@@ -113,9 +113,12 @@ pub async fn probe_duration(path: &Path) -> ConverterResult<f64> {
     // (auto_download 호출 제거 — resolve_binary 가 동봉/PATH/cache fallback 후 최후에만 다운로드)
     let output = Command::new(ffprobe_path()?)
         .args([
-            "-v", "error",
-            "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
         ])
         .arg(path)
         .output()
@@ -130,9 +133,9 @@ pub async fn probe_duration(path: &Path) -> ConverterResult<f64> {
     }
     let raw = String::from_utf8_lossy(&output.stdout);
     let trimmed = raw.trim();
-    trimmed.parse::<f64>().map_err(|_| {
-        ConverterError::Ffmpeg(format!("ffprobe duration 파싱 실패: '{}'", trimmed))
-    })
+    trimmed
+        .parse::<f64>()
+        .map_err(|_| ConverterError::Ffmpeg(format!("ffprobe duration 파싱 실패: '{}'", trimmed)))
 }
 
 /// 녹음 시각 메타데이터 추출. 없으면 Ok(None).
@@ -266,10 +269,14 @@ pub async fn split_audio_to_chunks(
                     .arg(input)
                     .args([
                         "-vn",
-                        "-ac", "1",       // mono
-                        "-ar", "16000",   // 16kHz
-                        "-acodec", "libmp3lame",
-                        "-b:a", "32k",
+                        "-ac",
+                        "1", // mono
+                        "-ar",
+                        "16000", // 16kHz
+                        "-acodec",
+                        "libmp3lame",
+                        "-b:a",
+                        "32k",
                     ])
                     .arg(&chunk_path)
                     .output()
@@ -287,7 +294,9 @@ pub async fn split_audio_to_chunks(
     // 실측 길이로 누적 startSec 보정
     let mut cumulative = 0.0;
     for chunk in chunks.iter_mut() {
-        let measured = probe_duration(&chunk.chunk_path).await.unwrap_or(chunk_duration_sec);
+        let measured = probe_duration(&chunk.chunk_path)
+            .await
+            .unwrap_or(chunk_duration_sec);
         chunk.start_sec = cumulative;
         cumulative += measured;
     }

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -733,21 +733,33 @@ async fn call_slides_llm(
 
     match company {
         AICompany::Gemini => {
-            let key = get_key(Provider::Gemini)
-                .map_err(err_to_string)?
-                .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-            let model_id = model.unwrap_or(super::MODEL_NOTES_GEMINI);
-            let full = format!("{}\n\n{}", system, prompt);
-            let cfg = llm::gemini::GenerationConfig {
-                max_output_tokens: Some(max_tokens),
-                temperature: Some(0.25),
-            };
-            Ok(
-                llm::gemini::generate_text(&key, model_id, &full, Vec::new(), Some(cfg))
-                    .await
-                    .map_err(err_to_string)?
-                    .text,
-            )
+            let model_id = model.unwrap_or(match auth {
+                ClaudeAuthMode::Subscription => super::MODEL_GEMINI_AGY,
+                ClaudeAuthMode::ApiKey => super::MODEL_NOTES_GEMINI,
+            });
+            match auth {
+                ClaudeAuthMode::Subscription => {
+                    llm::gemini_agy::generate_text(model_id, Some(system), prompt).await
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let key = get_key(Provider::Gemini)
+                        .map_err(err_to_string)?
+                        .ok_or_else(|| {
+                            "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string()
+                        })?;
+                    let full = format!("{}\n\n{}", system, prompt);
+                    let cfg = llm::gemini::GenerationConfig {
+                        max_output_tokens: Some(max_tokens),
+                        temperature: Some(0.25),
+                    };
+                    Ok(
+                        llm::gemini::generate_text(&key, model_id, &full, Vec::new(), Some(cfg))
+                            .await
+                            .map_err(err_to_string)?
+                            .text,
+                    )
+                }
+            }
         }
         AICompany::Claude => {
             let model_id = model.unwrap_or(super::MODEL_NOTES_CLAUDE);
@@ -817,15 +829,29 @@ async fn call_slides_llm(
             };
             Ok(result.map_err(err_to_string)?.text)
         }
+        AICompany::Grok => {
+            let model_id = model.unwrap_or(super::MODEL_GROK);
+            let auth_id = match auth {
+                ClaudeAuthMode::Subscription => "subscription",
+                ClaudeAuthMode::ApiKey => "api_key",
+            };
+            let key = grok_bearer(auth_id)?;
+            llm::grok::generate_text(&key, model_id, Some(system), prompt).await
+        }
     }
 }
 
-fn slide_default_model(company: crate::subscription_auth::AICompany) -> &'static str {
-    use crate::subscription_auth::AICompany;
-    match company {
-        AICompany::Gemini => super::MODEL_NOTES_GEMINI,
-        AICompany::Claude => super::MODEL_NOTES_CLAUDE,
-        AICompany::Openai => super::MODEL_CODEX,
+fn slide_default_model(
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+) -> &'static str {
+    use crate::subscription_auth::{AICompany, ClaudeAuthMode};
+    match (company, auth) {
+        (AICompany::Gemini, ClaudeAuthMode::Subscription) => super::MODEL_GEMINI_AGY,
+        (AICompany::Gemini, ClaudeAuthMode::ApiKey) => super::MODEL_NOTES_GEMINI,
+        (AICompany::Claude, _) => super::MODEL_NOTES_CLAUDE,
+        (AICompany::Openai, _) => super::MODEL_CODEX,
+        (AICompany::Grok, _) => super::MODEL_GROK,
     }
 }
 
@@ -839,6 +865,7 @@ fn slide_model_info(
         AICompany::Gemini => "gemini",
         AICompany::Claude => "claude",
         AICompany::Openai => "openai",
+        AICompany::Grok => "grok",
     };
     let auth_id = match auth {
         ClaudeAuthMode::ApiKey => "api_key",
@@ -847,7 +874,7 @@ fn slide_model_info(
     let model_id = model
         .map(str::trim)
         .filter(|m| !m.is_empty())
-        .unwrap_or_else(|| slide_default_model(company));
+        .unwrap_or_else(|| slide_default_model(company, auth));
     ProgressModelInfo {
         company: company_id.to_string(),
         auth: auth_id.to_string(),

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -97,19 +97,20 @@ const SLIDES_SYSTEM: &str = concat!(
     "You are a slide manuscript agent, not a visual renderer. Convert a grounded source map or deck plan into final slide JSON. ",
     "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"master\":{...},\"slides\":[...]}. The top-level master object is optional. ",
     "Allowed layout values: \"title\", \"content\", \"section\", \"two-column\", \"image-focus\", \"quote\", \"stat\", \"comparison\", \"timeline\". ",
-    "A slide may include: title:string, layout:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,query?,entity?,role?,kind?,alt?,aspect?,style?,sourcePreference?,licenseStrictness?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
+    "A slide may include: title:string, layout:string, importance:number(0-100), importanceReason:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,query?,entity?,role?,kind?,alt?,aspect?,style?,sourcePreference?,licenseStrictness?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
     "Never output more than 32 slides. Use the slide count target as a soft target inside that hard limit. ",
     "Optional master may include only deck-wide chrome policies for slideNumber, footer, or date, using enabled, includeOn(title/content/section), position(bottom-left/bottom-center/bottom-right), style(minimal/muted/accent/inverse), and short footer/date text. ",
     "Follow the deck plan when provided; otherwise plan internally from the source map. Do not flatten the document into a list. Each slide must express one clear message and cite its source through source.headingLevel and source.sectionPath. ",
     "Use slide titles rewritten for presentation impact when useful, but keep them faithful to the source. ",
     "Use \"section\" for major dividers, \"two-column\"/\"comparison\" for parallel ideas, \"stat\" for one important number, \"quote\" for a strong cited sentence, and \"image-focus\" only when an image asset would materially help. ",
-    "For image needs, output image intent only; do not embed URLs or base64. Prefer query/entity for stock or logo retrieval, prompt for generated fallback, role among cover/hero/support/logo/icon/background, aspect such as 16:9 or 4:3, sourcePreference among auto/stock/logo/generated/none, and licenseStrictness among presentation/open/internal-only. ",
+    "For each slide, assign importance based on deck role: cover, conclusion, executive recommendation, core claim, and key evidence should be high; ordinary supporting details should be lower. ",
+    "For image needs, output image intent only; do not embed URLs or base64. Use query/entity for stock or logo retrieval. Use prompt for generated images, and make it a real image-generation prompt, not a search query: describe subject, composition, mood, style, and constraints. role must be among cover/hero/support/logo/icon/background, aspect such as 16:9 or 4:3, sourcePreference among auto/stock/logo/generated/none, and licenseStrictness among presentation/open/internal-only. ",
     "When the image policy asks to actively add visuals, do not reserve images only for cover or section slides. Also add ambient or supporting visual intent to spacious body slides, sparse quote/stat slides, and concept slides where an image would improve atmosphere or comprehension. ",
     "For slides with multiple local topics, use blocks with explicit {kind:\"subhead\"} group labels followed by their related bullet/text blocks; never run separate subtopics together as one bullet list. Prefer splitting slides with more than three subhead groups. ",
     "Layout capacity rules: title slides need title plus at most two short support lines; content slides need at most seven short bullets; two-column/comparison slides need two balanced columns; stat slides need exactly one headline number; quote slides need one concise quotation; tables and code require short summaries when they would dominate the page. ",
     "Before finalizing each slide, perform a fit check: if text would overflow a slot, rewrite shorter or split into another slide instead of relying on tiny fonts. ",
     "Speaker notes are optional; include them only when useful, at most 1-2 natural sentences. ",
-    "Honor design options for layout direction, image policy, visual density, font preference, and margin preference. Use them to choose layout values and control how much text each slide carries. ",
+    "Honor design options for layout direction, image policy, image source mode, visual density, font preference, and margin preference. Use them to choose layout values and control how much text each slide carries. ",
     "Keep bullets short, avoid copying full source paragraphs, preserve the document language unless the user requests a target language, and never invent facts. ",
     "Do not output colors, coordinates, font sizes, font names, PptxGenJS options, OpenXML, placeholders, or raw CSS."
 );
@@ -146,6 +147,7 @@ pub struct SlideGenerationOptions {
     design_layout: Option<String>,
     visual_density: Option<String>,
     image_policy: Option<String>,
+    image_source_mode: Option<String>,
     font_preference: Option<String>,
     font_family: Option<String>,
     margin_preference: Option<String>,
@@ -575,6 +577,7 @@ fn slide_options_prompt(options: Option<&SlideGenerationOptions>) -> String {
     push_option_line(&mut lines, "Layout direction", &options.design_layout);
     push_option_line(&mut lines, "Visual density", &options.visual_density);
     push_option_line(&mut lines, "Image policy", &options.image_policy);
+    push_option_line(&mut lines, "Image source mode", &options.image_source_mode);
     push_option_line(&mut lines, "Font preference", &options.font_preference);
     push_option_line(&mut lines, "Installed font family", &options.font_family);
     push_option_line(&mut lines, "Margin preference", &options.margin_preference);

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -79,6 +79,9 @@ const SLIDES_PLAN_MAX_TOKENS: u32 = 12000;
 const SLIDES_TWO_PASS_SECTION_THRESHOLD: usize = 28;
 const SLIDES_TWO_PASS_SLIDE_THRESHOLD: usize = 24;
 const SLIDE_MARKDOWN_DRAFT_MAX_TOKENS: u32 = 30000;
+const SOURCE_MAP_BUDGET: usize = 18000;
+const SOURCE_MAP_MAX_SECTIONS: usize = 90;
+const SOURCE_MAP_CHUNK_CHARS: usize = 1100;
 
 const SLIDES_PLAN_SYSTEM: &str = concat!(
     "You are a deck planning agent. Build a grounded presentation plan from a Markdown source map. ",
@@ -97,14 +100,14 @@ const SLIDES_SYSTEM: &str = concat!(
     "You are a slide manuscript agent, not a visual renderer. Convert a grounded source map or deck plan into final slide JSON. ",
     "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"master\":{...},\"slides\":[...]}. The top-level master object is optional. ",
     "Allowed layout values: \"title\", \"content\", \"section\", \"two-column\", \"image-focus\", \"quote\", \"stat\", \"comparison\", \"timeline\". ",
-    "A slide may include: title:string, layout:string, importance:number(0-100), importanceReason:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,query?,entity?,role?,kind?,alt?,aspect?,style?,sourcePreference?,licenseStrictness?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
+    "A slide may include: title:string, layout:string, importance:number(0-100), importanceReason:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{src?,prompt?,query?,entity?,role?,kind?,alt?,aspect?,style?,sourcePreference?,licenseStrictness?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
     "Never output more than 32 slides. Use the slide count target as a soft target inside that hard limit. ",
     "Optional master may include only deck-wide chrome policies for slideNumber, footer, or date, using enabled, includeOn(title/content/section), position(bottom-left/bottom-center/bottom-right), style(minimal/muted/accent/inverse), and short footer/date text. ",
     "Follow the deck plan when provided; otherwise plan internally from the source map. Do not flatten the document into a list. Each slide must express one clear message and cite its source through source.headingLevel and source.sectionPath. ",
     "Use slide titles rewritten for presentation impact when useful, but keep them faithful to the source. ",
     "Use \"section\" for major dividers, \"two-column\"/\"comparison\" for parallel ideas, \"stat\" for one important number, \"quote\" for a strong cited sentence, and \"image-focus\" only when an image asset would materially help. ",
     "For each slide, assign importance based on deck role: cover, conclusion, executive recommendation, core claim, and key evidence should be high; ordinary supporting details should be lower. ",
-    "For image needs, output image intent only; do not embed URLs or base64. Use query/entity for stock or logo retrieval. Use prompt for generated images, and make it a real image-generation prompt, not a search query: describe subject, composition, mood, style, and constraints. role must be among cover/hero/support/logo/icon/background, aspect such as 16:9 or 4:3, sourcePreference among auto/stock/logo/generated/none, and licenseStrictness among presentation/open/internal-only. ",
+    "For image needs, output image intent only; do not embed new external URLs or base64. If a source section includes an existing Markdown image path, you may copy that exact path into image.src to preserve a source image, especially when image policy is source images only. Otherwise use query/entity for stock or logo retrieval. Use prompt for generated images, and make it a real image-generation prompt, not a search query: describe subject, composition, mood, style, and constraints. role must be among cover/hero/support/logo/icon/background, aspect such as 16:9 or 4:3, sourcePreference among auto/stock/logo/generated/none, and licenseStrictness among presentation/open/internal-only. ",
     "When the image policy asks to actively add visuals, do not reserve images only for cover or section slides. Also add ambient or supporting visual intent to spacious body slides, sparse quote/stat slides, and concept slides where an image would improve atmosphere or comprehension. ",
     "For slides with multiple local topics, use blocks with explicit {kind:\"subhead\"} group labels followed by their related bullet/text blocks; never run separate subtopics together as one bullet list. Prefer splitting slides with more than three subhead groups. ",
     "Layout capacity rules: title slides need title plus at most two short support lines; content slides need at most seven short bullets; two-column/comparison slides need two balanced columns; stat slides need exactly one headline number; quote slides need one concise quotation; tables and code require short summaries when they would dominate the page. ",
@@ -435,6 +438,18 @@ fn source_signals(content: &str) -> String {
     }
 }
 
+fn source_excerpt_chunks(content: &str, max_chars: usize) -> Vec<String> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let chars = trimmed.chars().collect::<Vec<_>>();
+    chars
+        .chunks(max_chars)
+        .map(|chunk| chunk.iter().collect::<String>())
+        .collect()
+}
+
 fn source_map_prompt(sections: &[MarkdownSourceSection]) -> String {
     if sections.is_empty() {
         return String::new();
@@ -443,8 +458,8 @@ fn source_map_prompt(sections: &[MarkdownSourceSection]) -> String {
         "<source_sections>".to_string(),
         "Use these source IDs for planning and final slides. Every non-cover slide should cite one or more source IDs in the plan.".to_string(),
     ];
-    let mut budget = 18000usize;
-    for section in sections.iter().take(90) {
+    let mut budget = SOURCE_MAP_BUDGET;
+    for section in sections.iter().take(SOURCE_MAP_MAX_SECTIONS) {
         if budget == 0 {
             break;
         }
@@ -452,33 +467,43 @@ fn source_map_prompt(sections: &[MarkdownSourceSection]) -> String {
         if excerpt.is_empty() {
             excerpt = section.title.clone();
         }
-        excerpt = short_text(&excerpt, 1100);
+        let chunks = source_excerpt_chunks(&excerpt, SOURCE_MAP_CHUNK_CHARS);
+        let chunk_count = chunks.len().max(1);
         let path = if section.section_path.is_empty() {
             "(root)".to_string()
         } else {
             section.section_path.join(" / ")
         };
-        let entry = format!(
-            "\n[{}]\nheading: H{} {}\npath: {}\nlines: {}-{}\nsignals: {}\nexcerpt:\n{}\n",
-            section.id,
-            section.level,
-            section.title,
-            path,
-            section.line_start,
-            section.line_end,
-            source_signals(&section.content),
-            excerpt
-        );
-        if entry.len() > budget {
-            break;
+        for (chunk_index, chunk) in chunks.into_iter().enumerate() {
+            let excerpt_label = if chunk_count > 1 {
+                format!("excerpt part {}/{}", chunk_index + 1, chunk_count)
+            } else {
+                "excerpt".to_string()
+            };
+            let entry = format!(
+                "\n[{}]\nheading: H{} {}\npath: {}\nlines: {}-{}\nsignals: {}\n{}:\n{}\n",
+                section.id,
+                section.level,
+                section.title,
+                path,
+                section.line_start,
+                section.line_end,
+                source_signals(&section.content),
+                excerpt_label,
+                chunk
+            );
+            if entry.len() > budget {
+                budget = 0;
+                break;
+            }
+            budget -= entry.len();
+            out.push(entry);
         }
-        budget -= entry.len();
-        out.push(entry);
     }
-    if sections.len() > 90 {
+    if sections.len() > SOURCE_MAP_MAX_SECTIONS {
         out.push(format!(
             "\n... {} additional source sections omitted",
-            sections.len() - 90
+            sections.len() - SOURCE_MAP_MAX_SECTIONS
         ));
     }
     out.push("</source_sections>".to_string());
@@ -1339,6 +1364,19 @@ mod tests {
         assert!(prompt.contains("path: Report"));
         assert!(prompt.contains("signals: table,image,quote,stat"));
         assert!(prompt.contains("73%"));
+    }
+
+    #[test]
+    fn source_map_prompt_chunks_long_sections_instead_of_dropping_tail() {
+        let md = format!(
+            "# Long Section\n{}\nTAIL_EVIDENCE_SHOULD_REMAIN",
+            "중요한 배경 설명 ".repeat(180)
+        );
+        let sections = markdown_source_sections(&md);
+        let prompt = source_map_prompt(&sections);
+
+        assert!(prompt.contains("excerpt part 2/"));
+        assert!(prompt.contains("TAIL_EVIDENCE_SHOULD_REMAIN"));
     }
 
     #[test]

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -510,6 +510,14 @@ fn source_map_prompt(sections: &[MarkdownSourceSection]) -> String {
     out.join("\n")
 }
 
+fn slide_generation_source_context(markdown: &str) -> (String, Vec<MarkdownSourceSection>, String) {
+    let markdown_body = strip_slide_draft_marker(markdown);
+    let outline_block = markdown_outline_prompt(&markdown_body);
+    let source_sections = markdown_source_sections(&markdown_body);
+    let source_map = source_map_prompt(&source_sections);
+    (outline_block, source_sections, source_map)
+}
+
 fn markdown_outline_prompt(markdown: &str) -> String {
     let mut outline = Vec::new();
     let mut in_frontmatter = false;
@@ -960,9 +968,7 @@ pub async fn generate_slides_llm(
 ) -> Result<String, String> {
     let emitter = new_emitter(app, job_id);
     let opt_block = slide_options_prompt(options.as_ref());
-    let outline_block = markdown_outline_prompt(&markdown);
-    let source_sections = markdown_source_sections(&markdown);
-    let source_map = source_map_prompt(&source_sections);
+    let (outline_block, source_sections, source_map) = slide_generation_source_context(&markdown);
     emitter.emit(
         "✅ 문서 구조 분석 완료",
         Some(format!("소스 섹션 {}개", source_sections.len())),
@@ -1449,6 +1455,17 @@ mod tests {
         let escaped = "&lt;!-- markmind:slide-draft v1 --&gt;\n# Slide";
         assert!(has_slide_draft_marker(escaped));
         assert_eq!(strip_slide_draft_marker(escaped), "# Slide");
+    }
+
+    #[test]
+    fn slide_generation_source_context_strips_draft_marker() {
+        let md = "<!-- markmind:slide-draft v2 -->\n# Actual Slide\nBody";
+        let (outline, sections, source_map) = slide_generation_source_context(md);
+
+        assert!(!outline.contains("markmind:slide-draft"));
+        assert!(!source_map.contains("markmind:slide-draft"));
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].title, "Actual Slide");
     }
 
     /// Codex P2 follow-up: ensure `extract_speakers` returns labels from a

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -70,11 +70,14 @@ pub fn get_conversions_dir() -> String {
 // 마크다운을 슬라이드용으로 "재구성"해 과밀 슬라이드를 막는다(규칙 기반의 약점
 // 보완). 기존 converters 의 키체인 + LLM 클라이언트를 그대로 재사용한다.
 // 반환은 프론트가 파싱하는 슬라이드 JSON 문자열:
-//   { "slides": [ { "title", "layout", "bullets"/"blocks"/"columns", "notes"? } ] }
+//   { "master"?: { deck-wide chrome }, "slides": [ { "title", "layout", "bullets"/"blocks"/"columns", "notes"? } ] }
 
-// 출력 토큰 상한 — 큰 덱(50장+)도 잘리지 않도록 넉넉히. 생성한 만큼만 과금.
-const SLIDES_MAX_TOKENS: u32 = 32000;
+// 최종 슬라이드 JSON 출력 상한. 장수 추정으로 흔들지 않고 단순 고정값을 쓴다.
+const SLIDES_MAX_TOKENS: u32 = 16000;
+const SLIDES_MAX_COUNT: usize = 32;
 const SLIDES_PLAN_MAX_TOKENS: u32 = 12000;
+const SLIDES_TWO_PASS_SECTION_THRESHOLD: usize = 28;
+const SLIDES_TWO_PASS_SLIDE_THRESHOLD: usize = 24;
 const SLIDE_MARKDOWN_DRAFT_MAX_TOKENS: u32 = 30000;
 
 const SLIDES_PLAN_SYSTEM: &str = concat!(
@@ -87,23 +90,28 @@ const SLIDES_PLAN_SYSTEM: &str = concat!(
     "Treat layouts as schemas, not decoration: choose the layout whose rhetorical shape fits the message. ",
     "Use title/opening, section, and ending roles deliberately; avoid a chain of generic title-plus-bullets slides. ",
     "Plan for native editable PowerPoint output: keep each slide to about six visible content elements, leave whitespace, and keep text near 60 percent of the available visual capacity. ",
-    "Use the requested slide count as a target, not a reason to pad weak slides. Never invent facts."
+    "Use the requested slide count as a target, not a reason to pad weak slides. Never output more than 32 slides. Never invent facts."
 );
 
 const SLIDES_SYSTEM: &str = concat!(
-    "You are a slide manuscript agent, not a visual renderer. Convert a grounded deck plan into final slide JSON. ",
-    "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[...]}. ",
+    "You are a slide manuscript agent, not a visual renderer. Convert a grounded source map or deck plan into final slide JSON. ",
+    "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"master\":{...},\"slides\":[...]}. The top-level master object is optional. ",
     "Allowed layout values: \"title\", \"content\", \"section\", \"two-column\", \"image-focus\", \"quote\", \"stat\", \"comparison\", \"timeline\". ",
-    "A slide may include: title:string, layout:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,kind?,alt?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
-    "Follow the deck plan. Do not flatten the document into a list. Each slide must express one clear message and cite its source through source.headingLevel and source.sectionPath. ",
+    "A slide may include: title:string, layout:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,query?,entity?,role?,kind?,alt?,aspect?,style?,sourcePreference?,licenseStrictness?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
+    "Never output more than 32 slides. Use the slide count target as a soft target inside that hard limit. ",
+    "Optional master may include only deck-wide chrome policies for slideNumber, footer, or date, using enabled, includeOn(title/content/section), position(bottom-left/bottom-center/bottom-right), style(minimal/muted/accent/inverse), and short footer/date text. ",
+    "Follow the deck plan when provided; otherwise plan internally from the source map. Do not flatten the document into a list. Each slide must express one clear message and cite its source through source.headingLevel and source.sectionPath. ",
     "Use slide titles rewritten for presentation impact when useful, but keep them faithful to the source. ",
-    "Use \"section\" for major dividers, \"two-column\"/\"comparison\" for parallel ideas, \"stat\" for one important number, \"quote\" for a strong cited sentence, and \"image-focus\" only when an image prompt would materially help. ",
+    "Use \"section\" for major dividers, \"two-column\"/\"comparison\" for parallel ideas, \"stat\" for one important number, \"quote\" for a strong cited sentence, and \"image-focus\" only when an image asset would materially help. ",
+    "For image needs, output image intent only; do not embed URLs or base64. Prefer query/entity for stock or logo retrieval, prompt for generated fallback, role among cover/hero/support/logo/icon/background, aspect such as 16:9 or 4:3, sourcePreference among auto/stock/logo/generated/none, and licenseStrictness among presentation/open/internal-only. ",
+    "When the image policy asks to actively add visuals, do not reserve images only for cover or section slides. Also add ambient or supporting visual intent to spacious body slides, sparse quote/stat slides, and concept slides where an image would improve atmosphere or comprehension. ",
+    "For slides with multiple local topics, use blocks with explicit {kind:\"subhead\"} group labels followed by their related bullet/text blocks; never run separate subtopics together as one bullet list. Prefer splitting slides with more than three subhead groups. ",
     "Layout capacity rules: title slides need title plus at most two short support lines; content slides need at most seven short bullets; two-column/comparison slides need two balanced columns; stat slides need exactly one headline number; quote slides need one concise quotation; tables and code require short summaries when they would dominate the page. ",
     "Before finalizing each slide, perform a fit check: if text would overflow a slot, rewrite shorter or split into another slide instead of relying on tiny fonts. ",
-    "Speaker notes must be natural narration, 2-5 sentences, explaining transitions and context without merely reading slide text aloud. ",
+    "Speaker notes are optional; include them only when useful, at most 1-2 natural sentences. ",
     "Honor design options for layout direction, image policy, visual density, font preference, and margin preference. Use them to choose layout values and control how much text each slide carries. ",
     "Keep bullets short, avoid copying full source paragraphs, preserve the document language unless the user requests a target language, and never invent facts. ",
-    "Do not output colors, coordinates, font sizes, PptxGenJS options, or raw CSS."
+    "Do not output colors, coordinates, font sizes, font names, PptxGenJS options, OpenXML, placeholders, or raw CSS."
 );
 
 const SLIDE_MARKDOWN_DRAFT_SYSTEM: &str = concat!(
@@ -165,6 +173,47 @@ fn short_text(value: &str, max_chars: usize) -> String {
         out.push(ch);
     }
     out
+}
+
+fn first_usize(value: &str) -> Option<usize> {
+    let mut buf = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_digit() {
+            buf.push(ch);
+        } else if !buf.is_empty() {
+            break;
+        }
+    }
+    buf.parse().ok()
+}
+
+fn slide_count_hint_label(value: &Option<String>) -> Option<String> {
+    let raw = value.as_deref().map(str::trim).filter(|v| !v.is_empty())?;
+    let Some(requested) = first_usize(raw) else {
+        return Some(raw.to_string());
+    };
+    let capped = requested.min(SLIDES_MAX_COUNT);
+    if requested > SLIDES_MAX_COUNT {
+        Some(format!(
+            "{} slides requested, capped at hard limit {}",
+            requested, SLIDES_MAX_COUNT
+        ))
+    } else {
+        Some(format!("{} slides target", capped))
+    }
+}
+
+fn should_use_two_pass_slide_generation(
+    options: Option<&SlideGenerationOptions>,
+    source_section_count: usize,
+) -> bool {
+    let slide_count_hint = options
+        .and_then(|o| o.slide_count_hint.as_deref())
+        .and_then(first_usize)
+        .map(|n| n.min(SLIDES_MAX_COUNT))
+        .unwrap_or(0);
+    source_section_count >= SLIDES_TWO_PASS_SECTION_THRESHOLD
+        || slide_count_hint >= SLIDES_TWO_PASS_SLIDE_THRESHOLD
 }
 
 #[derive(Debug, Clone)]
@@ -507,7 +556,13 @@ fn slide_options_prompt(options: Option<&SlideGenerationOptions>) -> String {
     push_option_line(&mut lines, "Audience", &options.audience);
     push_option_line(&mut lines, "Tone", &options.tone);
     push_option_line(&mut lines, "Target language", &options.language);
-    push_option_line(&mut lines, "Slide count hint", &options.slide_count_hint);
+    if let Some(slide_count) = slide_count_hint_label(&options.slide_count_hint) {
+        lines.push(format!("- Slide count target: {}", slide_count));
+    }
+    lines.push(format!(
+        "- Hard slide limit: output no more than {} slides",
+        SLIDES_MAX_COUNT
+    ));
     push_option_line(&mut lines, "Draft purpose", &options.draft_purpose);
     push_option_line(&mut lines, "Draft structure", &options.draft_structure);
     push_option_line(&mut lines, "Draft detail level", &options.draft_depth);
@@ -712,6 +767,7 @@ async fn call_slides_llm(
                         model_id,
                         Some(system),
                         prompt,
+                        Some(max_tokens),
                     )
                     .await
                 }
@@ -721,7 +777,14 @@ async fn call_slides_llm(
                         .ok_or_else(|| {
                             "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string()
                         })?;
-                    llm::openai_api::generate_text(&key, model_id, Some(system), prompt).await
+                    llm::openai_api::generate_text(
+                        &key,
+                        model_id,
+                        Some(system),
+                        prompt,
+                        Some(max_tokens),
+                    )
+                    .await
                 }
             };
             Ok(result.map_err(err_to_string)?.text)
@@ -774,6 +837,7 @@ async fn call_slides_llm_with_progress(
     model: Option<&str>,
     system: &str,
     prompt: &str,
+    detail: Option<String>,
     max_tokens: u32,
 ) -> Result<String, String> {
     use std::sync::{
@@ -783,7 +847,13 @@ async fn call_slides_llm_with_progress(
     use std::time::{Duration, Instant};
 
     let model_info = Some(slide_model_info(company, auth, model));
-    emitter.emit_update_with_model(step_id, waiting_step, None, None, model_info.clone());
+    emitter.emit_update_with_model(
+        step_id,
+        waiting_step,
+        detail.clone(),
+        None,
+        model_info.clone(),
+    );
 
     let started = Instant::now();
     let stop = Arc::new(AtomicBool::new(false));
@@ -792,6 +862,7 @@ async fn call_slides_llm_with_progress(
     let heartbeat_step_id = step_id.to_string();
     let heartbeat_step = waiting_step.to_string();
     let heartbeat_model = model_info.clone();
+    let heartbeat_detail = detail.clone();
     let heartbeat = tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -802,7 +873,7 @@ async fn call_slides_llm_with_progress(
             heartbeat_emitter.emit_update_with_model(
                 heartbeat_step_id.clone(),
                 format!("{heartbeat_step} {elapsed}초"),
-                None,
+                heartbeat_detail.clone(),
                 None,
                 heartbeat_model.clone(),
             );
@@ -814,7 +885,7 @@ async fn call_slides_llm_with_progress(
     heartbeat.abort();
 
     if result.is_ok() {
-        emitter.emit_update_with_model(step_id, done_step, None, Some(1.0), model_info);
+        emitter.emit_update_with_model(step_id, done_step, detail, Some(1.0), model_info);
     }
     result
 }
@@ -841,41 +912,51 @@ pub async fn generate_slides_llm(
         "✅ 문서 구조 분석 완료",
         Some(format!("소스 섹션 {}개", source_sections.len())),
     );
-    let plan_prompt = format!(
-        "Plan a slide deck from this Markdown-derived source map. Respect export options, source hierarchy, and source IDs.\n\n{}\n\n{}\n\n{}",
-        opt_block,
-        outline_block,
-        source_map
-    );
-    emitter.emit(
-        "✅ 슬라이드 계획 요청 완료",
-        Some(format!("소스 섹션 {}개", source_sections.len())),
-    );
-    let plan_raw = call_slides_llm_with_progress(
-        &emitter,
-        "pptx-plan-llm",
-        "⏳ AI가 슬라이드 구조를 계획하는 중…",
-        "✅ 슬라이드 구조 계획 완료",
-        company,
-        auth,
-        model.as_deref(),
-        SLIDES_PLAN_SYSTEM,
-        &plan_prompt,
-        SLIDES_PLAN_MAX_TOKENS,
-    )
-    .await?;
-    let deck_plan = extract_json_object(&plan_raw);
+    let use_two_pass =
+        should_use_two_pass_slide_generation(options.as_ref(), source_sections.len());
 
-    let draft_prompt = format!(
-        "Generate final slides JSON from the approved deck plan. Use only grounded source content. If the plan has an unsupported or weak slide, repair it locally instead of rewriting the whole deck.\n\n{}\n\n<deck_plan>\n{}\n</deck_plan>\n\n{}",
-        opt_block,
-        deck_plan,
-        source_map
-    );
-    emitter.emit("✅ 최종 슬라이드 JSON 요청 준비 완료", None);
+    let draft_prompt = if use_two_pass {
+        let plan_prompt = format!(
+            "Plan a slide deck from this Markdown-derived source map. Respect export options, source hierarchy, and source IDs.\n\n{}\n\n{}\n\n{}",
+            opt_block,
+            outline_block,
+            source_map
+        );
+        emitter.emit("✅ 슬라이드 계획 요청 완료", None);
+        let plan_raw = call_slides_llm_with_progress(
+            &emitter,
+            "pptx-plan-llm",
+            "⏳ AI가 슬라이드 구조를 계획하는 중…",
+            "✅ 슬라이드 구조 계획 완료",
+            company,
+            auth,
+            model.as_deref(),
+            SLIDES_PLAN_SYSTEM,
+            &plan_prompt,
+            None,
+            SLIDES_PLAN_MAX_TOKENS,
+        )
+        .await?;
+        let deck_plan = extract_json_object(&plan_raw);
+        emitter.emit("✅ 슬라이드 구조 계획 응답 수신", None);
 
-    // 큰 덱(50장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
-    // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
+        format!(
+            "Generate final slides JSON from the approved deck plan. Use only grounded source content. If the plan has an unsupported or weak slide, repair it locally instead of rewriting the whole deck.\n\n{}\n\n<deck_plan>\n{}\n</deck_plan>\n\n{}",
+            opt_block,
+            deck_plan,
+            source_map
+        )
+    } else {
+        format!(
+            "Generate final slides JSON directly from this Markdown-derived source map. Plan internally, but output only the final JSON. Respect export options, source hierarchy, and source IDs.\n\n{}\n\n{}\n\n{}",
+            opt_block,
+            outline_block,
+            source_map
+        )
+    };
+    emitter.emit("✅ 슬라이드 JSON 요청 준비 완료", None);
+
+    // 슬라이드 JSON이 잘리면 프론트 파싱 실패로 이어지므로 상한은 단순 고정값을 쓴다.
     let slides_raw = call_slides_llm_with_progress(
         &emitter,
         "pptx-slides-llm",
@@ -886,13 +967,15 @@ pub async fn generate_slides_llm(
         model.as_deref(),
         SLIDES_SYSTEM,
         &draft_prompt,
+        None,
         SLIDES_MAX_TOKENS,
     )
     .await?;
 
+    let cleaned = extract_json_object(&slides_raw);
     emitter.emit("✅ 슬라이드 JSON 정리 완료", None);
     emitter.emit("✅ AI 슬라이드 생성 완료", None);
-    Ok(extract_json_object(&slides_raw))
+    Ok(cleaned)
 }
 
 #[tauri::command]
@@ -920,13 +1003,13 @@ pub async fn generate_slide_markdown_draft(
 
     let prompt = if is_existing_draft {
         format!(
-            "Revise an existing MarkMind Markdown slide draft. The hidden `markmind:slide-draft` marker was detected, so this is a revision pass, not a new draft pass.\n\nPrimary source for this run:\n- Treat `<existing_slide_draft>` as the current deck manuscript.\n- Apply Draft revision mode and Extra instructions before considering broad regeneration.\n- Preserve useful user edits already present in the draft.\n\nRequired output contract:\n- Markdown only.\n- Return the full revised deck, not a patch and not a summary.\n- Preserve the existing slide separator convention: separate slides with a line containing only `---`.\n- Preserve slide order, slide count, headings, images, tables, code fences, and comments unless Draft revision mode, slide count hint, or Extra instructions clearly asks to change them.\n- Apply the user's detailed instruction strongly, especially emphasis, rewrite, tone, expansion, trimming, reordering, or comment requests.\n- If Draft revision mode says to preserve structure, make localized edits instead of rewriting the whole deck.\n- If Draft revision mode says to restructure, improve flow while keeping source facts and existing useful slide material.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n<existing_slide_draft>\n{}\n</existing_slide_draft>",
+            "Revise an existing MarkMind Markdown slide draft. The hidden `markmind:slide-draft` marker was detected, so this is a revision pass, not a new draft pass.\n\nPrimary source for this run:\n- Treat `<existing_slide_draft>` as the current deck manuscript.\n- Apply Draft revision mode and Extra instructions before considering broad regeneration.\n- Preserve useful user edits already present in the draft.\n\nRequired output contract:\n- Markdown only.\n- Return the full revised deck, not a patch and not a summary.\n- Preserve the existing slide separator convention: separate slides with a line containing only `---`.\n- Preserve slide order, slide count, headings, images, tables, code fences, and comments unless Draft revision mode, slide count hint, or Extra instructions clearly asks to change them.\n- Apply the user's detailed instruction strongly, especially emphasis, rewrite, tone, expansion, trimming, reordering, or comment requests.\n- If Draft revision mode says to preserve structure, make localized edits instead of rewriting the whole deck.\n- If Draft revision mode says to restructure, improve flow while keeping source facts and existing useful slide material.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- When a slide has multiple local topics, use Markdown subheadings (`###`) for each topic and separate groups with blank lines: subheading, related bullets/text, blank line, next subheading. Do not put different subtopics in one continuous bullet list.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n<existing_slide_draft>\n{}\n</existing_slide_draft>",
             opt_block,
             markdown_body
         )
     } else {
         format!(
-            "Create a Markdown slide draft for MarkMind slideshow review mode. The user will review and edit this Markdown before exporting to PPTX.\n\nRequired output contract:\n- Markdown only.\n- Separate slides with a line containing only `---`.\n- Use standard Markdown blocks supported by the editor: headings, short paragraphs, bullet lists, tables, blockquotes, code fences, and images already present in the source.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Treat source IDs like S1, S2, and S3 as internal grounding IDs only. Do not print them and do not add visible `출처: S2` / `Source: S2` lines.\n- Convert the source into slide pages with a presentation narrative. Avoid one slide per source heading unless that is genuinely the best structure.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n{}\n\n{}",
+            "Create a Markdown slide draft for MarkMind slideshow review mode. The user will review and edit this Markdown before exporting to PPTX.\n\nRequired output contract:\n- Markdown only.\n- Separate slides with a line containing only `---`.\n- Use standard Markdown blocks supported by the editor: headings, short paragraphs, bullet lists, tables, blockquotes, code fences, and images already present in the source.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Treat source IDs like S1, S2, and S3 as internal grounding IDs only. Do not print them and do not add visible `출처: S2` / `Source: S2` lines.\n- Convert the source into slide pages with a presentation narrative. Avoid one slide per source heading unless that is genuinely the best structure.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- When a slide has multiple local topics, use Markdown subheadings (`###`) for each topic and separate groups with blank lines: subheading, related bullets/text, blank line, next subheading. Do not put different subtopics in one continuous bullet list.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n{}\n\n{}",
             opt_block,
             outline_block,
             source_map
@@ -959,6 +1042,7 @@ pub async fn generate_slide_markdown_draft(
         model.as_deref(),
         SLIDE_MARKDOWN_DRAFT_SYSTEM,
         &prompt,
+        None,
         SLIDE_MARKDOWN_DRAFT_MAX_TOKENS,
     )
     .await?;
@@ -1035,6 +1119,7 @@ pub async fn ai_generate_codex(
         model_id,
         system.as_deref(),
         &prompt,
+        None,
     )
     .await
     .map(|r| r.text)
@@ -1069,7 +1154,7 @@ pub async fn ai_generate_openai(
     let key = get_key(Provider::Openai)
         .map_err(err_to_string)?
         .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    openai_api::generate_text(&key, &model, system.as_deref(), &prompt)
+    openai_api::generate_text(&key, &model, system.as_deref(), &prompt, None)
         .await
         .map(|r| r.text)
         .map_err(err_to_string)

--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -6,7 +6,8 @@ use super::audio_pipeline::{self, AudioJobOptions, AudioJobResult};
 use super::error::ConverterError;
 use super::notes_pipeline::{self, NotesJobOptions, NotesJobResult};
 use super::ocr_pipeline::{self, OcrJobOptions, OcrJobResult};
-use super::progress::ProgressEmitter;
+use super::progress::{ProgressEmitter, ProgressModelInfo};
+use serde::Deserialize;
 use tauri::AppHandle;
 
 /// Frontend 가 jobId 전달하면 그걸 사용 — listener 필터링으로 다른 윈도우의 동시
@@ -68,67 +69,616 @@ pub fn get_conversions_dir() -> String {
 //
 // 마크다운을 슬라이드용으로 "재구성"해 과밀 슬라이드를 막는다(규칙 기반의 약점
 // 보완). 기존 converters 의 키체인 + LLM 클라이언트를 그대로 재사용한다.
-// 반환은 프론트가 파싱하는 단순 슬라이드 JSON 문자열:
-//   { "slides": [ { "title", "layout":"title|content", "bullets":[...], "notes"? } ] }
+// 반환은 프론트가 파싱하는 슬라이드 JSON 문자열:
+//   { "slides": [ { "title", "layout", "bullets"/"blocks"/"columns", "notes"? } ] }
 
 // 출력 토큰 상한 — 큰 덱(50장+)도 잘리지 않도록 넉넉히. 생성한 만큼만 과금.
 const SLIDES_MAX_TOKENS: u32 = 32000;
+const SLIDES_PLAN_MAX_TOKENS: u32 = 12000;
+const SLIDE_MARKDOWN_DRAFT_MAX_TOKENS: u32 = 30000;
 
-const SLIDES_SYSTEM: &str = "You are a presentation designer. Convert the given Markdown document into a concise slide deck. Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[{\"title\":string,\"layout\":\"title\"|\"content\",\"bullets\":string[],\"notes\":string?}]}. Rules: the first slide is layout \"title\" (deck title + optional one-line subtitle as a single bullet); other slides are \"content\"; keep each bullet short (<= ~12 words); at most ~6 bullets per slide; split dense content across multiple slides to avoid overcrowding; omit the \"notes\" field unless it adds real speaker value (keeps output compact); preserve the document's language; do not invent facts.";
+const SLIDES_PLAN_SYSTEM: &str = concat!(
+    "You are a deck planning agent. Build a grounded presentation plan from a Markdown source map. ",
+    "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[...]}. ",
+    "Each planned slide must include id, role, message, sourceIds, layoutHint, layoutRationale, fitNotes, speakerIntent, and sectionPath. ",
+    "Do not write final slide bullets yet. Do not copy the document outline one-to-one. ",
+    "Create a narrative that may reorder sections when it improves audience understanding, but every planned claim must be grounded in sourceIds. ",
+    "Prefer one message per slide, merge weak adjacent sections, split dense sections, and include section divider slides only when they improve flow. ",
+    "Treat layouts as schemas, not decoration: choose the layout whose rhetorical shape fits the message. ",
+    "Use title/opening, section, and ending roles deliberately; avoid a chain of generic title-plus-bullets slides. ",
+    "Plan for native editable PowerPoint output: keep each slide to about six visible content elements, leave whitespace, and keep text near 60 percent of the available visual capacity. ",
+    "Use the requested slide count as a target, not a reason to pad weak slides. Never invent facts."
+);
 
-//
-// 모든 AI 작업은 전역 회사(company)→인증(auth)→모델(model) 선택(aiModelConfig)을
-// 따른다 — 슬라이드 생성도 회의록 파이프라인과 동일하게 3사·구독/API 키를 지원한다.
-#[tauri::command]
-pub async fn generate_slides_llm(
-    markdown: String,
+const SLIDES_SYSTEM: &str = concat!(
+    "You are a slide manuscript agent, not a visual renderer. Convert a grounded deck plan into final slide JSON. ",
+    "Output STRICT minified JSON only (no prose, no code fences, no markdown) of the form: {\"slides\":[...]}. ",
+    "Allowed layout values: \"title\", \"content\", \"section\", \"two-column\", \"image-focus\", \"quote\", \"stat\", \"comparison\", \"timeline\". ",
+    "A slide may include: title:string, layout:string, sourceIds:string[], bullets:string[], blocks:[{kind:\"text\"|\"bullet\"|\"subhead\",text:string,level?:number}], columns:[[string|{kind,text,level?}]], quote:{text,attribution?}, stat:{value,label?,context?}, image:{prompt?,kind?,alt?}, source:{headingLevel?:number,sectionPath?:string[]}, notes:string. ",
+    "Follow the deck plan. Do not flatten the document into a list. Each slide must express one clear message and cite its source through source.headingLevel and source.sectionPath. ",
+    "Use slide titles rewritten for presentation impact when useful, but keep them faithful to the source. ",
+    "Use \"section\" for major dividers, \"two-column\"/\"comparison\" for parallel ideas, \"stat\" for one important number, \"quote\" for a strong cited sentence, and \"image-focus\" only when an image prompt would materially help. ",
+    "Layout capacity rules: title slides need title plus at most two short support lines; content slides need at most seven short bullets; two-column/comparison slides need two balanced columns; stat slides need exactly one headline number; quote slides need one concise quotation; tables and code require short summaries when they would dominate the page. ",
+    "Before finalizing each slide, perform a fit check: if text would overflow a slot, rewrite shorter or split into another slide instead of relying on tiny fonts. ",
+    "Speaker notes must be natural narration, 2-5 sentences, explaining transitions and context without merely reading slide text aloud. ",
+    "Honor design options for layout direction, image policy, visual density, font preference, and margin preference. Use them to choose layout values and control how much text each slide carries. ",
+    "Keep bullets short, avoid copying full source paragraphs, preserve the document language unless the user requests a target language, and never invent facts. ",
+    "Do not output colors, coordinates, font sizes, PptxGenJS options, or raw CSS."
+);
+
+const SLIDE_MARKDOWN_DRAFT_SYSTEM: &str = concat!(
+    "You are a slide manuscript agent for a Markdown-first editor. ",
+    "Create a reviewable slide draft, not a PowerPoint file and not JSON. ",
+    "Output Markdown only, with no surrounding prose and no code fence around the whole answer. ",
+    "Use a horizontal rule line `---` between slides because the app uses it as a slide separator. ",
+    "Start each slide with a Markdown heading. Use heading depth to express source hierarchy where useful. ",
+    "Each slide should have one clear message, not a copied outline dump. ",
+    "Split dense source sections, merge weak adjacent sections, and reorder only when it improves the narrative. ",
+    "Use presentation-agent style planning: opening, section, content, evidence, comparison, key-stat, quote, and closing slides should each have a clear functional role. ",
+    "Use template-schema discipline even in Markdown: keep titles short, bullets compact, tables small, and two-column ideas balanced. ",
+    "Use native PowerPoint slot-fit discipline: if a slide would need tiny text or crowded elements, split it rather than forcing everything onto one page. ",
+    "Preserve source facts exactly. Never invent numbers, claims, citations, dates, or outcomes. ",
+    "Source IDs such as S1, S2, and S3 are internal grounding markers only. Never print them as visible source or citation text in the Markdown draft. ",
+    "Follow the draft comments option: when comments are enabled, add frequent visible blockquotes beginning with `> 코멘트:`, `> 검토 필요:`, or `> 추가 정보 필요:` for gaps, assumptions, open questions, and editorial choices; when comments are disabled, do not add reviewer comments and instead omit unsupported claims. ",
+    "Do not include colors, coordinates, font sizes, PptxGenJS options, CSS, or visual design directions."
+);
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SlideGenerationOptions {
+    audience: Option<String>,
+    tone: Option<String>,
+    language: Option<String>,
+    slide_count_hint: Option<String>,
+    draft_purpose: Option<String>,
+    draft_structure: Option<String>,
+    draft_depth: Option<String>,
+    draft_revision_mode: Option<String>,
+    draft_review_mode: Option<String>,
+    design_layout: Option<String>,
+    visual_density: Option<String>,
+    image_policy: Option<String>,
+    font_preference: Option<String>,
+    font_family: Option<String>,
+    margin_preference: Option<String>,
+    extra_instructions: Option<String>,
+    design_rules: Option<String>,
+    theme_name: Option<String>,
+    #[serde(default)]
+    theme_rules: Vec<String>,
+}
+
+fn push_option_line(lines: &mut Vec<String>, label: &str, value: &Option<String>) {
+    if let Some(v) = value.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        lines.push(format!("- {}: {}", label, v));
+    }
+}
+
+fn short_text(value: &str, max_chars: usize) -> String {
+    let trimmed = value.trim();
+    let mut out = String::new();
+    for (idx, ch) in trimmed.chars().enumerate() {
+        if idx >= max_chars {
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[derive(Debug, Clone)]
+struct MarkdownSourceSection {
+    id: String,
+    level: usize,
+    title: String,
+    section_path: Vec<String>,
+    line_start: usize,
+    line_end: usize,
+    content: String,
+}
+
+fn push_section(
+    sections: &mut Vec<MarkdownSourceSection>,
+    id_num: usize,
+    level: usize,
+    title: String,
+    section_path: Vec<String>,
+    line_start: usize,
+    line_end: usize,
+    content: Vec<String>,
+) {
+    let content = content.join("\n").trim().to_string();
+    if title.trim().is_empty() && content.is_empty() {
+        return;
+    }
+    sections.push(MarkdownSourceSection {
+        id: format!("S{}", id_num),
+        level,
+        title: title.trim().to_string(),
+        section_path,
+        line_start,
+        line_end,
+        content,
+    });
+}
+
+fn markdown_heading_level(line: &str) -> Option<(usize, String)> {
+    let left = line.trim_start();
+    let level = left.chars().take_while(|ch| *ch == '#').count();
+    if level == 0 || level > 6 || left.as_bytes().get(level) != Some(&b' ') {
+        return None;
+    }
+    let title = left[level..].trim();
+    if title.is_empty() {
+        return None;
+    }
+    Some((level, title.to_string()))
+}
+
+fn markdown_source_sections(markdown: &str) -> Vec<MarkdownSourceSection> {
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut sections = Vec::new();
+    let mut heading_stack: Vec<String> = Vec::new();
+    let mut in_frontmatter = false;
+    let mut in_fence = false;
+    let mut fence_marker = "";
+    let mut prelude: Vec<String> = Vec::new();
+    let mut current: Option<(usize, String, Vec<String>, usize, Vec<String>)> = None;
+    let mut next_id = 1;
+
+    for (idx, line) in lines.iter().enumerate() {
+        let line_no = idx + 1;
+        let trimmed = line.trim();
+        if idx == 0 && trimmed == "---" {
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter {
+            if trimmed == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+
+        let left = line.trim_start();
+        let fence = if left.starts_with("```") {
+            Some("```")
+        } else if left.starts_with("~~~") {
+            Some("~~~")
+        } else {
+            None
+        };
+        if let Some(marker) = fence {
+            if !in_fence {
+                in_fence = true;
+                fence_marker = marker;
+            } else if left.starts_with(fence_marker) {
+                in_fence = false;
+            }
+            if let Some((_, _, _, _, content)) = current.as_mut() {
+                content.push((*line).to_string());
+            } else {
+                prelude.push((*line).to_string());
+            }
+            continue;
+        }
+
+        if !in_fence {
+            if let Some((level, title)) = markdown_heading_level(line) {
+                if let Some((cur_level, cur_title, cur_path, cur_start, cur_content)) =
+                    current.take()
+                {
+                    push_section(
+                        &mut sections,
+                        next_id,
+                        cur_level,
+                        cur_title,
+                        cur_path,
+                        cur_start,
+                        line_no.saturating_sub(1),
+                        cur_content,
+                    );
+                    next_id += 1;
+                } else if !prelude.iter().all(|l| l.trim().is_empty()) {
+                    push_section(
+                        &mut sections,
+                        next_id,
+                        1,
+                        "Document opening".to_string(),
+                        Vec::new(),
+                        1,
+                        line_no.saturating_sub(1),
+                        std::mem::take(&mut prelude),
+                    );
+                    next_id += 1;
+                }
+
+                let section_path = heading_stack
+                    .iter()
+                    .take(level.saturating_sub(1))
+                    .filter(|s| !s.trim().is_empty())
+                    .cloned()
+                    .collect::<Vec<_>>();
+                if heading_stack.len() < level {
+                    heading_stack.resize(level, String::new());
+                }
+                heading_stack[level - 1] = title.clone();
+                heading_stack.truncate(level);
+                current = Some((level, title, section_path, line_no, Vec::new()));
+                continue;
+            }
+        }
+
+        if let Some((_, _, _, _, content)) = current.as_mut() {
+            content.push((*line).to_string());
+        } else {
+            prelude.push((*line).to_string());
+        }
+    }
+
+    if let Some((cur_level, cur_title, cur_path, cur_start, cur_content)) = current.take() {
+        push_section(
+            &mut sections,
+            next_id,
+            cur_level,
+            cur_title,
+            cur_path,
+            cur_start,
+            lines.len().max(cur_start),
+            cur_content,
+        );
+    } else if !prelude.iter().all(|l| l.trim().is_empty()) {
+        push_section(
+            &mut sections,
+            next_id,
+            1,
+            "Document".to_string(),
+            Vec::new(),
+            1,
+            lines.len().max(1),
+            prelude,
+        );
+    }
+
+    sections
+}
+
+fn source_signals(content: &str) -> String {
+    let has_table = content
+        .lines()
+        .any(|line| line.trim_start().starts_with('|'));
+    let image_count = content.matches("![").count();
+    let has_quote = content
+        .lines()
+        .any(|line| line.trim_start().starts_with('>'));
+    let has_code = content.contains("```") || content.contains("~~~");
+    let has_stat = content.split_whitespace().any(|word| {
+        word.chars().any(|c| c.is_ascii_digit())
+            && (word.contains('%')
+                || word.contains('$')
+                || word.contains('x')
+                || word.contains('X'))
+    });
+
+    let mut signals = Vec::new();
+    if has_table {
+        signals.push("table");
+    }
+    if image_count > 0 {
+        signals.push("image");
+    }
+    if has_quote {
+        signals.push("quote");
+    }
+    if has_code {
+        signals.push("code");
+    }
+    if has_stat {
+        signals.push("stat");
+    }
+    if signals.is_empty() {
+        "text".to_string()
+    } else {
+        signals.join(",")
+    }
+}
+
+fn source_map_prompt(sections: &[MarkdownSourceSection]) -> String {
+    if sections.is_empty() {
+        return String::new();
+    }
+    let mut out = vec![
+        "<source_sections>".to_string(),
+        "Use these source IDs for planning and final slides. Every non-cover slide should cite one or more source IDs in the plan.".to_string(),
+    ];
+    let mut budget = 18000usize;
+    for section in sections.iter().take(90) {
+        if budget == 0 {
+            break;
+        }
+        let mut excerpt = section.content.trim().to_string();
+        if excerpt.is_empty() {
+            excerpt = section.title.clone();
+        }
+        excerpt = short_text(&excerpt, 1100);
+        let path = if section.section_path.is_empty() {
+            "(root)".to_string()
+        } else {
+            section.section_path.join(" / ")
+        };
+        let entry = format!(
+            "\n[{}]\nheading: H{} {}\npath: {}\nlines: {}-{}\nsignals: {}\nexcerpt:\n{}\n",
+            section.id,
+            section.level,
+            section.title,
+            path,
+            section.line_start,
+            section.line_end,
+            source_signals(&section.content),
+            excerpt
+        );
+        if entry.len() > budget {
+            break;
+        }
+        budget -= entry.len();
+        out.push(entry);
+    }
+    if sections.len() > 90 {
+        out.push(format!(
+            "\n... {} additional source sections omitted",
+            sections.len() - 90
+        ));
+    }
+    out.push("</source_sections>".to_string());
+    out.join("\n")
+}
+
+fn markdown_outline_prompt(markdown: &str) -> String {
+    let mut outline = Vec::new();
+    let mut in_frontmatter = false;
+    let mut in_fence = false;
+    let mut fence_marker = "";
+
+    for (line_idx, line) in markdown.lines().enumerate() {
+        let trimmed = line.trim();
+        if line_idx == 0 && trimmed == "---" {
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter {
+            if trimmed == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+
+        let left = line.trim_start();
+        if left.starts_with("```") || left.starts_with("~~~") {
+            let marker = if left.starts_with("```") {
+                "```"
+            } else {
+                "~~~"
+            };
+            if !in_fence {
+                in_fence = true;
+                fence_marker = marker;
+            } else if left.starts_with(fence_marker) {
+                in_fence = false;
+            }
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        let level = left.chars().take_while(|ch| *ch == '#').count();
+        if level == 0 || level > 6 || left.as_bytes().get(level) != Some(&b' ') {
+            continue;
+        }
+        let text = short_text(&left[level..], 120);
+        if !text.is_empty() {
+            outline.push(format!("- H{} line {}: {}", level, line_idx + 1, text));
+        }
+    }
+
+    if outline.is_empty() {
+        return String::new();
+    }
+
+    let mut out = vec![
+        "<markdown_outline>".to_string(),
+        "Use this heading hierarchy as the source structure. Preserve it through source.headingLevel and source.sectionPath when planning slides.".to_string(),
+    ];
+    let total = outline.len();
+    out.extend(outline.into_iter().take(120));
+    if total > 120 {
+        out.push(format!("- ... {} additional headings omitted", total - 120));
+    }
+    out.push("</markdown_outline>".to_string());
+    out.join("\n")
+}
+
+fn slide_options_prompt(options: Option<&SlideGenerationOptions>) -> String {
+    let Some(options) = options else {
+        return String::new();
+    };
+    let mut lines = vec!["<export_options>".to_string()];
+    push_option_line(&mut lines, "Audience", &options.audience);
+    push_option_line(&mut lines, "Tone", &options.tone);
+    push_option_line(&mut lines, "Target language", &options.language);
+    push_option_line(&mut lines, "Slide count hint", &options.slide_count_hint);
+    push_option_line(&mut lines, "Draft purpose", &options.draft_purpose);
+    push_option_line(&mut lines, "Draft structure", &options.draft_structure);
+    push_option_line(&mut lines, "Draft detail level", &options.draft_depth);
+    push_option_line(
+        &mut lines,
+        "Draft revision mode",
+        &options.draft_revision_mode,
+    );
+    push_option_line(&mut lines, "Draft comments", &options.draft_review_mode);
+    push_option_line(&mut lines, "Layout direction", &options.design_layout);
+    push_option_line(&mut lines, "Visual density", &options.visual_density);
+    push_option_line(&mut lines, "Image policy", &options.image_policy);
+    push_option_line(&mut lines, "Font preference", &options.font_preference);
+    push_option_line(&mut lines, "Installed font family", &options.font_family);
+    push_option_line(&mut lines, "Margin preference", &options.margin_preference);
+    push_option_line(
+        &mut lines,
+        "Extra instructions",
+        &options.extra_instructions,
+    );
+    if let Some(theme) = options
+        .theme_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        lines.push(format!("- Selected theme: {}", theme));
+    }
+    if !options.theme_rules.is_empty() {
+        lines.push("- Theme rules:".to_string());
+        for rule in &options.theme_rules {
+            let rule = rule.trim();
+            if !rule.is_empty() {
+                lines.push(format!("  - {}", rule));
+            }
+        }
+    }
+    push_option_line(&mut lines, "Additional design rules", &options.design_rules);
+    lines.push("</export_options>".to_string());
+    lines.join("\n")
+}
+
+fn extract_json_object(raw: &str) -> String {
+    let Some(start) = raw.find('{') else {
+        return raw.trim().to_string();
+    };
+    let Some(end) = raw.rfind('}') else {
+        return raw.trim().to_string();
+    };
+    if end <= start {
+        return raw.trim().to_string();
+    }
+    raw[start..=end].trim().to_string()
+}
+
+fn strip_outer_markdown_fence(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let first = trimmed.lines().next().unwrap_or("").trim_start();
+    let marker = if first.starts_with("```") {
+        "```"
+    } else if first.starts_with("~~~") {
+        "~~~"
+    } else {
+        return trimmed.to_string();
+    };
+    let mut lines: Vec<&str> = trimmed.lines().collect();
+    if lines.len() >= 2
+        && lines
+            .last()
+            .map(|line| line.trim_start().starts_with(marker))
+            .unwrap_or(false)
+    {
+        lines.remove(0);
+        lines.pop();
+        return lines.join("\n").trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+fn strip_internal_source_labels(raw: &str) -> String {
+    static SOURCE_LINE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    static SOURCE_INLINE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let source_line_re = SOURCE_LINE_RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?i)^\s*(?:>\s*)?(?:[-*+]\s*)?(?:\*\*)?(?:출처|source|sources|source ids?)(?:\*\*)?\s*:\s*(?:\*\*)?\[?\(?\s*S\d+(?:\s*(?:[,;/&+]|\band\b|및)\s*S\d+|\s+S\d+)*\s*\)?\]?\s*\.?\s*$",
+        )
+        .expect("source line regex")
+    });
+    let source_inline_re = SOURCE_INLINE_RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?i)\s*\((?:출처|source|sources|source ids?)\s*:\s*S\d+(?:\s*(?:[,;/&+]|\band\b|및)\s*S\d+|\s+S\d+)*\s*\)",
+        )
+        .expect("source inline regex")
+    });
+
+    raw.lines()
+        .filter(|line| !source_line_re.is_match(line))
+        .map(|line| {
+            source_inline_re
+                .replace_all(line, "")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn has_slide_draft_marker(markdown: &str) -> bool {
+    markdown.lines().any(|line| {
+        let t = line.trim();
+        (t.starts_with("<!--") || t.starts_with("&lt;!--")) && t.contains("markmind:slide-draft")
+    })
+}
+
+fn strip_slide_draft_marker(markdown: &str) -> String {
+    markdown
+        .lines()
+        .filter(|line| {
+            let t = line.trim();
+            !((t.starts_with("<!--") || t.starts_with("&lt;!--"))
+                && t.contains("markmind:slide-draft"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+async fn call_slides_llm(
     company: crate::subscription_auth::AICompany,
     auth: crate::subscription_auth::ClaudeAuthMode,
-    model: Option<String>,
+    model: Option<&str>,
+    system: &str,
+    prompt: &str,
+    max_tokens: u32,
 ) -> Result<String, String> {
     use super::keychain::{get_key, Provider};
     use super::llm;
     use crate::subscription_auth::{AICompany, ClaudeAuthMode};
 
-    let prompt = format!(
-        "Convert this Markdown document into slides as specified.\n\n<markdown>\n{}\n</markdown>",
-        markdown
-    );
-
-    // 큰 덱(50장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
-    // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
-    let text = match company {
+    match company {
         AICompany::Gemini => {
-            // Gemini 는 구독 미지원 → 항상 API 키. system 파라미터가 없어 프롬프트 앞에 결합.
             let key = get_key(Provider::Gemini)
                 .map_err(err_to_string)?
                 .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-            let model_id = model.as_deref().unwrap_or(super::MODEL_NOTES_GEMINI);
-            let full = format!("{}\n\n{}", SLIDES_SYSTEM, prompt);
+            let model_id = model.unwrap_or(super::MODEL_NOTES_GEMINI);
+            let full = format!("{}\n\n{}", system, prompt);
             let cfg = llm::gemini::GenerationConfig {
-                max_output_tokens: Some(SLIDES_MAX_TOKENS),
-                temperature: Some(0.3),
+                max_output_tokens: Some(max_tokens),
+                temperature: Some(0.25),
             };
-            llm::gemini::generate_text(&key, model_id, &full, Vec::new(), Some(cfg))
-                .await
-                .map_err(err_to_string)?
-                .text
+            Ok(
+                llm::gemini::generate_text(&key, model_id, &full, Vec::new(), Some(cfg))
+                    .await
+                    .map_err(err_to_string)?
+                    .text,
+            )
         }
         AICompany::Claude => {
-            let model_id = model
-                .clone()
-                .unwrap_or_else(|| super::MODEL_NOTES_CLAUDE.to_string());
+            let model_id = model.unwrap_or(super::MODEL_NOTES_CLAUDE);
             let opts = llm::anthropic::ClaudeOptions {
-                max_output_tokens: Some(SLIDES_MAX_TOKENS),
-                system: Some(SLIDES_SYSTEM.to_string()),
+                max_output_tokens: Some(max_tokens),
+                system: Some(system.to_string()),
             };
             let result = match auth {
                 ClaudeAuthMode::Subscription => {
                     let token = crate::subscription_auth::claude_access_token().await?;
                     llm::anthropic::generate_text(
                         llm::anthropic::ClaudeAuth::Subscription(&token),
-                        &model_id,
-                        &prompt,
+                        model_id,
+                        prompt,
                         Some(opts),
                     )
                     .await
@@ -142,41 +692,281 @@ pub async fn generate_slides_llm(
                         })?;
                     llm::anthropic::generate_text(
                         llm::anthropic::ClaudeAuth::ApiKey(&key),
-                        &model_id,
-                        &prompt,
+                        model_id,
+                        prompt,
                         Some(opts),
                     )
                     .await
                 }
             };
-            result.map_err(err_to_string)?.text
+            Ok(result.map_err(err_to_string)?.text)
         }
         AICompany::Openai => {
-            let model_id = model.clone().unwrap_or_else(|| super::MODEL_CODEX.to_string());
+            let model_id = model.unwrap_or(super::MODEL_CODEX);
             let result = match auth {
                 ClaudeAuthMode::Subscription => {
                     let tokens = crate::subscription_auth::read_codex_tokens()?;
                     llm::openai_codex::generate_text(
                         &tokens.access_token,
                         tokens.account_id.as_deref(),
-                        &model_id,
-                        Some(SLIDES_SYSTEM),
-                        &prompt,
+                        model_id,
+                        Some(system),
+                        prompt,
                     )
                     .await
                 }
                 ClaudeAuthMode::ApiKey => {
                     let key = get_key(Provider::Openai)
                         .map_err(err_to_string)?
-                        .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-                    llm::openai_api::generate_text(&key, &model_id, Some(SLIDES_SYSTEM), &prompt).await
+                        .ok_or_else(|| {
+                            "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string()
+                        })?;
+                    llm::openai_api::generate_text(&key, model_id, Some(system), prompt).await
                 }
             };
-            result.map_err(err_to_string)?.text
+            Ok(result.map_err(err_to_string)?.text)
         }
-    };
+    }
+}
 
-    Ok(text)
+fn slide_default_model(company: crate::subscription_auth::AICompany) -> &'static str {
+    use crate::subscription_auth::AICompany;
+    match company {
+        AICompany::Gemini => super::MODEL_NOTES_GEMINI,
+        AICompany::Claude => super::MODEL_NOTES_CLAUDE,
+        AICompany::Openai => super::MODEL_CODEX,
+    }
+}
+
+fn slide_model_info(
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+    model: Option<&str>,
+) -> ProgressModelInfo {
+    use crate::subscription_auth::{AICompany, ClaudeAuthMode};
+    let company_id = match company {
+        AICompany::Gemini => "gemini",
+        AICompany::Claude => "claude",
+        AICompany::Openai => "openai",
+    };
+    let auth_id = match auth {
+        ClaudeAuthMode::ApiKey => "api_key",
+        ClaudeAuthMode::Subscription => "subscription",
+    };
+    let model_id = model
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| slide_default_model(company));
+    ProgressModelInfo {
+        company: company_id.to_string(),
+        auth: auth_id.to_string(),
+        model: model_id.to_string(),
+    }
+}
+
+async fn call_slides_llm_with_progress(
+    emitter: &ProgressEmitter,
+    step_id: &str,
+    waiting_step: &str,
+    done_step: &str,
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+    model: Option<&str>,
+    system: &str,
+    prompt: &str,
+    max_tokens: u32,
+) -> Result<String, String> {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::time::{Duration, Instant};
+
+    let model_info = Some(slide_model_info(company, auth, model));
+    emitter.emit_update_with_model(step_id, waiting_step, None, None, model_info.clone());
+
+    let started = Instant::now();
+    let stop = Arc::new(AtomicBool::new(false));
+    let heartbeat_stop = stop.clone();
+    let heartbeat_emitter = emitter.clone();
+    let heartbeat_step_id = step_id.to_string();
+    let heartbeat_step = waiting_step.to_string();
+    let heartbeat_model = model_info.clone();
+    let heartbeat = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            if heartbeat_stop.load(Ordering::Relaxed) {
+                break;
+            }
+            let elapsed = started.elapsed().as_secs();
+            heartbeat_emitter.emit_update_with_model(
+                heartbeat_step_id.clone(),
+                format!("{heartbeat_step} {elapsed}초"),
+                None,
+                None,
+                heartbeat_model.clone(),
+            );
+        }
+    });
+
+    let result = call_slides_llm(company, auth, model, system, prompt, max_tokens).await;
+    stop.store(true, Ordering::Relaxed);
+    heartbeat.abort();
+
+    if result.is_ok() {
+        emitter.emit_update_with_model(step_id, done_step, None, Some(1.0), model_info);
+    }
+    result
+}
+
+//
+// 모든 AI 작업은 전역 회사(company)→인증(auth)→모델(model) 선택(aiModelConfig)을
+// 따른다 — 슬라이드 생성도 회의록 파이프라인과 동일하게 3사·구독/API 키를 지원한다.
+#[tauri::command]
+pub async fn generate_slides_llm(
+    app: AppHandle,
+    markdown: String,
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+    model: Option<String>,
+    options: Option<SlideGenerationOptions>,
+    job_id: Option<String>,
+) -> Result<String, String> {
+    let emitter = new_emitter(app, job_id);
+    let opt_block = slide_options_prompt(options.as_ref());
+    let outline_block = markdown_outline_prompt(&markdown);
+    let source_sections = markdown_source_sections(&markdown);
+    let source_map = source_map_prompt(&source_sections);
+    emitter.emit(
+        "✅ 문서 구조 분석 완료",
+        Some(format!("소스 섹션 {}개", source_sections.len())),
+    );
+    let plan_prompt = format!(
+        "Plan a slide deck from this Markdown-derived source map. Respect export options, source hierarchy, and source IDs.\n\n{}\n\n{}\n\n{}",
+        opt_block,
+        outline_block,
+        source_map
+    );
+    emitter.emit(
+        "✅ 슬라이드 계획 요청 완료",
+        Some(format!("소스 섹션 {}개", source_sections.len())),
+    );
+    let plan_raw = call_slides_llm_with_progress(
+        &emitter,
+        "pptx-plan-llm",
+        "⏳ AI가 슬라이드 구조를 계획하는 중…",
+        "✅ 슬라이드 구조 계획 완료",
+        company,
+        auth,
+        model.as_deref(),
+        SLIDES_PLAN_SYSTEM,
+        &plan_prompt,
+        SLIDES_PLAN_MAX_TOKENS,
+    )
+    .await?;
+    let deck_plan = extract_json_object(&plan_raw);
+
+    let draft_prompt = format!(
+        "Generate final slides JSON from the approved deck plan. Use only grounded source content. If the plan has an unsupported or weak slide, repair it locally instead of rewriting the whole deck.\n\n{}\n\n<deck_plan>\n{}\n</deck_plan>\n\n{}",
+        opt_block,
+        deck_plan,
+        source_map
+    );
+    emitter.emit("✅ 최종 슬라이드 JSON 요청 준비 완료", None);
+
+    // 큰 덱(50장+)의 슬라이드 JSON 이 잘리면 프론트 파싱 실패 → 폴백.
+    // 출력 토큰은 생성한 만큼만 과금되므로 상한은 넉넉히(미사용 시 비용 0).
+    let slides_raw = call_slides_llm_with_progress(
+        &emitter,
+        "pptx-slides-llm",
+        "⏳ AI가 최종 슬라이드를 작성하는 중…",
+        "✅ 최종 슬라이드 작성 완료",
+        company,
+        auth,
+        model.as_deref(),
+        SLIDES_SYSTEM,
+        &draft_prompt,
+        SLIDES_MAX_TOKENS,
+    )
+    .await?;
+
+    emitter.emit("✅ 슬라이드 JSON 정리 완료", None);
+    emitter.emit("✅ AI 슬라이드 생성 완료", None);
+    Ok(extract_json_object(&slides_raw))
+}
+
+#[tauri::command]
+pub async fn generate_slide_markdown_draft(
+    app: AppHandle,
+    markdown: String,
+    company: crate::subscription_auth::AICompany,
+    auth: crate::subscription_auth::ClaudeAuthMode,
+    model: Option<String>,
+    options: Option<SlideGenerationOptions>,
+    job_id: Option<String>,
+) -> Result<String, String> {
+    let emitter = new_emitter(app, job_id);
+    let is_existing_draft = has_slide_draft_marker(&markdown);
+    let markdown_body = strip_slide_draft_marker(&markdown);
+    let opt_block = slide_options_prompt(options.as_ref());
+    let outline_block = markdown_outline_prompt(&markdown_body);
+    let source_sections = markdown_source_sections(&markdown_body);
+    let source_map = source_map_prompt(&source_sections);
+
+    emitter.emit(
+        "✅ 문서 구조 분석 완료",
+        Some(format!("소스 섹션 {}개", source_sections.len())),
+    );
+
+    let prompt = if is_existing_draft {
+        format!(
+            "Revise an existing MarkMind Markdown slide draft. The hidden `markmind:slide-draft` marker was detected, so this is a revision pass, not a new draft pass.\n\nPrimary source for this run:\n- Treat `<existing_slide_draft>` as the current deck manuscript.\n- Apply Draft revision mode and Extra instructions before considering broad regeneration.\n- Preserve useful user edits already present in the draft.\n\nRequired output contract:\n- Markdown only.\n- Return the full revised deck, not a patch and not a summary.\n- Preserve the existing slide separator convention: separate slides with a line containing only `---`.\n- Preserve slide order, slide count, headings, images, tables, code fences, and comments unless Draft revision mode, slide count hint, or Extra instructions clearly asks to change them.\n- Apply the user's detailed instruction strongly, especially emphasis, rewrite, tone, expansion, trimming, reordering, or comment requests.\n- If Draft revision mode says to preserve structure, make localized edits instead of rewriting the whole deck.\n- If Draft revision mode says to restructure, improve flow while keeping source facts and existing useful slide material.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n<existing_slide_draft>\n{}\n</existing_slide_draft>",
+            opt_block,
+            markdown_body
+        )
+    } else {
+        format!(
+            "Create a Markdown slide draft for MarkMind slideshow review mode. The user will review and edit this Markdown before exporting to PPTX.\n\nRequired output contract:\n- Markdown only.\n- Separate slides with a line containing only `---`.\n- Use standard Markdown blocks supported by the editor: headings, short paragraphs, bullet lists, tables, blockquotes, code fences, and images already present in the source.\n- Do not output slide JSON, speaker layout JSON, design tokens, implementation notes, or the hidden `markmind:slide-draft` marker.\n- Treat source IDs like S1, S2, and S3 as internal grounding IDs only. Do not print them and do not add visible `출처: S2` / `Source: S2` lines.\n- Convert the source into slide pages with a presentation narrative. Avoid one slide per source heading unless that is genuinely the best structure.\n- Keep each slide focused on one message. Prefer short bullets over copied paragraphs.\n- Follow the Draft comments option. If comments are enabled, proactively add useful `> 코멘트:` / `> 검토 필요:` / `> 추가 정보 필요:` blockquotes for questions, assumptions, missing evidence, and suggested refinements. If comments are disabled, keep the draft clean and omit unsupported details instead of adding comments.\n\n{}\n\n{}\n\n{}",
+            opt_block,
+            outline_block,
+            source_map
+        )
+    };
+    emitter.emit(
+        if is_existing_draft {
+            "✅ 슬라이드 초안 수정 요청 준비 완료"
+        } else {
+            "✅ 슬라이드 초안 작성 요청 준비 완료"
+        },
+        Some(format!("소스 섹션 {}개", source_sections.len())),
+    );
+
+    let draft_raw = call_slides_llm_with_progress(
+        &emitter,
+        "slide-draft-llm",
+        if is_existing_draft {
+            "⏳ AI가 슬라이드 초안을 수정하는 중…"
+        } else {
+            "⏳ AI가 슬라이드 초안을 작성하는 중…"
+        },
+        if is_existing_draft {
+            "✅ 슬라이드 초안 수정 완료"
+        } else {
+            "✅ 슬라이드 초안 작성 완료"
+        },
+        company,
+        auth,
+        model.as_deref(),
+        SLIDE_MARKDOWN_DRAFT_SYSTEM,
+        &prompt,
+        SLIDE_MARKDOWN_DRAFT_MAX_TOKENS,
+    )
+    .await?;
+
+    emitter.emit("🔍 응답 정리 중...", None);
+    let cleaned = strip_internal_source_labels(&strip_outer_markdown_fence(&draft_raw));
+    emitter.emit("✅ 슬라이드 초안 준비 완료", None);
+    Ok(cleaned)
 }
 
 // ─── 범용 Claude 텍스트 생성 (문법/번역/문서개선/구조화 — React AI 모드) ─────
@@ -205,8 +995,13 @@ pub async fn ai_generate_claude(
     let result = match claude_auth {
         ClaudeAuthMode::Subscription => {
             let token = crate::subscription_auth::claude_access_token().await?;
-            anthropic::generate_text(ClaudeAuth::Subscription(&token), model_id, &prompt, Some(opts))
-                .await
+            anthropic::generate_text(
+                ClaudeAuth::Subscription(&token),
+                model_id,
+                &prompt,
+                Some(opts),
+            )
+            .await
         }
         ClaudeAuthMode::ApiKey => {
             let key = get_key(Provider::Claude)
@@ -326,7 +1121,15 @@ pub async fn generate_image_gemini(
     let key = get_key(Provider::Gemini)
         .map_err(err_to_string)?
         .ok_or_else(|| "Gemini API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_gemini(&key, &model, &prompt, &aspect_ratio, &resolution, &reference_images).await
+    image_gen::generate_gemini(
+        &key,
+        &model,
+        &prompt,
+        &aspect_ratio,
+        &resolution,
+        &reference_images,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -343,7 +1146,16 @@ pub async fn generate_image_openai(
     let key = get_key(Provider::Openai)
         .map_err(err_to_string)?
         .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    image_gen::generate_openai(&key, &model, &prompt, &aspect_ratio, &resolution, &quality, &reference_images).await
+    image_gen::generate_openai(
+        &key,
+        &model,
+        &prompt,
+        &aspect_ratio,
+        &resolution,
+        &quality,
+        &reference_images,
+    )
+    .await
 }
 
 // ─── ChatGPT(Codex 구독) 이미지 생성 ────────────────────────────────────────
@@ -388,6 +1200,104 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    #[test]
+    fn markdown_source_sections_preserve_heading_paths() {
+        let md = [
+            "---",
+            "title: Demo",
+            "---",
+            "# Strategy",
+            "opening",
+            "```",
+            "## not a heading",
+            "```",
+            "## Problem",
+            "market is fragmented",
+            "### Evidence",
+            "- duplicate work",
+            "## Solution",
+            "shared deck pipeline",
+        ]
+        .join("\n");
+        let sections = markdown_source_sections(&md);
+        let titles = sections
+            .iter()
+            .map(|s| s.title.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(titles, vec!["Strategy", "Problem", "Evidence", "Solution"]);
+        assert_eq!(sections[1].level, 2);
+        assert_eq!(sections[1].section_path, vec!["Strategy"]);
+        assert_eq!(sections[2].section_path, vec!["Strategy", "Problem"]);
+        assert!(sections[0].content.contains("## not a heading"));
+    }
+
+    #[test]
+    fn source_map_prompt_exposes_ids_paths_and_content_signals() {
+        let md = [
+            "# Report",
+            "## Metrics",
+            "| A | B |",
+            "| - | - |",
+            "| 73% | win |",
+            "![chart](chart.png)",
+            "> cited signal",
+        ]
+        .join("\n");
+        let sections = markdown_source_sections(&md);
+        let prompt = source_map_prompt(&sections);
+
+        assert!(prompt.contains("[S2]"));
+        assert!(prompt.contains("path: Report"));
+        assert!(prompt.contains("signals: table,image,quote,stat"));
+        assert!(prompt.contains("73%"));
+    }
+
+    #[test]
+    fn strip_outer_markdown_fence_removes_wrapping_fence_only() {
+        let wrapped = "```markdown\n# Title\n\n---\n\n## Body\n```";
+        assert_eq!(
+            strip_outer_markdown_fence(wrapped),
+            "# Title\n\n---\n\n## Body"
+        );
+
+        let plain = "# Title\n\n```ts\nconst x = 1;\n```";
+        assert_eq!(strip_outer_markdown_fence(plain), plain);
+    }
+
+    #[test]
+    fn strip_internal_source_labels_removes_only_source_ids() {
+        let md = [
+            "# Slide",
+            "- 핵심 메시지 (출처: S2)",
+            "- 실제 출처: 회사 보고서",
+            "출처: S2, S3",
+            "> Source: S4",
+            "---",
+            "## Next",
+            "**출처:** S5",
+        ]
+        .join("\n");
+
+        let cleaned = strip_internal_source_labels(&md);
+        assert!(cleaned.contains("- 핵심 메시지"));
+        assert!(cleaned.contains("- 실제 출처: 회사 보고서"));
+        assert!(!cleaned.contains("출처: S2"));
+        assert!(!cleaned.contains("Source: S4"));
+        assert!(!cleaned.contains("S5"));
+    }
+
+    #[test]
+    fn slide_draft_marker_detection_and_strip() {
+        let md = "<!-- markmind:slide-draft v1 -->\n# Slide\nbody";
+        assert!(has_slide_draft_marker(md));
+        assert_eq!(strip_slide_draft_marker(md), "# Slide\nbody");
+
+        let escaped = "&lt;!-- markmind:slide-draft v1 --&gt;\n# Slide";
+        assert!(has_slide_draft_marker(escaped));
+        assert_eq!(strip_slide_draft_marker(escaped), "# Slide");
+    }
+
     /// Codex P2 follow-up: ensure `extract_speakers` returns labels from a
     /// clean (no-timestamp) transcript when it's part of an STT pair —
     /// previously the per-file gate skipped the clean file, breaking
@@ -398,7 +1308,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let ts_path = dir.path().join("ts.md");
         let cl_path = dir.path().join("clean.md");
-        std::fs::write(&ts_path, "**[00:00:05] 화자A:** 안녕\n**[00:00:10] 화자B:** 반갑").unwrap();
+        std::fs::write(
+            &ts_path,
+            "**[00:00:05] 화자A:** 안녕\n**[00:00:10] 화자B:** 반갑",
+        )
+        .unwrap();
         // clean has the same labels but no timestamps — exact shape of
         // remove_timestamps output
         std::fs::write(&cl_path, "**화자A:** 안녕\n**화자B:** 반갑").unwrap();
@@ -418,7 +1332,10 @@ mod tests {
         let p = dir.path().join("notes.md");
         std::fs::write(&p, "**일시:** 2026년 5월 28일\n**참석자:** 승우, 재문").unwrap();
         let labels = extract_speakers(vec![p.to_string_lossy().into_owned()]).unwrap();
-        assert!(labels.is_empty(), "metadata-only doc must not yield speakers");
+        assert!(
+            labels.is_empty(),
+            "metadata-only doc must not yield speakers"
+        );
     }
 
     /// rename_speakers must update BOTH timestamped and clean files when
@@ -440,8 +1357,16 @@ mod tests {
         .unwrap();
         let ts_after = std::fs::read_to_string(&ts_path).unwrap();
         let cl_after = std::fs::read_to_string(&cl_path).unwrap();
-        assert!(ts_after.contains("김철수:**"), "ts file not renamed: {}", ts_after);
-        assert!(cl_after.contains("김철수:**"), "clean file not renamed: {}", cl_after);
+        assert!(
+            ts_after.contains("김철수:**"),
+            "ts file not renamed: {}",
+            ts_after
+        );
+        assert!(
+            cl_after.contains("김철수:**"),
+            "clean file not renamed: {}",
+            cl_after
+        );
     }
 }
 
@@ -473,17 +1398,11 @@ mod tests {
 fn speaker_line_patterns() -> Result<Vec<regex::Regex>, regex::Error> {
     Ok(vec![
         // 1: **[time] LABEL:**   /   **LABEL:**          (full bold envelope)
-        regex::Regex::new(
-            r"(?m)^\*\*(?:\[\d{1,2}:\d{2}(?::\d{2})?\]\s+)?([^\*\n:]{1,40}?):\*\*",
-        )?,
+        regex::Regex::new(r"(?m)^\*\*(?:\[\d{1,2}:\d{2}(?::\d{2})?\]\s+)?([^\*\n:]{1,40}?):\*\*")?,
         // 2: [time] **LABEL**:   (timestamp + label-only bold, colon outside)
-        regex::Regex::new(
-            r"(?m)^\[\d{1,2}:\d{2}(?::\d{2})?\]\s+\*\*([^\*\n:]{1,40}?)\*\*\s*:\s",
-        )?,
+        regex::Regex::new(r"(?m)^\[\d{1,2}:\d{2}(?::\d{2})?\]\s+\*\*([^\*\n:]{1,40}?)\*\*\s*:\s")?,
         // 3: [time] LABEL:       (timestamp anchored, no bold)
-        regex::Regex::new(
-            r"(?m)^\[\d{1,2}:\d{2}(?::\d{2})?\]\s+([^\*\n:]{1,40}?):\s+\S",
-        )?,
+        regex::Regex::new(r"(?m)^\[\d{1,2}:\d{2}(?::\d{2})?\]\s+([^\*\n:]{1,40}?):\s+\S")?,
     ])
 }
 
@@ -495,9 +1414,8 @@ fn speaker_line_patterns() -> Result<Vec<regex::Regex>, regex::Error> {
 /// `**일시:**`, `**참석자:**`, `**결정사항:**` as fake speakers.
 fn has_any_timestamp(text: &str) -> bool {
     static TS_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    let re = TS_RE.get_or_init(|| {
-        regex::Regex::new(r"\[\d{1,2}:\d{2}(?::\d{2})?\]").expect("regex compile")
-    });
+    let re = TS_RE
+        .get_or_init(|| regex::Regex::new(r"\[\d{1,2}:\d{2}(?::\d{2})?\]").expect("regex compile"));
     re.is_match(text)
 }
 
@@ -579,7 +1497,10 @@ pub fn merge_md_files(
             }
             frontmatter_emitted = true;
         }
-        let label = labels.get(idx).cloned().unwrap_or_else(|| format!("파일 {}", idx + 1));
+        let label = labels
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| format!("파일 {}", idx + 1));
         combined.push_str(&format!("## 파일 {} — {}\n\n", idx + 1, label));
         combined.push_str(body.trim());
         combined.push_str("\n\n");
@@ -587,7 +1508,13 @@ pub fn merge_md_files(
 
     let safe_base = output_basename
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' || c == ' ' { c } else { '_' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' || c == '-' || c == ' ' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect::<String>();
     let target = dir.join(format!("{}.md", safe_base.trim()));
     // 충돌 시 (2), (3) ...
@@ -627,10 +1554,7 @@ fn split_frontmatter(md: &str) -> (Option<String>, String) {
 /// 화자 라벨 일괄 치환. mappings: (from, to). `to` 가 빈 문자열이면 그 화자의
 /// 모든 발화 라인 통째로 제거 (라벨 prefix 부터 다음 발화 직전까지).
 #[tauri::command]
-pub fn rename_speakers(
-    paths: Vec<String>,
-    mappings: Vec<(String, String)>,
-) -> Result<(), String> {
+pub fn rename_speakers(paths: Vec<String>, mappings: Vec<(String, String)>) -> Result<(), String> {
     use std::collections::HashMap;
     // 빈 매핑 / 동일 매핑 정리
     let mut rename: HashMap<String, String> = HashMap::new();
@@ -682,9 +1606,7 @@ pub fn rename_speakers(
     // captures borrow from the input string, and proving that to the
     // checker for a Fn(&str) -> Option<Captures<'?>> is more verbose than
     // just inlining the loop at the call site.
-    let any_header_matches = |s: &str| -> bool {
-        header_patterns.iter().any(|p| p.is_match(s))
-    };
+    let any_header_matches = |s: &str| -> bool { header_patterns.iter().any(|p| p.is_match(s)) };
 
     // Set-level gate — at least one path must look like STT output. The
     // clean transcript that pairs with a timestamped one has timestamps
@@ -727,9 +1649,7 @@ pub fn rename_speakers(
             let mut matched_rest = "";
             for p in &header_patterns {
                 if let Some(caps) = p.captures(trimmed_line) {
-                    matched_label = caps
-                        .name("label")
-                        .map(|m| m.as_str().trim().to_string());
+                    matched_label = caps.name("label").map(|m| m.as_str().trim().to_string());
                     matched_prefix = caps.name("prefix").map(|m| m.as_str()).unwrap_or("");
                     matched_suffix = caps.name("suffix").map(|m| m.as_str()).unwrap_or("");
                     matched_rest = caps.name("rest").map(|m| m.as_str()).unwrap_or("");

--- a/src-tauri/src/converters/diarize_cloud.rs
+++ b/src-tauri/src/converters/diarize_cloud.rs
@@ -99,7 +99,10 @@ pub async fn diarize_cloud(
     // 4) 폴링 → 화자 구간 → DiarSegment
     let turns = poll_job(&client, api_key, &job_id).await?;
     Ok(labels_to_segments(
-        turns.into_iter().map(|t| (t.start, t.end, t.speaker)).collect(),
+        turns
+            .into_iter()
+            .map(|t| (t.start, t.end, t.speaker))
+            .collect(),
     ))
 }
 
@@ -196,5 +199,8 @@ fn api_error(route: &str, status: reqwest::StatusCode, body: &str) -> ConverterE
         );
     }
     let snippet: String = body.chars().take(200).collect();
-    ConverterError::Internal(format!("pyannote.ai {} 오류 (HTTP {}): {}", route, status, snippet))
+    ConverterError::Internal(format!(
+        "pyannote.ai {} 오류 (HTTP {}): {}",
+        route, status, snippet
+    ))
 }

--- a/src-tauri/src/converters/diarize_local.rs
+++ b/src-tauri/src/converters/diarize_local.rs
@@ -92,7 +92,10 @@ pub async fn diarize_local(
         cmd.env("MARKMIND_FFMPEG", ff);
     }
     // HF_TOKEN 이 환경에 없으면, 이미 캐시된 게이트 모델을 토큰 없이 쓰도록 오프라인 모드.
-    if std::env::var("HF_TOKEN").map(|v| v.trim().is_empty()).unwrap_or(true) {
+    if std::env::var("HF_TOKEN")
+        .map(|v| v.trim().is_empty())
+        .unwrap_or(true)
+    {
         cmd.env("HF_HUB_OFFLINE", "1");
     }
 
@@ -132,7 +135,11 @@ pub async fn diarize_local(
                     cur_step = step.to_string();
                     step_started = Instant::now();
                 }
-                let frac = if total > 0.0 { (completed / total).clamp(0.0, 1.0) } else { 0.0 };
+                let frac = if total > 0.0 {
+                    (completed / total).clamp(0.0, 1.0)
+                } else {
+                    0.0
+                };
                 let el = step_started.elapsed().as_secs_f64();
                 let detail = if completed > 0.0 && completed < total {
                     let eta = el * (total - completed) / completed;
@@ -178,17 +185,26 @@ pub async fn diarize_local(
 
     let turns: Vec<Turn> = serde_json::from_str(stdout_str.trim()).map_err(|e| {
         let head: String = stdout_str.chars().take(120).collect();
-        ConverterError::Internal(format!("diarization 출력 파싱 실패: {} (stdout: {})", e, head))
+        ConverterError::Internal(format!(
+            "diarization 출력 파싱 실패: {} (stdout: {})",
+            e, head
+        ))
     })?;
 
     emitter.emit_update(
         "diar-local",
         "🎭 화자 분리 완료",
-        Some(format!("{} 소요", fmt_duration(started.elapsed().as_secs_f64()))),
+        Some(format!(
+            "{} 소요",
+            fmt_duration(started.elapsed().as_secs_f64())
+        )),
         Some(1.0),
     );
 
     Ok(labels_to_segments(
-        turns.into_iter().map(|t| (t.start, t.end, t.speaker)).collect(),
+        turns
+            .into_iter()
+            .map(|t| (t.start, t.end, t.speaker))
+            .collect(),
     ))
 }

--- a/src-tauri/src/converters/error.rs
+++ b/src-tauri/src/converters/error.rs
@@ -19,6 +19,9 @@ pub enum ConverterError {
     #[error("OpenAI API 오류: {0}")]
     OpenAi(String),
 
+    #[error("Grok API 오류: {0}")]
+    Grok(String),
+
     #[error("네트워크 연결이 불안정합니다. 잠시 후 다시 시도해주세요. ({0})")]
     Network(String),
 

--- a/src-tauri/src/converters/llm/anthropic.rs
+++ b/src-tauri/src/converters/llm/anthropic.rs
@@ -71,7 +71,9 @@ struct MessageResponse {
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ContentBlock {
-    Text { text: String },
+    Text {
+        text: String,
+    },
     #[serde(other)]
     Other,
 }
@@ -113,7 +115,10 @@ pub async fn generate_text(
             }];
             if let Some(s) = opts.system.as_deref() {
                 if !s.trim().is_empty() {
-                    blocks.push(SystemBlock { kind: "text", text: s });
+                    blocks.push(SystemBlock {
+                        kind: "text",
+                        text: s,
+                    });
                 }
             }
             Some(SystemField::Blocks(blocks))
@@ -167,7 +172,11 @@ pub async fn generate_text(
                         model: model.to_string(),
                         input_tokens: parsed.usage.input_tokens,
                         output_tokens: parsed.usage.output_tokens,
-                        cost_usd: calc_cost(model, parsed.usage.input_tokens, parsed.usage.output_tokens),
+                        cost_usd: calc_cost(
+                            model,
+                            parsed.usage.input_tokens,
+                            parsed.usage.output_tokens,
+                        ),
                     };
                     return Ok(GenerateResult { text, usage });
                 }
@@ -181,7 +190,11 @@ pub async fn generate_text(
                     let backoff = backoff_ms(attempt);
                     log::warn!(
                         "[claude] {} 시도 {}/{} 실패 ({}), {}ms 후 재시도",
-                        model, attempt, MAX_RETRIES, status_code, backoff
+                        model,
+                        attempt,
+                        MAX_RETRIES,
+                        status_code,
+                        backoff
                     );
                     last_err = Some(err);
                     tokio::time::sleep(Duration::from_millis(backoff)).await;
@@ -194,7 +207,11 @@ pub async fn generate_text(
                     let backoff = backoff_ms(attempt);
                     log::warn!(
                         "[claude] {} 네트워크 오류 {}/{} ({}), {}ms 후 재시도",
-                        model, attempt, MAX_RETRIES, e, backoff
+                        model,
+                        attempt,
+                        MAX_RETRIES,
+                        e,
+                        backoff
                     );
                     last_err = Some(ConverterError::Network(e.to_string()));
                     tokio::time::sleep(Duration::from_millis(backoff)).await;
@@ -209,7 +226,9 @@ pub async fn generate_text(
 
 fn classify_error(status: u16, body_msg: &str) -> ConverterError {
     match status {
-        401 | 403 => ConverterError::Claude("Claude 인증 실패 — API 키 또는 구독 로그인을 확인하세요.".into()),
+        401 | 403 => ConverterError::Claude(
+            "Claude 인증 실패 — API 키 또는 구독 로그인을 확인하세요.".into(),
+        ),
         429 => ConverterError::RateLimit,
         503 | 529 => ConverterError::Overloaded,
         _ => ConverterError::Claude(format!("HTTP {} — {}", status, body_msg)),

--- a/src-tauri/src/converters/llm/gemini.rs
+++ b/src-tauri/src/converters/llm/gemini.rs
@@ -257,14 +257,24 @@ pub async fn generate_text_with_file_api(
         generation_config: None,
     };
     let url = format!("{}/{}:generateContent?key={}", GENERATE_URL, model, api_key);
-    let result = call_generate(&url, &body, model, &format!("generateContent(file {})", model)).await;
+    let result = call_generate(
+        &url,
+        &body,
+        model,
+        &format!("generateContent(file {})", model),
+    )
+    .await;
 
     // 항상 삭제 (성공/실패 무관)
     let _ = delete_file(api_key, &current.name).await;
     result
 }
 
-async fn upload_file(api_key: &str, file_path: &Path, mime_type: &str) -> ConverterResult<GeminiFile> {
+async fn upload_file(
+    api_key: &str,
+    file_path: &Path,
+    mime_type: &str,
+) -> ConverterResult<GeminiFile> {
     let file_bytes = tokio::fs::read(file_path).await?;
     let file_size = file_bytes.len();
     let display_name = file_path
@@ -344,14 +354,18 @@ async fn upload_file(api_key: &str, file_path: &Path, mime_type: &str) -> Conver
             parse_gemini_error(&body)
         )));
     }
-    let parsed: FileUploadResponse = upload_resp.json().await.map_err(|e| {
-        ConverterError::Gemini(format!("File API 응답 파싱 실패: {}", e))
-    })?;
+    let parsed: FileUploadResponse = upload_resp
+        .json()
+        .await
+        .map_err(|e| ConverterError::Gemini(format!("File API 응답 파싱 실패: {}", e)))?;
     Ok(parsed.file)
 }
 
 async fn get_file_status(api_key: &str, name: &str) -> ConverterResult<GeminiFile> {
-    let url = format!("https://generativelanguage.googleapis.com/v1beta/{}?key={}", name, api_key);
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/{}?key={}",
+        name, api_key
+    );
     let client = build_client()?;
     let resp = client.get(&url).send().await.map_err(http_to_converter)?;
     if !resp.status().is_success() {
@@ -361,14 +375,18 @@ async fn get_file_status(api_key: &str, name: &str) -> ConverterResult<GeminiFil
             parse_gemini_error(&body)
         )));
     }
-    let info: GeminiFile = resp.json().await.map_err(|e| {
-        ConverterError::Gemini(format!("File API 응답 파싱 실패: {}", e))
-    })?;
+    let info: GeminiFile = resp
+        .json()
+        .await
+        .map_err(|e| ConverterError::Gemini(format!("File API 응답 파싱 실패: {}", e)))?;
     Ok(info)
 }
 
 async fn delete_file(api_key: &str, name: &str) -> ConverterResult<()> {
-    let url = format!("https://generativelanguage.googleapis.com/v1beta/{}?key={}", name, api_key);
+    let url = format!(
+        "https://generativelanguage.googleapis.com/v1beta/{}?key={}",
+        name, api_key
+    );
     let client = build_client()?;
     let _ = client.delete(&url).send().await;
     Ok(())
@@ -406,9 +424,10 @@ async fn call_generate(
         let body = resp.text().await.unwrap_or_default();
         return Err(classify_status_error(status.as_u16(), &body));
     }
-    let parsed: GenerateResponse = resp.json().await.map_err(|e| {
-        ConverterError::Gemini(format!("응답 JSON 파싱 실패: {}", e))
-    })?;
+    let parsed: GenerateResponse = resp
+        .json()
+        .await
+        .map_err(|e| ConverterError::Gemini(format!("응답 JSON 파싱 실패: {}", e)))?;
     let text = parsed
         .candidates
         .unwrap_or_default()
@@ -456,7 +475,11 @@ where
                     let backoff = backoff_ms(attempt);
                     log::warn!(
                         "[gemini] {} 시도 {}/{} 실패 ({:?}), {}ms 후 재시도",
-                        label, attempt, MAX_RETRIES, e, backoff
+                        label,
+                        attempt,
+                        MAX_RETRIES,
+                        e,
+                        backoff
                     );
                     last_err = Some(e);
                     tokio::time::sleep(Duration::from_millis(backoff)).await;
@@ -496,7 +519,10 @@ fn classify_status_error(status: u16, body: &str) -> ConverterError {
     }
     match status {
         400 if msg.contains("API key not valid") || msg.contains("INVALID_ARGUMENT") => {
-            ConverterError::Gemini(format!("API 키가 잘못되었거나 입력이 유효하지 않습니다: {}", msg))
+            ConverterError::Gemini(format!(
+                "API 키가 잘못되었거나 입력이 유효하지 않습니다: {}",
+                msg
+            ))
         }
         401 | 403 => ConverterError::Gemini(format!("API 키 권한 오류: {}", msg)),
         429 => ConverterError::RateLimit,
@@ -527,6 +553,9 @@ fn clean_text(text: String) -> String {
         .or_else(|| trimmed.strip_prefix("```md\n"))
         .or_else(|| trimmed.strip_prefix("```\n"))
         .unwrap_or(trimmed);
-    let stripped = stripped.strip_suffix("```").map(|s| s.trim_end()).unwrap_or(stripped);
+    let stripped = stripped
+        .strip_suffix("```")
+        .map(|s| s.trim_end())
+        .unwrap_or(stripped);
     stripped.to_string()
 }

--- a/src-tauri/src/converters/llm/grok.rs
+++ b/src-tauri/src/converters/llm/grok.rs
@@ -59,10 +59,16 @@ pub async fn generate_text(
     let mut messages = Vec::new();
     if let Some(s) = system {
         if !s.is_empty() {
-            messages.push(ChatMessage { role: "system", content: s });
+            messages.push(ChatMessage {
+                role: "system",
+                content: s,
+            });
         }
     }
-    messages.push(ChatMessage { role: "user", content: prompt });
+    messages.push(ChatMessage {
+        role: "user",
+        content: prompt,
+    });
 
     let body = ChatRequest {
         model,

--- a/src-tauri/src/converters/llm/image_gen.rs
+++ b/src-tauri/src/converters/llm/image_gen.rs
@@ -191,9 +191,9 @@ fn openai_size(aspect_ratio: &str, resolution: &str) -> String {
     const MAX_EDGE: i64 = 3840;
     let (rw, rh) = parse_ratio(aspect_ratio);
     let target = match resolution.to_uppercase().as_str() {
-        "4K" => MAX_PX as f64,    // 4K — 제약상 최대 픽셀
-        "2K" => 4_194_304.0,      // 2K ≈ 2048²
-        _ => 1_048_576.0,         // 1K ≈ 1024²
+        "4K" => MAX_PX as f64, // 4K — 제약상 최대 픽셀
+        "2K" => 4_194_304.0,   // 2K ≈ 2048²
+        _ => 1_048_576.0,      // 1K ≈ 1024²
     };
     // 비율 유지하며 목표 픽셀에 맞는 실수 변 길이
     let mut h = (target * rh / rw).sqrt();
@@ -384,7 +384,9 @@ mod tests {
     /// openai_size: 제약(16배수·최대변3840·픽셀 655360~8294400)을 항상 만족해야.
     #[test]
     fn openai_size_satisfies_constraints() {
-        for ar in ["1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "21:9", "garbage"] {
+        for ar in [
+            "1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "21:9", "garbage",
+        ] {
             for res in ["1K", "2K", "4K"] {
                 let s = openai_size(ar, res);
                 let (w, h): (i64, i64) = {
@@ -395,7 +397,10 @@ mod tests {
                 assert_eq!(h % 16, 0, "{ar}/{res}={s}: height not /16");
                 assert!(w <= 3840 && h <= 3840, "{ar}/{res}={s}: edge > 3840");
                 let px = w * h;
-                assert!((655_360..=8_294_400).contains(&px), "{ar}/{res}={s}: px {px} out of range");
+                assert!(
+                    (655_360..=8_294_400).contains(&px),
+                    "{ar}/{res}={s}: px {px} out of range"
+                );
             }
         }
     }

--- a/src-tauri/src/converters/llm/openai_api.rs
+++ b/src-tauri/src/converters/llm/openai_api.rs
@@ -59,10 +59,16 @@ pub async fn generate_text(
     let mut messages = Vec::new();
     if let Some(s) = system {
         if !s.is_empty() {
-            messages.push(ChatMessage { role: "system", content: s });
+            messages.push(ChatMessage {
+                role: "system",
+                content: s,
+            });
         }
     }
-    messages.push(ChatMessage { role: "user", content: prompt });
+    messages.push(ChatMessage {
+        role: "user",
+        content: prompt,
+    });
 
     let body = ChatRequest {
         model,

--- a/src-tauri/src/converters/llm/openai_api.rs
+++ b/src-tauri/src/converters/llm/openai_api.rs
@@ -55,6 +55,7 @@ pub async fn generate_text(
     model: &str,
     system: Option<&str>,
     prompt: &str,
+    max_completion_tokens: Option<u32>,
 ) -> ConverterResult<GenerateResult> {
     let mut messages = Vec::new();
     if let Some(s) = system {
@@ -73,7 +74,7 @@ pub async fn generate_text(
     let body = ChatRequest {
         model,
         messages,
-        max_completion_tokens: Some(16000),
+        max_completion_tokens: Some(max_completion_tokens.unwrap_or(16000)),
     };
 
     let client = reqwest::Client::builder()

--- a/src-tauri/src/converters/llm/openai_codex.rs
+++ b/src-tauri/src/converters/llm/openai_codex.rs
@@ -17,7 +17,11 @@ pub async fn generate_text(
     model: &str,
     system: Option<&str>,
     prompt: &str,
+    _max_output_tokens: Option<u32>,
 ) -> ConverterResult<GenerateResult> {
+    // chatgpt.com Codex backend is not the public Responses API and currently rejects
+    // `max_output_tokens` with HTTP 400. Keep the argument for call-site parity, but do
+    // not send it on the subscription path.
     let body = serde_json::json!({
         "model": model,
         "instructions": system.unwrap_or(""),

--- a/src-tauri/src/converters/llm/openai_codex.rs
+++ b/src-tauri/src/converters/llm/openai_codex.rs
@@ -55,7 +55,11 @@ pub async fn generate_text(
         let raw = resp.text().await.unwrap_or_default();
         let snippet: String = raw.chars().take(500).collect();
         eprintln!("[codex] 에러 본문: {}", snippet);
-        return Err(ConverterError::Codex(format!("HTTP {} — {}", status.as_u16(), snippet)));
+        return Err(ConverterError::Codex(format!(
+            "HTTP {} — {}",
+            status.as_u16(),
+            snippet
+        )));
     }
 
     let sse = resp
@@ -141,7 +145,11 @@ fn extract_completed_text(v: &serde_json::Value) -> Option<String> {
             }
         }
     }
-    if let Some(content) = v.get("item").and_then(|i| i.get("content")).and_then(|c| c.as_array()) {
+    if let Some(content) = v
+        .get("item")
+        .and_then(|i| i.get("content"))
+        .and_then(|c| c.as_array())
+    {
         for c in content {
             if let Some(txt) = c.get("text").and_then(|t| t.as_str()) {
                 acc.push_str(txt);

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -37,12 +37,16 @@ pub const MODEL_OCR_ENHANCE: &str = "gemini-3-pro-image-preview";
 //  transcription 권장 모델.) 음질 회귀 발견 시 mod.rs 의 이 상수만 되돌리면 됨.
 pub const MODEL_AUDIO: &str = "gemini-3.1-flash-lite";
 pub const MODEL_NOTES_GEMINI: &str = "gemini-3.1-pro-preview";
+/// Antigravity CLI(`agy`) 구독 호출용 Gemini 모델명. `agy --model` 은 API model id 가
+/// 아니라 `agy models` 에 표시되는 이름을 받는다.
+pub const MODEL_GEMINI_AGY: &str = "Gemini 3.1 Pro (High)";
 pub const MODEL_NOTES_CLAUDE: &str = "claude-sonnet-4-6";
 #[allow(dead_code)] // OpenAI API 키 호출은 아직 미구현 — 미래 사용용 default
 pub const MODEL_OPENAI_DEFAULT: &str = "gpt-5.4-mini-2026-03-17";
 /// ChatGPT(Codex 구독) backend 호출 모델. `~/.codex/models_cache.json` 의 실제 id 기반
 /// (gpt-5.4 / gpt-5.4-mini / gpt-5.5). 최신 gpt-5.5 사용.
 pub const MODEL_CODEX: &str = "gpt-5.5";
+pub const MODEL_GROK: &str = "grok-4.3";
 
 /// 단가 — USD per 1M tokens
 pub fn pricing(model: &str) -> Option<(f64, f64)> {

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -10,10 +10,10 @@
 
 pub mod audio_pipeline;
 pub mod audio_splitter;
+pub mod commands;
 pub mod diar;
 pub mod diarize_cloud;
 pub mod diarize_local;
-pub mod commands;
 pub mod error;
 pub mod keychain;
 pub mod llm;

--- a/src-tauri/src/converters/mod.rs
+++ b/src-tauri/src/converters/mod.rs
@@ -21,6 +21,7 @@ pub mod notes_pipeline;
 pub mod ocr_pipeline;
 pub mod pdf_extractor;
 pub mod progress;
+pub mod slide_assets;
 pub mod speaker_dedup;
 pub mod templates;
 pub mod vad;

--- a/src-tauri/src/converters/notes_pipeline.rs
+++ b/src-tauri/src/converters/notes_pipeline.rs
@@ -2,12 +2,12 @@
 
 use super::error::{ConverterError, ConverterResult};
 use super::keychain::{get_key, Provider};
-use super::llm::{anthropic, gemini};
+use super::llm::{anthropic, gemini, gemini_agy, grok};
 use super::progress::ProgressEmitter;
 use super::templates::{build_evidence_markdown, get_template, strip_frontmatter, EvidenceMeta};
 use super::{
-    conversions_dir, CostSummary, DetailLevel, EvidenceType, MODEL_CODEX, MODEL_NOTES_CLAUDE,
-    MODEL_NOTES_GEMINI,
+    conversions_dir, CostSummary, DetailLevel, EvidenceType, GenerateResult, UsageInfo,
+    MODEL_CODEX, MODEL_GEMINI_AGY, MODEL_GROK, MODEL_NOTES_CLAUDE, MODEL_NOTES_GEMINI,
 };
 use serde::{Deserialize, Serialize};
 
@@ -71,6 +71,7 @@ pub async fn run(
         crate::subscription_auth::AICompany::Gemini => "Gemini",
         crate::subscription_auth::AICompany::Claude => "Claude",
         crate::subscription_auth::AICompany::Openai => "ChatGPT",
+        crate::subscription_auth::AICompany::Grok => "Grok",
     };
     emitter.emit(
         format!(
@@ -95,25 +96,44 @@ pub async fn run(
 
     let generate_result = match opts.company {
         AICompany::Gemini => {
-            let api_key =
-                get_key(Provider::Gemini)?.ok_or(ConverterError::MissingApiKey("Gemini"))?;
-            let model = opts.model.as_deref().unwrap_or(MODEL_NOTES_GEMINI);
+            let model = opts.model.as_deref().unwrap_or(match opts.auth {
+                ClaudeAuthMode::Subscription => MODEL_GEMINI_AGY,
+                ClaudeAuthMode::ApiKey => MODEL_NOTES_GEMINI,
+            });
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
-                Some(format!("{} · max {} tok", model, MAX_OUTPUT_TOKENS)),
+                Some(format!(
+                    "{} · {} · max {} tok",
+                    model, auth_label, MAX_OUTPUT_TOKENS
+                )),
             );
             let start = std::time::Instant::now();
-            let result = gemini::generate_text(
-                &api_key,
-                model,
-                &prompt,
-                vec![],
-                Some(gemini::GenerationConfig {
-                    max_output_tokens: Some(MAX_OUTPUT_TOKENS),
-                    temperature: None,
-                }),
-            )
-            .await?;
+            let result = match opts.auth {
+                ClaudeAuthMode::Subscription => {
+                    let text = gemini_agy::generate_text(model, None, &prompt)
+                        .await
+                        .map_err(ConverterError::Gemini)?;
+                    GenerateResult {
+                        text,
+                        usage: zero_usage(model),
+                    }
+                }
+                ClaudeAuthMode::ApiKey => {
+                    let api_key = get_key(Provider::Gemini)?
+                        .ok_or(ConverterError::MissingApiKey("Gemini"))?;
+                    gemini::generate_text(
+                        &api_key,
+                        model,
+                        &prompt,
+                        vec![],
+                        Some(gemini::GenerationConfig {
+                            max_output_tokens: Some(MAX_OUTPUT_TOKENS),
+                            temperature: None,
+                        }),
+                    )
+                    .await?
+                }
+            };
             emitter.emit(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
                 Some(format!(
@@ -214,6 +234,26 @@ pub async fn run(
             );
             result
         }
+        AICompany::Grok => {
+            let model = opts.model.clone().unwrap_or_else(|| MODEL_GROK.to_string());
+            emitter.emit(
+                "🧠 미팅 노트 생성 중...",
+                Some(format!("{} · {}", model, auth_label)),
+            );
+            let start = std::time::Instant::now();
+            let key = grok_bearer(opts.auth)?;
+            let text = grok::generate_text(&key, &model, None, &prompt)
+                .await
+                .map_err(ConverterError::Grok)?;
+            emitter.emit(
+                format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
+                Some("토큰 사용량 미제공".to_string()),
+            );
+            GenerateResult {
+                text,
+                usage: zero_usage(&model),
+            }
+        }
     };
 
     if generate_result.text.trim().is_empty() {
@@ -242,6 +282,27 @@ pub async fn run(
         template_name: template.info.name,
         cost: CostSummary::from_usages(vec![generate_result.usage]),
     })
+}
+
+fn zero_usage(model: &str) -> UsageInfo {
+    UsageInfo {
+        model: model.to_string(),
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_usd: 0.0,
+    }
+}
+
+fn grok_bearer(auth: crate::subscription_auth::ClaudeAuthMode) -> ConverterResult<String> {
+    use crate::subscription_auth::ClaudeAuthMode;
+    match auth {
+        ClaudeAuthMode::Subscription => {
+            crate::subscription_auth::read_grok_token().map_err(ConverterError::Grok)
+        }
+        ClaudeAuthMode::ApiKey => {
+            get_key(Provider::Grok)?.ok_or(ConverterError::MissingApiKey("Grok"))
+        }
+    }
 }
 
 /// 1234567 → "1,234,567" (doc-converter `.toLocaleString()` 대응)

--- a/src-tauri/src/converters/notes_pipeline.rs
+++ b/src-tauri/src/converters/notes_pipeline.rs
@@ -195,13 +195,14 @@ pub async fn run(
                         &model,
                         None,
                         &prompt,
+                        None,
                     )
                     .await?
                 }
                 ClaudeAuthMode::ApiKey => {
                     let api_key = get_key(Provider::Openai)?
                         .ok_or(ConverterError::MissingApiKey("OpenAI"))?;
-                    openai_api::generate_text(&api_key, &model, None, &prompt).await?
+                    openai_api::generate_text(&api_key, &model, None, &prompt, None).await?
                 }
             };
             emitter.emit(

--- a/src-tauri/src/converters/notes_pipeline.rs
+++ b/src-tauri/src/converters/notes_pipeline.rs
@@ -4,9 +4,7 @@ use super::error::{ConverterError, ConverterResult};
 use super::keychain::{get_key, Provider};
 use super::llm::{anthropic, gemini};
 use super::progress::ProgressEmitter;
-use super::templates::{
-    build_evidence_markdown, get_template, strip_frontmatter, EvidenceMeta,
-};
+use super::templates::{build_evidence_markdown, get_template, strip_frontmatter, EvidenceMeta};
 use super::{
     conversions_dir, CostSummary, DetailLevel, EvidenceType, MODEL_CODEX, MODEL_NOTES_CLAUDE,
     MODEL_NOTES_GEMINI,
@@ -97,8 +95,8 @@ pub async fn run(
 
     let generate_result = match opts.company {
         AICompany::Gemini => {
-            let api_key = get_key(Provider::Gemini)?
-                .ok_or(ConverterError::MissingApiKey("Gemini"))?;
+            let api_key =
+                get_key(Provider::Gemini)?.ok_or(ConverterError::MissingApiKey("Gemini"))?;
             let model = opts.model.as_deref().unwrap_or(MODEL_NOTES_GEMINI);
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
@@ -118,7 +116,10 @@ pub async fn run(
             .await?;
             emitter.emit(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
-                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
+                Some(format!(
+                    "{} 토큰 출력",
+                    format_num(result.usage.output_tokens as usize)
+                )),
             );
             result
         }
@@ -129,7 +130,10 @@ pub async fn run(
                 .unwrap_or_else(|| MODEL_NOTES_CLAUDE.to_string());
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
-                Some(format!("{} · {} · max {} tok", model, auth_label, MAX_OUTPUT_TOKENS)),
+                Some(format!(
+                    "{} · {} · max {} tok",
+                    model, auth_label, MAX_OUTPUT_TOKENS
+                )),
             );
             let start = std::time::Instant::now();
             let claude_opts = anthropic::ClaudeOptions {
@@ -163,13 +167,19 @@ pub async fn run(
             };
             emitter.emit(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
-                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
+                Some(format!(
+                    "{} 토큰 출력",
+                    format_num(result.usage.output_tokens as usize)
+                )),
             );
             result
         }
         AICompany::Openai => {
             use super::llm::{openai_api, openai_codex};
-            let model = opts.model.clone().unwrap_or_else(|| MODEL_CODEX.to_string());
+            let model = opts
+                .model
+                .clone()
+                .unwrap_or_else(|| MODEL_CODEX.to_string());
             emitter.emit(
                 "🧠 미팅 노트 생성 중...",
                 Some(format!("{} · {} · ChatGPT", model, auth_label)),
@@ -177,8 +187,8 @@ pub async fn run(
             let start = std::time::Instant::now();
             let result = match opts.auth {
                 ClaudeAuthMode::Subscription => {
-                    let tokens =
-                        crate::subscription_auth::read_codex_tokens().map_err(ConverterError::Codex)?;
+                    let tokens = crate::subscription_auth::read_codex_tokens()
+                        .map_err(ConverterError::Codex)?;
                     openai_codex::generate_text(
                         &tokens.access_token,
                         tokens.account_id.as_deref(),
@@ -196,7 +206,10 @@ pub async fn run(
             };
             emitter.emit(
                 format!("✅ 노트 생성 완료 ({:.1}초)", start.elapsed().as_secs_f64()),
-                Some(format!("{} 토큰 출력", format_num(result.usage.output_tokens as usize))),
+                Some(format!(
+                    "{} 토큰 출력",
+                    format_num(result.usage.output_tokens as usize)
+                )),
             );
             result
         }
@@ -222,7 +235,6 @@ pub async fn run(
     let target_path = unique_path(&target_dir, &format!("회의록_{}", safe_name), "md");
     std::fs::write(&target_path, &markdown)?;
     // doc-converter 와 동일: 저장 step 은 표시 안 함 (결과 카드의 경로로 충분)
-
 
     Ok(NotesJobResult {
         markdown_path: target_path.to_string_lossy().into_owned(),

--- a/src-tauri/src/converters/ocr_pipeline.rs
+++ b/src-tauri/src/converters/ocr_pipeline.rs
@@ -36,13 +36,15 @@ pub struct OcrJobResult {
 }
 
 pub async fn run(emitter: &ProgressEmitter, opts: OcrJobOptions) -> ConverterResult<OcrJobResult> {
-    let api_key = get_key(Provider::Gemini)?
-        .ok_or(ConverterError::MissingApiKey("Gemini"))?;
+    let api_key = get_key(Provider::Gemini)?.ok_or(ConverterError::MissingApiKey("Gemini"))?;
     let file_path = Path::new(&opts.file_path).to_path_buf();
-    let file_name = opts
-        .original_name
-        .clone()
-        .unwrap_or_else(|| file_path.file_name().and_then(|s| s.to_str()).unwrap_or("").to_string());
+    let file_name = opts.original_name.clone().unwrap_or_else(|| {
+        file_path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string()
+    });
     let is_pdf = file_path
         .extension()
         .and_then(|s| s.to_str())
@@ -71,9 +73,24 @@ pub async fn run(emitter: &ProgressEmitter, opts: OcrJobOptions) -> ConverterRes
     emitter.emit(pass1_label.clone(), Some(MODEL_OCR_FAST.into()));
     let start1 = std::time::Instant::now();
     let raw_text = if is_pdf {
-        run_pdf_pass(&api_key, MODEL_OCR_FAST, pass1_prompt, &file_path, emitter, &mut usages).await?
+        run_pdf_pass(
+            &api_key,
+            MODEL_OCR_FAST,
+            pass1_prompt,
+            &file_path,
+            emitter,
+            &mut usages,
+        )
+        .await?
     } else {
-        run_image_pass(&api_key, MODEL_OCR_FAST, pass1_prompt, &file_path, &mut usages).await?
+        run_image_pass(
+            &api_key,
+            MODEL_OCR_FAST,
+            pass1_prompt,
+            &file_path,
+            &mut usages,
+        )
+        .await?
     };
     let last_in = usages.last().map(|u| u.input_tokens).unwrap_or(0);
     emitter.emit(
@@ -104,14 +121,32 @@ pub async fn run(emitter: &ProgressEmitter, opts: OcrJobOptions) -> ConverterRes
             )
         };
         emitter.emit(
-            format!("🧠 Pass 2/{} — 문맥 보강 + Markdown 구조화 중...", total_passes),
+            format!(
+                "🧠 Pass 2/{} — 문맥 보강 + Markdown 구조화 중...",
+                total_passes
+            ),
             Some(MODEL_OCR_ENHANCE.into()),
         );
         let start2 = std::time::Instant::now();
         let result = if is_pdf {
-            run_pdf_pass(&api_key, MODEL_OCR_ENHANCE, &pass2_prompt, &file_path, emitter, &mut usages).await?
+            run_pdf_pass(
+                &api_key,
+                MODEL_OCR_ENHANCE,
+                &pass2_prompt,
+                &file_path,
+                emitter,
+                &mut usages,
+            )
+            .await?
         } else {
-            run_image_pass(&api_key, MODEL_OCR_ENHANCE, &pass2_prompt, &file_path, &mut usages).await?
+            run_image_pass(
+                &api_key,
+                MODEL_OCR_ENHANCE,
+                &pass2_prompt,
+                &file_path,
+                &mut usages,
+            )
+            .await?
         };
         let last_in = usages.last().map(|u| u.input_tokens).unwrap_or(0);
         emitter.emit(
@@ -220,7 +255,10 @@ async fn run_pdf_pass(
             );
             let images = extract_pdf_to_images(pdf_path).await?;
             emitter.emit(
-                format!("✅ 로컬 변환 완료 ({}장). 텍스트 추출 시작...", images.len()),
+                format!(
+                    "✅ 로컬 변환 완료 ({}장). 텍스트 추출 시작...",
+                    images.len()
+                ),
                 Some(model.into()),
             );
             let mut inline_data = Vec::with_capacity(images.len());
@@ -345,7 +383,8 @@ const PASS1_PROMPT_IMAGE: &str = "이 이미지에서 손글씨 텍스트를 추
 - 한 문장/줄이 끝나면 새 줄에서 시작해주세요.
 - 텍스트만 출력하세요. 설명, 제목, 코드 블록은 포함하지 마세요.";
 
-const PASS2_PROMPT_PDF_HEADER: &str = "아래는 PDF에서 1차 OCR로 추출된 텍스트입니다.\n원본 PDF를 직접 보고 다음을 수행해주세요:";
+const PASS2_PROMPT_PDF_HEADER: &str =
+    "아래는 PDF에서 1차 OCR로 추출된 텍스트입니다.\n원본 PDF를 직접 보고 다음을 수행해주세요:";
 
 const PASS2_PROMPT_PDF_BODY: &str = "## 작업:
 1. 한글 맞춤법/문법 교정

--- a/src-tauri/src/converters/pdf_extractor.rs
+++ b/src-tauri/src/converters/pdf_extractor.rs
@@ -23,7 +23,9 @@ pub async fn extract_pdf_to_images(pdf_path: &std::path::Path) -> ConverterResul
 fn extract_blocking(pdf_path: &std::path::Path) -> ConverterResult<Vec<PathBuf>> {
     let pdfium = Pdfium::new(
         Pdfium::bind_to_system_library()
-            .or_else(|_| Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./")))
+            .or_else(|_| {
+                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+            })
             .map_err(|e| {
                 ConverterError::Pdf(format!(
                     "pdfium 라이브러리 로드 실패 — libpdfium 이 설치/동봉되어 있는지 확인: {}",
@@ -48,9 +50,9 @@ fn extract_blocking(pdf_path: &std::path::Path) -> ConverterResult<Vec<PathBuf>>
 
     let mut paths = Vec::new();
     for (page_idx, page) in document.pages().iter().enumerate() {
-        let bitmap = page
-            .render_with_config(&render_config)
-            .map_err(|e| ConverterError::Pdf(format!("페이지 {} 렌더링 실패: {}", page_idx + 1, e)))?;
+        let bitmap = page.render_with_config(&render_config).map_err(|e| {
+            ConverterError::Pdf(format!("페이지 {} 렌더링 실패: {}", page_idx + 1, e))
+        })?;
         let image = bitmap.as_image();
         let target = out_dir.join(format!("page-{:04}.png", page_idx + 1));
         image

--- a/src-tauri/src/converters/progress.rs
+++ b/src-tauri/src/converters/progress.rs
@@ -6,6 +6,13 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgressModelInfo {
+    pub company: String,
+    pub auth: String,
+    pub model: String,
+}
+
 /// 단일 진행 step — frontend ProgressPanel 이 한 줄씩 표시
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProgressStep {
@@ -19,6 +26,9 @@ pub struct ProgressStep {
     /// 0.0 ~ 1.0 — 알 수 있는 경우만
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress: Option<f32>,
+    /// AI 모델 표시용 메타데이터. frontend 가 Settings 와 같은 카탈로그/로고로 렌더한다.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<ProgressModelInfo>,
     /// stable id — 같은 stepId 면 ProgressPanel 이 in-place 갱신 (heartbeat / progress 갱신용).
     /// None 이면 새 row append (기본 동작).
     #[serde(rename = "stepId", skip_serializing_if = "Option::is_none")]
@@ -38,7 +48,11 @@ pub struct ProgressEmitter {
 
 impl ProgressEmitter {
     pub fn new(app: AppHandle, job_id: String) -> Self {
-        Self { app, job_id, prefix: None }
+        Self {
+            app,
+            job_id,
+            prefix: None,
+        }
     }
 
     pub fn job_id(&self) -> &str {
@@ -87,18 +101,25 @@ impl ProgressEmitter {
             step: self.prefix_step(step.into()),
             detail,
             progress: None,
+            model: None,
             step_id: None,
         };
         let _ = self.app.emit("converter-progress", event);
     }
 
     #[allow(dead_code)]
-    pub fn emit_with_progress(&self, step: impl Into<String>, detail: Option<String>, progress: f32) {
+    pub fn emit_with_progress(
+        &self,
+        step: impl Into<String>,
+        detail: Option<String>,
+        progress: f32,
+    ) {
         let event = ProgressStep {
             job_id: self.job_id.clone(),
             step: self.prefix_step(step.into()),
             detail,
             progress: Some(progress),
+            model: None,
             step_id: None,
         };
         let _ = self.app.emit("converter-progress", event);
@@ -119,6 +140,26 @@ impl ProgressEmitter {
             step: self.prefix_step(step.into()),
             detail,
             progress,
+            model: None,
+            step_id: Some(step_id.into()),
+        };
+        let _ = self.app.emit("converter-progress", event);
+    }
+
+    pub fn emit_update_with_model(
+        &self,
+        step_id: impl Into<String>,
+        step: impl Into<String>,
+        detail: Option<String>,
+        progress: Option<f32>,
+        model: Option<ProgressModelInfo>,
+    ) {
+        let event = ProgressStep {
+            job_id: self.job_id.clone(),
+            step: self.prefix_step(step.into()),
+            detail,
+            progress,
+            model,
             step_id: Some(step_id.into()),
         };
         let _ = self.app.emit("converter-progress", event);

--- a/src-tauri/src/converters/slide_assets.rs
+++ b/src-tauri/src/converters/slide_assets.rs
@@ -1,0 +1,388 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{cmp::Ordering, time::Duration};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StockSlideAssetIntent {
+    title: String,
+    role: String,
+    query: Option<String>,
+    entity: Option<String>,
+    aspect: Option<String>,
+    source_preference: Option<String>,
+    license_strictness: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedStockSlideAsset {
+    data_url: String,
+    provider: String,
+    source_url: Option<String>,
+    attribution: Option<String>,
+    license: Option<String>,
+    width: Option<u32>,
+    height: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateAsset {
+    provider: &'static str,
+    url: String,
+    source_url: Option<String>,
+    attribution: Option<String>,
+    license: Option<String>,
+    width: Option<u32>,
+    height: Option<u32>,
+    mime: Option<String>,
+    score: f64,
+}
+
+#[tauri::command]
+pub async fn resolve_stock_slide_asset(
+    intent: StockSlideAssetIntent,
+) -> Result<Option<ResolvedStockSlideAsset>, String> {
+    let source_preference = intent
+        .source_preference
+        .as_deref()
+        .unwrap_or("auto")
+        .to_ascii_lowercase();
+    if source_preference == "none" || source_preference == "generated" {
+        return Ok(None);
+    }
+    let query = stock_query(&intent);
+    if query.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(12))
+        .user_agent("MarkMind/0.9 slide asset resolver")
+        .build()
+        .map_err(|e| format!("이미지 검색 클라이언트 생성 실패: {e}"))?;
+
+    let (openverse, wikimedia) = tokio::join!(
+        search_openverse(&client, &intent, &query),
+        search_wikimedia(&client, &intent, &query)
+    );
+
+    let mut candidates = Vec::new();
+    if let Ok(items) = openverse {
+        candidates.extend(items);
+    }
+    if let Ok(items) = wikimedia {
+        candidates.extend(items);
+    }
+    candidates.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
+
+    for candidate in candidates.into_iter().take(8) {
+        match fetch_candidate(&client, candidate.clone()).await {
+            Ok(asset) => return Ok(Some(asset)),
+            Err(err) => {
+                log::debug!(
+                    "[slide_assets] candidate fetch skipped provider={} url={} err={}",
+                    candidate.provider,
+                    candidate.url,
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn stock_query(intent: &StockSlideAssetIntent) -> String {
+    let mut parts = Vec::new();
+    if let Some(entity) = intent
+        .entity
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        parts.push(entity.to_string());
+    }
+    if let Some(query) = intent
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        parts.push(query.to_string());
+    }
+    if parts.is_empty() {
+        parts.push(intent.title.trim().to_string());
+    }
+    if intent.role == "logo" && !parts.iter().any(|p| p.to_lowercase().contains("logo")) {
+        parts.push("logo".to_string());
+    }
+    parts.join(" ")
+}
+
+async fn search_openverse(
+    client: &reqwest::Client,
+    intent: &StockSlideAssetIntent,
+    query: &str,
+) -> Result<Vec<CandidateAsset>, String> {
+    if intent.source_preference.as_deref() == Some("logo") {
+        return Ok(Vec::new());
+    }
+    let url = format!(
+        "https://api.openverse.engineering/v1/images/?q={}&page_size=8&mature=false",
+        urlencoding::encode(query)
+    );
+    let v: Value = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Openverse 검색 실패: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Openverse 검색 응답 오류: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("Openverse 응답 파싱 실패: {e}"))?;
+    let mut out = Vec::new();
+    for item in v
+        .get("results")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some(url) = item.get("url").and_then(Value::as_str).map(str::to_string) else {
+            continue;
+        };
+        let width = u32_field(item, "width");
+        let height = u32_field(item, "height");
+        let license = item
+            .get("license")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let creator = item
+            .get("creator")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+        let attribution = match (title, creator) {
+            (Some(t), Some(c)) => Some(format!("{t} — {c} / Openverse")),
+            (Some(t), None) => Some(format!("{t} / Openverse")),
+            (None, Some(c)) => Some(format!("{c} / Openverse")),
+            (None, None) => Some("Openverse".to_string()),
+        };
+        let mut candidate = CandidateAsset {
+            provider: "openverse",
+            url,
+            source_url: item
+                .get("foreign_landing_url")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            attribution,
+            license,
+            width,
+            height,
+            mime: None,
+            score: 0.0,
+        };
+        candidate.score = score_candidate(&candidate, intent);
+        out.push(candidate);
+    }
+    Ok(out)
+}
+
+async fn search_wikimedia(
+    client: &reqwest::Client,
+    intent: &StockSlideAssetIntent,
+    query: &str,
+) -> Result<Vec<CandidateAsset>, String> {
+    let url = format!(
+        "https://commons.wikimedia.org/w/api.php?action=query&generator=search&gsrnamespace=6&gsrlimit=8&gsrsearch={}&prop=imageinfo&iiprop=url|extmetadata|mime|size&format=json",
+        urlencoding::encode(query)
+    );
+    let v: Value = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Wikimedia 검색 실패: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("Wikimedia 검색 응답 오류: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("Wikimedia 응답 파싱 실패: {e}"))?;
+    let mut out = Vec::new();
+    let Some(pages) = v
+        .get("query")
+        .and_then(|q| q.get("pages"))
+        .and_then(Value::as_object)
+    else {
+        return Ok(out);
+    };
+    for page in pages.values() {
+        let Some(info) = page
+            .get("imageinfo")
+            .and_then(Value::as_array)
+            .and_then(|arr| arr.first())
+        else {
+            continue;
+        };
+        let Some(url) = info.get("url").and_then(Value::as_str).map(str::to_string) else {
+            continue;
+        };
+        let mime = info.get("mime").and_then(Value::as_str).map(str::to_string);
+        let width = u32_field(info, "width");
+        let height = u32_field(info, "height");
+        let meta = info.get("extmetadata").and_then(Value::as_object);
+        let title = meta_value(meta, "ObjectName")
+            .or_else(|| page.get("title").and_then(Value::as_str).map(clean_html));
+        let author = meta_value(meta, "Artist").or_else(|| meta_value(meta, "Credit"));
+        let license = meta_value(meta, "LicenseShortName").or_else(|| meta_value(meta, "License"));
+        let attribution = match (title.as_deref(), author.as_deref()) {
+            (Some(t), Some(a)) if !a.is_empty() => Some(format!("{t} — {a} / Wikimedia Commons")),
+            (Some(t), _) => Some(format!("{t} / Wikimedia Commons")),
+            _ => Some("Wikimedia Commons".to_string()),
+        };
+        let mut candidate = CandidateAsset {
+            provider: "wikimedia",
+            url,
+            source_url: info
+                .get("descriptionurl")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            attribution,
+            license,
+            width,
+            height,
+            mime,
+            score: 0.0,
+        };
+        candidate.score = score_candidate(&candidate, intent);
+        out.push(candidate);
+    }
+    Ok(out)
+}
+
+async fn fetch_candidate(
+    client: &reqwest::Client,
+    candidate: CandidateAsset,
+) -> Result<ResolvedStockSlideAsset, String> {
+    let resp = client
+        .get(&candidate.url)
+        .send()
+        .await
+        .map_err(|e| format!("이미지 다운로드 실패: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("이미지 다운로드 응답 오류: {e}"))?;
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(normalize_mime)
+        .or_else(|| candidate.mime.as_deref().and_then(normalize_mime))
+        .ok_or_else(|| "지원하지 않는 이미지 형식".to_string())?;
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("이미지 바이트 읽기 실패: {e}"))?;
+    if bytes.len() > 8 * 1024 * 1024 {
+        return Err("이미지가 너무 큼".to_string());
+    }
+    let b64 = STANDARD.encode(bytes);
+    Ok(ResolvedStockSlideAsset {
+        data_url: format!("data:{content_type};base64,{b64}"),
+        provider: candidate.provider.to_string(),
+        source_url: candidate.source_url,
+        attribution: candidate.attribution,
+        license: candidate.license,
+        width: candidate.width,
+        height: candidate.height,
+    })
+}
+
+fn score_candidate(candidate: &CandidateAsset, intent: &StockSlideAssetIntent) -> f64 {
+    let mut score = 0.0;
+    if let (Some(w), Some(h)) = (candidate.width, candidate.height) {
+        let megapixels = (w as f64 * h as f64) / 1_000_000.0;
+        score += megapixels.min(6.0) * 0.5;
+        if let Some(target) = intent.aspect.as_deref().and_then(aspect_ratio) {
+            let actual = w as f64 / h.max(1) as f64;
+            score += (2.0 - (target - actual).abs()).max(0.0);
+        }
+    }
+    if candidate.provider == "wikimedia"
+        && (intent.role == "logo" || intent.license_strictness.as_deref() == Some("open"))
+    {
+        score += 1.5;
+    }
+    if candidate.provider == "openverse" && intent.role != "logo" {
+        score += 0.8;
+    }
+    if let Some(license) = candidate.license.as_deref().map(str::to_lowercase) {
+        if license.contains("public") || license.contains("cc0") {
+            score += 0.8;
+        } else if license.contains("cc") || license.contains("creative") {
+            score += 0.4;
+        }
+    }
+    if candidate.mime.as_deref().is_some_and(|m| m.contains("svg")) && intent.role == "logo" {
+        score += 0.6;
+    }
+    score
+}
+
+fn u32_field(value: &Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|v| u32::try_from(v).ok())
+}
+
+fn meta_value(meta: Option<&serde_json::Map<String, Value>>, key: &str) -> Option<String> {
+    meta.and_then(|m| m.get(key))
+        .and_then(|v| v.get("value"))
+        .and_then(Value::as_str)
+        .map(clean_html)
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn clean_html(value: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in value.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out.replace("&quot;", "\"")
+        .replace("&amp;", "&")
+        .replace("&#039;", "'")
+}
+
+fn normalize_mime(value: &str) -> Option<String> {
+    let mime = value.split(';').next()?.trim().to_ascii_lowercase();
+    match mime.as_str() {
+        "image/jpeg" | "image/jpg" => Some("image/jpeg".to_string()),
+        "image/png" => Some("image/png".to_string()),
+        "image/svg+xml" => Some("image/svg+xml".to_string()),
+        _ => None,
+    }
+}
+
+fn aspect_ratio(value: &str) -> Option<f64> {
+    let (w, h) = value.split_once(':')?;
+    let w = w.trim().parse::<f64>().ok()?;
+    let h = h.trim().parse::<f64>().ok()?;
+    if w > 0.0 && h > 0.0 {
+        Some(w / h)
+    } else {
+        None
+    }
+}

--- a/src-tauri/src/converters/slide_assets.rs
+++ b/src-tauri/src/converters/slide_assets.rs
@@ -44,12 +44,7 @@ struct CandidateAsset {
 pub async fn resolve_stock_slide_asset(
     intent: StockSlideAssetIntent,
 ) -> Result<Option<ResolvedStockSlideAsset>, String> {
-    let source_preference = intent
-        .source_preference
-        .as_deref()
-        .unwrap_or("auto")
-        .to_ascii_lowercase();
-    if source_preference == "none" || source_preference == "generated" {
+    if !allows_stock_lookup(&intent) {
         return Ok(None);
     }
     let query = stock_query(&intent);
@@ -92,6 +87,14 @@ pub async fn resolve_stock_slide_asset(
     }
 
     Ok(None)
+}
+
+fn allows_stock_lookup(intent: &StockSlideAssetIntent) -> bool {
+    !intent
+        .source_preference
+        .as_deref()
+        .unwrap_or("auto")
+        .eq_ignore_ascii_case("none")
 }
 
 fn stock_query(intent: &StockSlideAssetIntent) -> String {
@@ -384,5 +387,35 @@ fn aspect_ratio(value: &str) -> Option<f64> {
         Some(w / h)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn intent(source_preference: Option<&str>) -> StockSlideAssetIntent {
+        StockSlideAssetIntent {
+            title: "AI adoption conditions".to_string(),
+            role: "support".to_string(),
+            query: Some("workplace collaboration training".to_string()),
+            entity: None,
+            aspect: Some("16:9".to_string()),
+            source_preference: source_preference.map(str::to_string),
+            license_strictness: Some("presentation".to_string()),
+        }
+    }
+
+    #[test]
+    fn generated_preference_still_allows_forced_stock_lookup() {
+        let item = intent(Some("generated"));
+
+        assert!(allows_stock_lookup(&item));
+        assert_eq!(stock_query(&item), "workplace collaboration training");
+    }
+
+    #[test]
+    fn none_preference_blocks_stock_lookup() {
+        assert!(!allows_stock_lookup(&intent(Some("none"))));
     }
 }

--- a/src-tauri/src/converters/speaker_dedup.rs
+++ b/src-tauri/src/converters/speaker_dedup.rs
@@ -27,9 +27,8 @@ use std::collections::HashMap;
 /// 메타 / 손편집 마크다운은 false. (commands.rs::has_any_timestamp 와 동일.)
 fn has_any_timestamp(text: &str) -> bool {
     static TS_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
-    let re = TS_RE.get_or_init(|| {
-        Regex::new(r"\[\d{1,2}:\d{2}(?::\d{2})?\]").expect("regex compile")
-    });
+    let re =
+        TS_RE.get_or_init(|| Regex::new(r"\[\d{1,2}:\d{2}(?::\d{2})?\]").expect("regex compile"));
     re.is_match(text)
 }
 
@@ -263,9 +262,7 @@ fn extract_speaker_samples(text: &str) -> Vec<SpeakerSample> {
         let mut matched_rest: &str = "";
         for p in &header_patterns {
             if let Some(caps) = p.captures(line) {
-                matched_label = caps
-                    .name("label")
-                    .map(|m| m.as_str().trim().to_string());
+                matched_label = caps.name("label").map(|m| m.as_str().trim().to_string());
                 matched_rest = caps.name("rest").map(|m| m.as_str()).unwrap_or("");
                 break;
             }
@@ -470,7 +467,9 @@ mod tests {
         let s = extract_speaker_samples(text);
         let labels: Vec<&str> = s.iter().map(|s| s.label.as_str()).collect();
         assert_eq!(labels, vec!["화자A", "화자B"]);
-        assert!(!labels.iter().any(|l| *l == "일시" || *l == "참석자" || *l == "장소"));
+        assert!(!labels
+            .iter()
+            .any(|l| *l == "일시" || *l == "참석자" || *l == "장소"));
     }
 
     /// Codex follow-up — extract and apply_rename must use the same

--- a/src-tauri/src/converters/templates.rs
+++ b/src-tauri/src/converters/templates.rs
@@ -96,7 +96,10 @@ fn read_template(path: &Path, source: TemplateSource) -> ConverterResult<Option<
         info: TemplateInfo {
             id,
             name,
-            description: fm.get("description").map(|s| s.trim().to_string()).unwrap_or_default(),
+            description: fm
+                .get("description")
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default(),
             source,
             path: path.to_path_buf(),
         },
@@ -127,7 +130,11 @@ fn list_from_dir(dir: &Path, source: TemplateSource) -> Vec<LoadedTemplate> {
     let mut out = Vec::new();
     for entry in read.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()).map(|s| s.to_lowercase()) != Some("md".into())
+        if path
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_lowercase())
+            != Some("md".into())
         {
             continue;
         }
@@ -164,8 +171,9 @@ pub fn get_template(app: &AppHandle, id_or_path: &str) -> ConverterResult<Loaded
     // 절대/상대 경로
     if id_or_path.contains('/') || id_or_path.contains('\\') {
         let path = PathBuf::from(id_or_path);
-        let t = read_template(&path, TemplateSource::User)?
-            .ok_or_else(|| ConverterError::Template(format!("템플릿을 읽을 수 없습니다: {}", id_or_path)))?;
+        let t = read_template(&path, TemplateSource::User)?.ok_or_else(|| {
+            ConverterError::Template(format!("템플릿을 읽을 수 없습니다: {}", id_or_path))
+        })?;
         return Ok(t);
     }
 
@@ -212,8 +220,16 @@ pub fn save_user_template(filename: &str, content: &str) -> ConverterResult<Temp
     }
     let parsed = parse_frontmatter(content)
         .ok_or_else(|| ConverterError::Template("템플릿에 frontmatter 가 없습니다.".into()))?;
-    if parsed.0.get("name").map(|s| s.trim()).unwrap_or("").is_empty() {
-        return Err(ConverterError::Template("frontmatter 에 name 필드가 필요합니다.".into()));
+    if parsed
+        .0
+        .get("name")
+        .map(|s| s.trim())
+        .unwrap_or("")
+        .is_empty()
+    {
+        return Err(ConverterError::Template(
+            "frontmatter 에 name 필드가 필요합니다.".into(),
+        ));
     }
 
     let target = user_dir()?.join(format!("{}.md", base));

--- a/src-tauri/src/converters/vad.rs
+++ b/src-tauri/src/converters/vad.rs
@@ -8,10 +8,10 @@
 //!   3) post-processing (threshold + min duration + pad + merge)
 //!   4) ffmpeg concat demuxer 로 speech 구간만 이어붙인 mp3 + 매핑 테이블
 
+use super::audio_splitter::ffmpeg_path;
 use crate::converters::error::{ConverterError, ConverterResult};
 use crate::converters::progress::{fmt_duration, ProgressEmitter};
 use ndarray::{Array, Array1, Array3};
-use super::audio_splitter::ffmpeg_path;
 use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::value::TensorRef;
 use std::path::{Path, PathBuf};
@@ -88,14 +88,13 @@ pub fn run_vad(
         &probs,
         PostProcessConfig {
             threshold: opts.threshold,
-            min_speech_samples: ((opts.min_speech_duration_ms as f32 / 1000.0)
-                * SAMPLE_RATE as f32) as usize,
+            min_speech_samples: ((opts.min_speech_duration_ms as f32 / 1000.0) * SAMPLE_RATE as f32)
+                as usize,
             min_silence_samples: ((opts.min_silence_duration_ms as f32 / 1000.0)
                 * SAMPLE_RATE as f32) as usize,
-            speech_pad_samples: ((opts.speech_pad_ms as f32 / 1000.0)
-                * SAMPLE_RATE as f32) as usize,
-            merge_gap_samples: ((opts.merge_gap_ms as f32 / 1000.0)
-                * SAMPLE_RATE as f32) as usize,
+            speech_pad_samples: ((opts.speech_pad_ms as f32 / 1000.0) * SAMPLE_RATE as f32)
+                as usize,
+            merge_gap_samples: ((opts.merge_gap_ms as f32 / 1000.0) * SAMPLE_RATE as f32) as usize,
             total_samples: pcm.len(),
         },
     ))
@@ -275,7 +274,17 @@ pub async fn decode_to_16k_pcm(input: &Path) -> ConverterResult<Vec<i16>> {
         .ok_or_else(|| ConverterError::Vad("non-UTF8 path".into()))?;
     let output = Command::new(ffmpeg_path()?)
         .args([
-            "-i", in_str, "-ac", "1", "-ar", "16000", "-f", "s16le", "-loglevel", "error", "-",
+            "-i",
+            in_str,
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-f",
+            "s16le",
+            "-loglevel",
+            "error",
+            "-",
         ])
         .output()
         .await
@@ -335,7 +344,10 @@ pub async fn trim_silence(
     // 임시 작업 디렉토리 — OS temp dir 사용 (input 폴더가 read-only 인 경우 대비).
     // tempfile 사용 안 함 (Drop 시 자동 삭제하지만 우리는 trim_result 가 work_dir 보유 후
     // cleanup_trimmed() 에서 명시 삭제)
-    let work_dir = std::env::temp_dir().join(format!("markmind_vad_trim_{}", uuid::Uuid::new_v4().simple()));
+    let work_dir = std::env::temp_dir().join(format!(
+        "markmind_vad_trim_{}",
+        uuid::Uuid::new_v4().simple()
+    ));
     tokio::fs::create_dir_all(&work_dir).await?;
 
     // 1) PCM 디코드
@@ -557,8 +569,18 @@ mod tests {
         // 원본 [0-10] 화자 + [20-30] 무음 + [30-40] 화자
         // trimmed [0-10] [10-20]  ← 무음 10초 제거
         let map = vec![
-            SegmentMap { trimmed_start: 0.0, trimmed_end: 10.0, original_start: 0.0, original_end: 10.0 },
-            SegmentMap { trimmed_start: 10.0, trimmed_end: 20.0, original_start: 30.0, original_end: 40.0 },
+            SegmentMap {
+                trimmed_start: 0.0,
+                trimmed_end: 10.0,
+                original_start: 0.0,
+                original_end: 10.0,
+            },
+            SegmentMap {
+                trimmed_start: 10.0,
+                trimmed_end: 20.0,
+                original_start: 30.0,
+                original_end: 40.0,
+            },
         ];
         // trimmed 5초 = 원본 5초
         assert_eq!(trimmed_to_original(5.0, &map), 5.0);
@@ -572,8 +594,10 @@ mod tests {
     #[test]
     fn test_trimmed_to_original_clamp() {
         let map = vec![SegmentMap {
-            trimmed_start: 0.0, trimmed_end: 10.0,
-            original_start: 0.0, original_end: 10.0,
+            trimmed_start: 0.0,
+            trimmed_end: 10.0,
+            original_start: 0.0,
+            original_end: 10.0,
         }];
         // 범위 초과 → 마지막 original_end 로 clamp
         assert_eq!(trimmed_to_original(15.0, &map), 10.0);

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeSet;
+use std::process::Command;
+
+fn parse_atsutil_font_families(stdout: &str) -> Vec<String> {
+    let mut in_families = false;
+    let mut families = BTreeSet::new();
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.ends_with("Fonts:") {
+            in_families = false;
+            continue;
+        }
+        if trimmed.ends_with("Families:") {
+            in_families = true;
+            continue;
+        }
+        if !in_families || trimmed.starts_with('.') {
+            continue;
+        }
+        families.insert(trimmed.to_string());
+    }
+
+    families.into_iter().collect()
+}
+
+#[tauri::command]
+pub async fn list_installed_font_families() -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let output = Command::new("atsutil")
+            .args(["fonts", "-list"])
+            .output()
+            .map_err(|e| format!("폰트 목록을 가져오지 못했습니다: {}", e))?;
+        if !output.status.success() {
+            return Err(format!(
+                "폰트 목록 명령 실패: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        Ok(parse_atsutil_font_families(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    })
+    .await
+    .map_err(|e| format!("폰트 목록 작업 실패: {}", e))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_atsutil_font_families;
+
+    #[test]
+    fn parses_family_section_only() {
+        let raw = r#"
+System Fonts:
+    ArialMT
+    Helvetica
+System Families:
+    Arial
+    .SF Compact
+    Helvetica Neue
+    Apple SD Gothic Neo
+"#;
+        assert_eq!(
+            parse_atsutil_font_families(raw),
+            vec!["Apple SD Gothic Neo", "Arial", "Helvetica Neue"]
+        );
+    }
+}

--- a/src-tauri/src/gdrive/api.rs
+++ b/src-tauri/src/gdrive/api.rs
@@ -42,7 +42,10 @@ struct ListResponse {
 ///
 /// `max_results`: 가져올 최대 파일 수 (None = 무제한, 끝까지 follow `nextPageToken`).
 /// API 호출 1회당 page_size=100 (Drive max). 1000개 가져오려면 10번 호출.
-pub async fn list_files(query: Option<&str>, max_results: Option<u32>) -> GDriveResult<Vec<DriveFile>> {
+pub async fn list_files(
+    query: Option<&str>,
+    max_results: Option<u32>,
+) -> GDriveResult<Vec<DriveFile>> {
     const PAGE_SIZE: u32 = 100; // Drive API max
     const SAFETY_LIMIT: u32 = 10_000; // 무한 loop 방어
 
@@ -73,7 +76,10 @@ pub async fn list_files(query: Option<&str>, max_results: Option<u32>) -> GDrive
         if !res.status().is_success() {
             let status = res.status();
             let body = res.text().await.unwrap_or_default();
-            return Err(GDriveError::Api(format!("list_files ({}): {}", status, body)));
+            return Err(GDriveError::Api(format!(
+                "list_files ({}): {}",
+                status, body
+            )));
         }
         let parsed: ListResponse = res.json().await?;
         all.extend(parsed.files);

--- a/src-tauri/src/gdrive/auth.rs
+++ b/src-tauri/src/gdrive/auth.rs
@@ -79,8 +79,8 @@ pub struct ConnectResult {
 /// OAuth flow 시작 → refresh_token + access_token 획득 후 저장.
 /// 반환값: 연결된 사용자 email.
 pub async fn connect() -> GDriveResult<ConnectResult> {
-    let (client_id, client_secret) = storage::get_client_credentials()?
-        .ok_or(GDriveError::NotConfigured)?;
+    let (client_id, client_secret) =
+        storage::get_client_credentials()?.ok_or(GDriveError::NotConfigured)?;
 
     // 1. loopback server 시작 (random port)
     let server = Server::http("127.0.0.1:0")
@@ -123,12 +123,19 @@ pub async fn connect() -> GDriveResult<ConnectResult> {
     }
 
     // 7. code → token 교환
-    let token = exchange_code(&code, &code_verifier, &redirect_uri, &client_id, &client_secret).await?;
+    let token = exchange_code(
+        &code,
+        &code_verifier,
+        &redirect_uri,
+        &client_id,
+        &client_secret,
+    )
+    .await?;
 
     // 8. refresh_token 확보 (없으면 에러 — access_type=offline + prompt=consent 이면 항상 옴)
-    let refresh = token
-        .refresh_token
-        .ok_or_else(|| GDriveError::OAuth("refresh_token 없음 (이미 동의한 적 있는 계정?)".into()))?;
+    let refresh = token.refresh_token.ok_or_else(|| {
+        GDriveError::OAuth("refresh_token 없음 (이미 동의한 적 있는 계정?)".into())
+    })?;
 
     // 9. access_token 메모리 캐시 (Keychain 무관)
     let now = now_secs();
@@ -154,8 +161,8 @@ pub async fn connect() -> GDriveResult<ConnectResult> {
 
 /// 캐시된 access_token 이 유효하면 반환. 만료/없으면 refresh_token 으로 갱신.
 pub async fn get_or_refresh_access_token() -> GDriveResult<String> {
-    let (client_id, client_secret) = storage::get_client_credentials()?
-        .ok_or(GDriveError::NotConfigured)?;
+    let (client_id, client_secret) =
+        storage::get_client_credentials()?.ok_or(GDriveError::NotConfigured)?;
 
     let now = now_secs();
 
@@ -167,8 +174,7 @@ pub async fn get_or_refresh_access_token() -> GDriveResult<String> {
     }
 
     // 2. refresh_token 으로 갱신
-    let refresh = storage::get_refresh_token()?
-        .ok_or(GDriveError::NotAuthenticated)?;
+    let refresh = storage::get_refresh_token()?.ok_or(GDriveError::NotAuthenticated)?;
     let token = refresh_access_token(&refresh, &client_id, &client_secret).await?;
 
     storage::set_cached_access(AccessTokenCache {
@@ -325,11 +331,10 @@ fn respond_html(request: tiny_http::Request, html: &str) -> std::io::Result<()> 
     let body = html.as_bytes();
     let response = Response::new(
         tiny_http::StatusCode(200),
-        vec![tiny_http::Header::from_bytes(
-            &b"Content-Type"[..],
-            &b"text/html; charset=utf-8"[..],
-        )
-        .unwrap()],
+        vec![
+            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+                .unwrap(),
+        ],
         Cursor::new(body.to_vec()),
         Some(body.len()),
         None,

--- a/src-tauri/src/lan_server.rs
+++ b/src-tauri/src/lan_server.rs
@@ -235,7 +235,11 @@ async fn list_files(State(ctx): State<Ctx>) -> Result<Json<ListResp>, StatusCode
         });
     }
     // 최근 수정 우선(모바일에서 방금 본 문서 찾기 쉽게).
-    files.sort_by(|a, b| b.modified.cmp(&a.modified).then_with(|| a.path.cmp(&b.path)));
+    files.sort_by(|a, b| {
+        b.modified
+            .cmp(&a.modified)
+            .then_with(|| a.path.cmp(&b.path))
+    });
     Ok(Json(ListResp {
         root: ctx.root.to_string_lossy().to_string(),
         files,
@@ -401,7 +405,10 @@ fn build_router(ctx: Ctx) -> Router {
 /// 서버를 `0.0.0.0:LAN_PORT` 에 bind 하고 spawn. bind 실패(포트 사용 중 등)는
 /// 동기로 즉시 Err 반환(사용자에게 표시). 성공 시 LanInfo(LAN IP + 포트).
 pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, String> {
-    let mut guard = state.inner.lock().map_err(|_| "상태 lock 실패".to_string())?;
+    let mut guard = state
+        .inner
+        .lock()
+        .map_err(|_| "상태 lock 실패".to_string())?;
     if guard.is_some() {
         return Err("이미 연결되어 있습니다 (먼저 Disconnect)".into());
     }
@@ -477,7 +484,10 @@ pub fn start(state: &LanState, root: String, token: String) -> Result<LanInfo, S
 
 /// 서버 graceful shutdown(이미 꺼져 있으면 no-op).
 pub fn stop(state: &LanState) -> Result<(), String> {
-    let mut guard = state.inner.lock().map_err(|_| "상태 lock 실패".to_string())?;
+    let mut guard = state
+        .inner
+        .lock()
+        .map_err(|_| "상태 lock 실패".to_string())?;
     if let Some(srv) = guard.take() {
         let _ = srv.shutdown.send(());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -356,6 +356,7 @@ pub fn run() {
             converters::commands::generate_image_openai,
             converters::commands::generate_image_codex,
             converters::commands::generate_image_grok,
+            converters::slide_assets::resolve_stock_slide_asset,
             converters::commands::extract_speakers,
             converters::commands::rename_speakers,
             converters::commands::merge_md_files,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,12 @@
-use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use std::collections::HashMap;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 mod converters;
 mod export_pptx;
+mod fonts;
 mod gdrive;
 mod lan_server;
 mod mcp;
@@ -129,8 +130,15 @@ pub(crate) fn create_content_window(
 /// pending(store_pending(win-*, path))을 못 받고 "main"(없으면 null)을 가져가
 /// **빈 창**이 됐다. `window.label()` 로 자기 것을 가져오게 고침.
 #[tauri::command]
-fn get_pending_file(window: tauri::Window, state: tauri::State<'_, PendingFiles>) -> Option<String> {
-    state.0.lock().ok().and_then(|mut m| m.remove(window.label()))
+fn get_pending_file(
+    window: tauri::Window,
+    state: tauri::State<'_, PendingFiles>,
+) -> Option<String> {
+    state
+        .0
+        .lock()
+        .ok()
+        .and_then(|mut m| m.remove(window.label()))
 }
 
 /// 프론트(각 윈도우)가 자기 문서 상태를 MCP 공유 상태에 동기화.
@@ -176,7 +184,6 @@ fn mcp_apply_edit_result(
     );
 }
 
-
 /// PendingFiles HashMap 에 label → path 저장. 비async 헬퍼 — borrow checker 의
 /// async fn 안 MutexGuard 수명 추론 이슈 회피.
 fn store_pending_file(app: &tauri::AppHandle, label: &str, path: &str) {
@@ -192,7 +199,11 @@ async fn open_new_window(app: tauri::AppHandle, file_path: Option<String>) -> Re
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis();
-    let label = format!("win-{}-{}", timestamp, WIN_SEQ.fetch_add(1, Ordering::Relaxed));
+    let label = format!(
+        "win-{}-{}",
+        timestamp,
+        WIN_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
 
     // path 가 있으면 PendingFiles 에 저장 — URL 에는 file 쿼리 안 넣음 (길이/인코딩 회피)
     if let Some(ref path) = file_path {
@@ -239,7 +250,11 @@ fn spawn_window_for_file(app: &tauri::AppHandle, path: &str) {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis();
-    let label = format!("win-{}-{}", timestamp, WIN_SEQ.fetch_add(1, Ordering::Relaxed));
+    let label = format!(
+        "win-{}-{}",
+        timestamp,
+        WIN_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
 
     store_pending_file(app, &label, path);
 
@@ -331,6 +346,7 @@ pub fn run() {
             converters::commands::run_notes_job,
             converters::commands::get_conversions_dir,
             converters::commands::generate_slides_llm,
+            converters::commands::generate_slide_markdown_draft,
             converters::commands::ai_generate_claude,
             converters::commands::ai_generate_codex,
             converters::commands::ai_generate_gemini_agy,
@@ -359,6 +375,8 @@ pub fn run() {
             print_pdf::export_pdf,
             // PPTX export — 프론트 PptxGenJS ArrayBuffer → fs::write (이슈 #6)
             export_pptx::save_pptx,
+            // Installed fonts — PPTX 서체 선택용
+            fonts::list_installed_font_families,
             // 사용자 메모리(#15) — AI system prompt 주입용 "내 정보"
             user_memory::read_user_memory,
             user_memory::write_user_memory,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -20,8 +20,7 @@ use rmcp::{
     handler::server::router::tool::ToolRouter,
     handler::server::wrapper::{Json, Parameters},
     model::{Icon, Implementation, ServerCapabilities, ServerInfo},
-    schemars, tool, tool_handler, tool_router,
-    ServerHandler,
+    schemars, tool, tool_handler, tool_router, ServerHandler,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
@@ -98,13 +97,17 @@ impl McpState {
     /// tool 이 15s/300s timeout 까지 매달리지 않게 한다(닫힌 창은 영영 ack 불가).
     pub fn cancel_window_pending(&self, label: &str) {
         let cancelled: Vec<oneshot::Sender<EditOutcome>> = {
-            let Ok(mut m) = self.pending.lock() else { return };
+            let Ok(mut m) = self.pending.lock() else {
+                return;
+            };
             let ids: Vec<String> = m
                 .iter()
                 .filter(|(_, (l, _))| l == label)
                 .map(|(id, _)| id.clone())
                 .collect();
-            ids.into_iter().filter_map(|id| m.remove(&id).map(|(_, tx)| tx)).collect()
+            ids.into_iter()
+                .filter_map(|id| m.remove(&id).map(|(_, tx)| tx))
+                .collect()
         };
         for tx in cancelled {
             let _ = tx.send(EditOutcome {
@@ -131,7 +134,10 @@ impl McpState {
 
     /// 채널 회수(timeout 정리 등). 있으면 제거 후 반환.
     pub fn take_pending(&self, id: &str) -> Option<oneshot::Sender<EditOutcome>> {
-        self.pending.lock().ok().and_then(|mut m| m.remove(id).map(|(_, tx)| tx))
+        self.pending
+            .lock()
+            .ok()
+            .and_then(|mut m| m.remove(id).map(|(_, tx)| tx))
     }
 
     /// 프론트 ack — 해당 요청 채널을 결과로 resolve.
@@ -225,7 +231,12 @@ struct EditResultOut {
 
 impl EditResultOut {
     fn fail(msg: impl Into<String>) -> Self {
-        Self { applied: false, window_label: None, char_count: None, message: msg.into() }
+        Self {
+            applied: false,
+            window_label: None,
+            char_count: None,
+            message: msg.into(),
+        }
     }
 }
 
@@ -429,7 +440,8 @@ impl MarkMindServer {
                         applied: true,
                         window_label: Some(label),
                         char_count: o.char_count,
-                        message: "applied to editor (unsaved — call save_document to persist)".into(),
+                        message: "applied to editor (unsaved — call save_document to persist)"
+                            .into(),
                     }
                 } else {
                     EditResultOut::fail(o.error.unwrap_or_else(|| "edit rejected".into()))
@@ -509,20 +521,29 @@ impl MarkMindServer {
     )]
     async fn get_outline(&self, Parameters(args): Parameters<GetDocArgs>) -> Json<OutlineResult> {
         let Some(label) = resolve_target(&self.state, &args.window_label, &args.file_path) else {
-            return Json(OutlineResult { window_label: None, outline: vec![] });
+            return Json(OutlineResult {
+                window_label: None,
+                outline: vec![],
+            });
         };
         let docs = self.state.docs.lock().unwrap_or_else(|e| e.into_inner());
         let outline = docs
             .get(&label)
             .map(|d| parse_outline(&d.content))
             .unwrap_or_default();
-        Json(OutlineResult { window_label: Some(label), outline })
+        Json(OutlineResult {
+            window_label: Some(label),
+            outline,
+        })
     }
 
     #[tool(
         description = "Open a NEW MarkMind editor window containing `content` (e.g. a draft you composed). `file_name` sets the title (defaults to Untitled.md). The document is unsaved with no file path until the user saves it. Returns the new window_label."
     )]
-    async fn create_document(&self, Parameters(args): Parameters<CreateDocArgs>) -> Json<EditResultOut> {
+    async fn create_document(
+        &self,
+        Parameters(args): Parameters<CreateDocArgs>,
+    ) -> Json<EditResultOut> {
         if args.content.len() > MAX_CONTENT_BYTES {
             return Json(EditResultOut::fail(format!(
                 "content 가 너무 큽니다 (상한 {}MB)",
@@ -535,10 +556,9 @@ impl MarkMindServer {
         let content = args.content;
         // create_content_window 은 build 결과를 blocking recv 로 회수하므로
         // async 실행기를 막지 않도록 spawn_blocking 으로 분리.
-        let result = tokio::task::spawn_blocking(move || {
-            crate::create_content_window(&app, content, name)
-        })
-        .await;
+        let result =
+            tokio::task::spawn_blocking(move || crate::create_content_window(&app, content, name))
+                .await;
         match result {
             Ok(Ok(label)) => Json(EditResultOut {
                 applied: true,
@@ -554,7 +574,10 @@ impl MarkMindServer {
     #[tool(
         description = "Propose replacing a document's full content with `new_content`, shown to the user as a diff preview that they must ACCEPT or REJECT (target by window_label, file_path, or current focused window). Nothing changes unless the user accepts. Use this (instead of set_document_content) when the user should review a large or risky rewrite. Waits up to 5 minutes for the user's decision."
     )]
-    async fn propose_edit(&self, Parameters(args): Parameters<ProposeEditArgs>) -> Json<EditResultOut> {
+    async fn propose_edit(
+        &self,
+        Parameters(args): Parameters<ProposeEditArgs>,
+    ) -> Json<EditResultOut> {
         if args.new_content.len() > MAX_CONTENT_BYTES {
             return Json(EditResultOut::fail(format!(
                 "new_content 가 너무 큽니다 (상한 {}MB)",
@@ -562,7 +585,9 @@ impl MarkMindServer {
             )));
         }
         let Some(label) = resolve_target(&self.state, &args.window_label, &args.file_path) else {
-            return Json(EditResultOut::fail("일치하는 열린 문서가 없습니다 (list_open_documents 로 확인)"));
+            return Json(EditResultOut::fail(
+                "일치하는 열린 문서가 없습니다 (list_open_documents 로 확인)",
+            ));
         };
         let payload = EditRequest {
             request_id: uuid::Uuid::new_v4().to_string(),
@@ -571,7 +596,10 @@ impl MarkMindServer {
             description: args.description,
         };
         // 사용자 결정 대기 — 5분 timeout.
-        Json(self.dispatch_edit(label, "mcp-propose-edit", 300, payload).await)
+        Json(
+            self.dispatch_edit(label, "mcp-propose-edit", 300, payload)
+                .await,
+        )
     }
 }
 
@@ -640,7 +668,12 @@ pub async fn start(state: Arc<McpState>, app: AppHandle, shutdown: CancellationT
         .with_cancellation_token(shutdown.clone());
 
     let service = StreamableHttpService::new(
-        move || Ok(MarkMindServer::new(factory_state.clone(), factory_app.clone())),
+        move || {
+            Ok(MarkMindServer::new(
+                factory_state.clone(),
+                factory_app.clone(),
+            ))
+        },
         Arc::new(LocalSessionManager::default()),
         config,
     );
@@ -687,7 +720,10 @@ mod outline_tests {
     #[test]
     fn skips_headings_inside_fence() {
         let md = "# Real\n```\n# fake in code\n```\n## After";
-        assert_eq!(items(md), vec![(1, "Real".into(), 1), (2, "After".into(), 5)]);
+        assert_eq!(
+            items(md),
+            vec![(1, "Real".into(), 1), (2, "After".into(), 5)]
+        );
     }
 
     #[test]
@@ -714,9 +750,15 @@ mod outline_tests {
     #[test]
     fn indented_4spaces_is_code_not_fence_or_heading() {
         // 4칸 들여쓴 ``` 는 펜스 아님(코드블록) → 토글 안 됨, 뒤 헤딩 정상 인식
-        assert_eq!(items("text\n    ```\n# heading"), vec![(1, "heading".into(), 3)]);
+        assert_eq!(
+            items("text\n    ```\n# heading"),
+            vec![(1, "heading".into(), 3)]
+        );
         // 4칸 들여쓴 # 는 헤딩 아님
-        assert_eq!(items("    # not heading\n# yes"), vec![(1, "yes".into(), 2)]);
+        assert_eq!(
+            items("    # not heading\n# yes"),
+            vec![(1, "yes".into(), 2)]
+        );
     }
 
     #[test]

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -219,7 +219,10 @@ mod tests {
         }
         let loaded = load();
         assert_eq!(loaded.gemini, Some("test-key".to_string()));
-        assert_eq!(loaded.gdrive_user_email, Some("test@example.com".to_string()));
+        assert_eq!(
+            loaded.gdrive_user_email,
+            Some("test@example.com".to_string())
+        );
         if let Ok(mut g) = CACHE.lock() {
             *g = None;
         }

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -68,13 +68,21 @@ static CLAUDE_TOKEN_CACHE: Mutex<Option<CachedClaudeToken>> = Mutex::new(None);
 struct ClaudeOauth {
     #[serde(rename = "accessToken")]
     access_token: String,
-    #[serde(rename = "refreshToken", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "refreshToken",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     refresh_token: Option<String>,
     /// unix epoch milliseconds.
     #[serde(rename = "expiresAt", default, skip_serializing_if = "Option::is_none")]
     expires_at: Option<u64>,
     /// 구독 종류 — "max" / "pro" 등 (플랜 표시용, write-back 보존).
-    #[serde(rename = "subscriptionType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "subscriptionType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     subscription_type: Option<String>,
     #[serde(flatten)]
     extra: serde_json::Map<String, serde_json::Value>,
@@ -139,7 +147,9 @@ fn claude_logged_in() -> bool {
 
 fn write_claude_creds(creds: &ClaudeCreds) -> Result<(), String> {
     let json = serde_json::to_string(creds).map_err(|e| e.to_string())?;
-    claude_entry()?.set_password(&json).map_err(|e| e.to_string())
+    claude_entry()?
+        .set_password(&json)
+        .map_err(|e| e.to_string())
 }
 
 /// 유효한 Claude 구독 access token 반환. 만료 임박이면 refresh 후 keychain write-back.
@@ -168,11 +178,9 @@ pub async fn claude_access_token() -> Result<String, String> {
     let token = if !needs_refresh {
         creds.claude_ai_oauth.access_token.clone()
     } else {
-        let refresh_token = creds
-            .claude_ai_oauth
-            .refresh_token
-            .clone()
-            .ok_or_else(|| "refresh token 이 없습니다. 터미널에서 `claude` 재로그인하세요.".to_string())?;
+        let refresh_token = creds.claude_ai_oauth.refresh_token.clone().ok_or_else(|| {
+            "refresh token 이 없습니다. 터미널에서 `claude` 재로그인하세요.".to_string()
+        })?;
         let refreshed = refresh_claude_token(&refresh_token).await?;
         creds.claude_ai_oauth.access_token = refreshed.access_token.clone();
         if refreshed.refresh_token.is_some() {
@@ -241,8 +249,9 @@ pub struct CodexTokens {
 /// (만료 refresh 는 미구현 — 만료 시 `codex` 재로그인 안내. 후속 Phase 에서 추가.)
 pub fn read_codex_tokens() -> Result<CodexTokens, String> {
     let path = codex_auth_path().ok_or_else(|| "HOME 환경변수를 찾을 수 없습니다.".to_string())?;
-    let raw = std::fs::read_to_string(&path)
-        .map_err(|_| "Codex 로그인을 찾을 수 없습니다. 터미널에서 `codex` 로 로그인하세요.".to_string())?;
+    let raw = std::fs::read_to_string(&path).map_err(|_| {
+        "Codex 로그인을 찾을 수 없습니다. 터미널에서 `codex` 로 로그인하세요.".to_string()
+    })?;
     let v: serde_json::Value =
         serde_json::from_str(&raw).map_err(|e| format!("auth.json 파싱 실패: {e}"))?;
     let tokens = v
@@ -311,7 +320,9 @@ pub fn read_grok_token() -> Result<String, String> {
         .values()
         .find_map(|scope| scope.get("key").and_then(|k| k.as_str()))
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| "Grok access token 이 없습니다. `grok login` 재로그인이 필요합니다.".to_string())?;
+        .ok_or_else(|| {
+            "Grok access token 이 없습니다. `grok login` 재로그인이 필요합니다.".to_string()
+        })?;
     Ok(token.to_string())
 }
 

--- a/src-tauri/src/subscription_auth.rs
+++ b/src-tauri/src/subscription_auth.rs
@@ -38,6 +38,7 @@ pub enum AICompany {
     Gemini,
     Claude,
     Openai,
+    Grok,
 }
 
 // ─── Claude Code (Anthropic) ────────────────────────────────────────────────

--- a/src/App.css
+++ b/src/App.css
@@ -3553,9 +3553,13 @@ code.hljs {
 }
 .pptx-busy-card {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 12px;
-  padding: 16px 22px;
+  width: min(460px, calc(100vw - 48px));
+  max-height: min(560px, calc(100vh - 80px));
+  overflow: hidden;
+  padding: 16px;
   border-radius: 12px;
   background: var(--bg-elevated, #ffffff);
   color: var(--text-primary, #1a1a2e);
@@ -3563,8 +3567,27 @@ code.hljs {
   font-size: 14px;
   font-weight: 500;
 }
+.pptx-busy-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.pptx-busy-head span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .pptx-busy-card .spinning {
   color: #2f6fed;
+}
+.pptx-busy-card .convert-progress {
+  margin: 0;
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  background: var(--bg-secondary);
 }
 
 /* ─── 뷰어 설정: 본문 폰트 / 읽기 폭 (Settings → 뷰어 설정 탭) ─── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { GanttView } from './components/GanttView';
 import { SlideshowView } from './components/SlideshowView';
 import { getSlideshowSettings, setSlideshowSettings as persistSlideshowSettings, type SlideshowSettings } from './lib/slideSplit';
 import { applySlideDesignOptions, BUILTIN_SLIDE_THEMES, DEFAULT_SLIDE_THEME, getSlideTheme, type SlideExportOptions } from './lib/slideTheme';
+import { clampMarkdownSlideDraft, PPTX_MAX_SLIDES } from './lib/slideLimits';
 import { markMindPptxDesignRulesText } from './lib/pptxDesignSystem';
 import { Toolbar, EditableFileName, PaneHeader, ViewMode, PaneView, EDITABLE_VIEWS, isPaneView } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
@@ -528,8 +529,18 @@ function App() {
           extraInstructions: pptxOptions.extraInstructions?.trim() || null,
         },
       });
-      const next = draft.trim();
+      let next = draft.trim();
       if (!next) throw new Error('AI가 빈 슬라이드 초안을 반환했습니다.');
+      const clamped = clampMarkdownSlideDraft(next);
+      if (clamped.clamped) {
+        next = clamped.markdown;
+        pushPptxProgressStep(
+          jobId,
+          '✅ 슬라이드 장수 제한 적용',
+          `${clamped.originalCount}장 → ${PPTX_MAX_SLIDES}장`,
+          'slide-draft-limit',
+        );
+      }
       pushPptxProgressStep(jobId, '📝 문서에 반영 중...', undefined, 'slide-draft-apply');
       updateContent(withSlideDraftMarker(next, nextDraftVersion));
       setViewMode('slideshow');
@@ -557,13 +568,21 @@ function App() {
     const sel = getAIModelSelection();
     const baseName = (fileName || 'Untitled').replace(/\.(md|markdown|mdx|txt)$/i, '');
     try {
-      const [{ save }, { invoke }, { markdownToSlides, slidesFromLlmJson }, { buildPptx }, { normalizeSlidesForPptx, validateSlideDeck, summarizeSlideIssues }] =
+      const [
+        { save },
+        { invoke },
+        { markdownToSlides, slideDeckFromLlmJson },
+        { buildPptx },
+        { normalizeSlidesForPptx, validateSlideDeck, summarizeSlideIssues },
+        { resolveSlideAssets },
+      ] =
         await Promise.all([
           import('@tauri-apps/plugin-dialog'),
           import('@tauri-apps/api/core'),
           import('./lib/markdownToSlides'),
           import('./lib/buildPptx'),
           import('./lib/slideValidation'),
+          import('./services/slideAssets'),
         ]);
       const path = await save({
         defaultPath: `${baseName}.pptx`,
@@ -595,9 +614,10 @@ function App() {
         },
       });
       pushPptxProgressStep(jobId, '🔍 AI 응답 검증 중...', undefined, 'pptx-validate-response');
-      let slides = slidesFromLlmJson(raw);
+      const aiDeck = slideDeckFromLlmJson(raw);
+      let slides = aiDeck?.slides ?? null;
       console.log(
-        `[export_pptx] AI(${sel.company}/${sel.auth}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장`,
+        `[export_pptx] AI(${sel.company}/${sel.auth}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장, master ${aiDeck?.masterSpec ? 'yes' : 'no'}`,
       );
       if (!slides || slides.length === 0) {
         // 조용한 폴백 금지 — 사용자에게 알리고 원문 로깅(메모리: silent fallback 함정)
@@ -608,12 +628,27 @@ function App() {
 
       pushPptxProgressStep(jobId, '📊 슬라이드 레이아웃 검증 중...', undefined, 'pptx-layout-qa');
       slides = normalizeSlidesForPptx(slides);
+      if (slides.length > PPTX_MAX_SLIDES) {
+        const originalCount = slides.length;
+        slides = slides.slice(0, PPTX_MAX_SLIDES);
+        pushPptxProgressStep(
+          jobId,
+          '✅ 슬라이드 장수 제한 적용',
+          `${originalCount}장 → ${PPTX_MAX_SLIDES}장`,
+          'pptx-slide-limit',
+        );
+      }
       const report = validateSlideDeck(slides);
       const issueSummary = summarizeSlideIssues(report);
       if (issueSummary) console.warn('[export_pptx] slide QA warnings:\n' + issueSummary);
       const baseDir = filePath ? filePath.replace(/\/[^/]*$/, '') : undefined;
+      const assetResult = await resolveSlideAssets(slides, pptxOptions, {
+        theme: slideTheme,
+        onProgress: (step, detail, stepId) => pushPptxProgressStep(jobId, step, detail, stepId),
+      });
+      slides = assetResult.slides;
       pushPptxProgressStep(jobId, '💾 PPTX 파일 생성 중...', undefined, 'pptx-build');
-      const buf = await buildPptx(slides, { title: baseName, baseDir, theme: slideTheme });
+      const buf = await buildPptx(slides, { title: baseName, baseDir, theme: slideTheme, masterSpec: aiDeck?.masterSpec });
       pushPptxProgressStep(jobId, '💾 PPTX 저장 중...', undefined, 'pptx-save');
       await invoke('save_pptx', { path, data: Array.from(new Uint8Array(buf)) });
       pushPptxProgressStep(jobId, '✅ 파워포인트 생성 완료');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { GanttView } from './components/GanttView';
 import { SlideshowView } from './components/SlideshowView';
 import { getSlideshowSettings, setSlideshowSettings as persistSlideshowSettings, type SlideshowSettings } from './lib/slideSplit';
 import { applySlideDesignOptions, BUILTIN_SLIDE_THEMES, DEFAULT_SLIDE_THEME, getSlideTheme, type SlideExportOptions } from './lib/slideTheme';
-import { clampMarkdownSlideDraft, PPTX_MAX_SLIDES } from './lib/slideLimits';
+import { clampMarkdownSlideDraft, PPTX_MAX_SLIDES, slideImagePolicyMode } from './lib/slideLimits';
 import { markMindPptxDesignRulesText } from './lib/pptxDesignSystem';
 import { Toolbar, EditableFileName, PaneHeader, ViewMode, PaneView, EDITABLE_VIEWS, isPaneView } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
@@ -572,7 +572,7 @@ function App() {
       const [
         { save },
         { invoke },
-        { markdownToSlides, slideDeckFromLlmJson },
+        { markdownToSlides, preserveSourceImagesForPptx, slideDeckFromLlmJson },
         { buildPptx },
         { normalizeSlidesForPptx, validateSlideDeck, summarizeSlideIssues },
         { resolveSlideAssets },
@@ -628,6 +628,9 @@ function App() {
         console.warn('[export_pptx] AI 응답 파싱 실패, 규칙 기반 안전망으로 폴백. 원문:', raw);
         alert('AI 응답을 해석하지 못해 기본 레이아웃으로 저장합니다.\n(개발자 콘솔에 원문이 로깅되었습니다)');
         slides = markdownToSlides(content);
+      }
+      if (slideImagePolicyMode(pptxOptions.imagePolicy) === 'sourceOnly') {
+        slides = preserveSourceImagesForPptx(slides, markdownToSlides(content));
       }
 
       pushPptxProgressStep(jobId, '📊 슬라이드 레이아웃 검증 중...', undefined, 'pptx-layout-qa');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { AIMode, DiffChunk } from './types/ai';
 import { Editor, EditorHandle } from './components/Editor';
 import { McpProposalView } from './components/McpProposalView';
 import { generateDiff, isAuthError } from './services/aiService';
-import { getAIModelSelection, AI_CATALOG } from './services/aiModelConfig';
+import { getAIModelSelection } from './services/aiModelConfig';
 import { setValidationStatus } from './services/apiValidation';
 import { Preview, type PreviewHandle } from './components/Preview';
 import { MindmapView } from './components/MindmapView';
@@ -13,6 +13,8 @@ import { SearchBar } from './components/SearchBar';
 import { GanttView } from './components/GanttView';
 import { SlideshowView } from './components/SlideshowView';
 import { getSlideshowSettings, setSlideshowSettings as persistSlideshowSettings, type SlideshowSettings } from './lib/slideSplit';
+import { applySlideDesignOptions, BUILTIN_SLIDE_THEMES, DEFAULT_SLIDE_THEME, getSlideTheme, type SlideExportOptions } from './lib/slideTheme';
+import { markMindPptxDesignRulesText } from './lib/pptxDesignSystem';
 import { Toolbar, EditableFileName, PaneHeader, ViewMode, PaneView, EDITABLE_VIEWS, isPaneView } from './components/Toolbar';
 import { StatusBar } from './components/StatusBar';
 import { OutlinePanel } from './components/OutlinePanel';
@@ -35,6 +37,8 @@ import { useRecentFiles } from './hooks/useRecentFiles';
 import { useAI } from './hooks/useAI';
 import { useAuth } from './hooks/useAuth';
 import { useConverter } from './hooks/useConverter';
+import { ProgressPanel } from './components/convert/ProgressPanel';
+import type { JobState, ProgressStep } from './types/converter';
 import { isTauri } from './services/platform';
 import { useNativeMenu } from './hooks/useNativeMenu';
 import { getCallbackPath } from './services/knowaiAuth';
@@ -63,6 +67,34 @@ function countMcpChanges(chunks: DiffChunk[]): number {
     inChange = changed;
   }
   return n;
+}
+
+const SLIDE_REVIEW_MARKER_RE =
+  /^\s*>\s*(?:코멘트|검토 필요|확인 필요|추가 정보 필요|정보 필요|TODO|NEEDS REVIEW|CHECK)\s*:/im;
+const SLIDE_DRAFT_MARKER_RE = /^\s*(?:<!--\s*markmind:slide-draft\b[^>]*-->|&lt;!--\s*markmind:slide-draft\b.*?--&gt;)\s*$/im;
+const SLIDE_DRAFT_MARKER_VERSION_RE =
+  /^\s*(?:<!--\s*markmind:slide-draft\s+v(\d+)\b[^>]*-->|&lt;!--\s*markmind:slide-draft\s+v(\d+)\b.*?--&gt;)\s*$/im;
+
+function getSlideDraftMarkerVersion(markdown: string): number {
+  const match = markdown.match(SLIDE_DRAFT_MARKER_VERSION_RE);
+  if (!match) return SLIDE_DRAFT_MARKER_RE.test(markdown) ? 1 : 0;
+  const raw = match[1] ?? match[2];
+  const version = Number.parseInt(raw, 10);
+  return Number.isFinite(version) && version > 0 ? version : 1;
+}
+
+function withSlideDraftMarker(markdown: string, version: number): string {
+  const body = markdown.replace(SLIDE_DRAFT_MARKER_RE, '').trim();
+  const safeVersion = Math.max(1, Math.floor(version));
+  return `<!-- markmind:slide-draft v${safeVersion} -->\n${body}\n`;
+}
+
+function createSlideProgressJobId(): string {
+  const uuid =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID().replace(/-/g, '')
+      : Math.random().toString(36).slice(2) + Date.now().toString(36);
+  return `slide-${uuid}`;
 }
 
 function App() {
@@ -355,6 +387,22 @@ function App() {
   const [pptxAiReady, setPptxAiReady] = useState(false);
   // PPTX 내보내기 진행 표시(특히 AI 레이아웃은 LLM 호출로 수초~수십초 소요).
   const [pptxBusy, setPptxBusy] = useState<string | null>(null);
+  const [pptxProgress, setPptxProgress] = useState<JobState>({ phase: 'idle', steps: [] });
+  const pptxProgressJobIdRef = useRef<string | null>(null);
+  const [pptxOptions, setPptxOptions] = useState<SlideExportOptions>({
+    themeId: DEFAULT_SLIDE_THEME.id,
+    language: '',
+    draftPurpose: 'executive briefing for decision makers',
+    draftStructure: 'choose the strongest narrative structure',
+    draftDepth: 'standard',
+    draftRevisionMode: 'apply detailed instructions while preserving the current slide order and count unless explicitly requested',
+    draftReviewMode: 'add frequent reviewer comments and questions for gaps, assumptions, and choices',
+    designLayout: 'auto content-aware layout mix with strong variety',
+    visualDensity: 'balanced text density with readable slide capacity',
+    imagePolicy: 'add image intent only when it materially improves the slide',
+    fontPreference: 'free multilingual sans font pairing',
+    marginPreference: 'theme default balanced margins',
+  });
   useEffect(() => {
     if (!isTauri()) return;
     (async () => {
@@ -374,19 +422,148 @@ function App() {
     })();
   }, [settingsVisible]);
 
-  // PPTX 내보내기 — LLM 스마트 레이아웃 단일 경로(디폴트). 규칙 기반은 LLM 응답을
-  // 전혀 해석 못한 catastrophic 실패 시의 안전망으로만 내부 사용한다.
+  useEffect(() => {
+    if (!isTauri()) return;
+    let mounted = true;
+    let unlisten: (() => void) | null = null;
+
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen<ProgressStep>('converter-progress', (event) => {
+          if (!mounted) return;
+          const step = event.payload;
+          if (!pptxProgressJobIdRef.current || step.jobId !== pptxProgressJobIdRef.current) return;
+          setPptxProgress((prev) => {
+            if (step.stepId) {
+              const idx = prev.steps.findIndex((s) => s.stepId === step.stepId);
+              if (idx >= 0) {
+                const next = [...prev.steps];
+                next[idx] = step;
+                return { ...prev, steps: next };
+              }
+            }
+            return { ...prev, steps: [...prev.steps, step] };
+          });
+        });
+      } catch (err) {
+        console.warn('[slide_progress] event listener 실패:', err);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      if (unlisten) Promise.resolve(unlisten()).catch(() => { /* listener race */ });
+    };
+  }, []);
+
+  const beginPptxProgress = useCallback((label: string): string => {
+    const jobId = createSlideProgressJobId();
+    pptxProgressJobIdRef.current = jobId;
+    setPptxBusy(label);
+    setPptxProgress({ phase: 'running', steps: [] });
+    return jobId;
+  }, []);
+
+  const pushPptxProgressStep = useCallback((jobId: string, step: string, detail?: string, stepId?: string) => {
+    if (pptxProgressJobIdRef.current !== jobId) return;
+    const progressStep: ProgressStep = { jobId, step, detail, stepId };
+    setPptxProgress((prev) => {
+      if (stepId) {
+        const idx = prev.steps.findIndex((s) => s.stepId === stepId);
+        if (idx >= 0) {
+          const next = [...prev.steps];
+          next[idx] = progressStep;
+          return { ...prev, steps: next };
+        }
+      }
+      return { ...prev, steps: [...prev.steps, progressStep] };
+    });
+  }, []);
+
+  const clearPptxProgress = useCallback(() => {
+    pptxProgressJobIdRef.current = null;
+    setPptxBusy(null);
+    setPptxProgress({ phase: 'idle', steps: [] });
+  }, []);
+
+  // 슬라이드 초안 생성 — AI는 편집 가능한 Markdown 페이지만 생성한다.
+  const handleGenerateSlideDraft = useCallback(async () => {
+    if (content.trim().length === 0) return;
+    const isExistingDraft = SLIDE_DRAFT_MARKER_RE.test(content);
+    const nextDraftVersion = isExistingDraft ? getSlideDraftMarkerVersion(content) + 1 : 1;
+    const ok = await confirmAction(
+      isDirty
+        ? isExistingDraft
+          ? '수정 지시를 반영해 현재 슬라이드 초안을 수정합니다. 저장하지 않은 변경도 수정 결과로 바뀝니다. 계속할까요?'
+          : 'AI 슬라이드 초안이 현재 문서를 교체합니다. 저장하지 않은 변경도 초안으로 바뀝니다. 계속할까요?'
+        : isExistingDraft
+          ? '수정 지시를 반영해 현재 슬라이드 초안을 수정합니다. 계속할까요?'
+          : 'AI 슬라이드 초안이 현재 문서를 교체합니다. 계속할까요?',
+      { title: isExistingDraft ? '슬라이드 초안 수정' : '슬라이드 초안 만들기', kind: 'warning' },
+    );
+    if (!ok) return;
+
+    const sel = getAIModelSelection();
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      const jobId = beginPptxProgress(isExistingDraft ? '슬라이드 초안 수정 중…' : '슬라이드 초안 생성 중…');
+
+      const draft = await invoke<string>('generate_slide_markdown_draft', {
+        markdown: content,
+        company: sel.company,
+        auth: sel.auth,
+        model: sel.model,
+        jobId,
+        options: {
+          audience: pptxOptions.audience?.trim() || null,
+          tone: pptxOptions.tone?.trim() || null,
+          language: pptxOptions.language?.trim() || null,
+          slideCountHint: pptxOptions.slideCountHint?.trim() || null,
+          draftPurpose: pptxOptions.draftPurpose?.trim() || null,
+          draftStructure: pptxOptions.draftStructure?.trim() || null,
+          draftDepth: pptxOptions.draftDepth?.trim() || null,
+          draftRevisionMode: pptxOptions.draftRevisionMode?.trim() || null,
+          draftReviewMode: pptxOptions.draftReviewMode?.trim() || null,
+          extraInstructions: pptxOptions.extraInstructions?.trim() || null,
+        },
+      });
+      const next = draft.trim();
+      if (!next) throw new Error('AI가 빈 슬라이드 초안을 반환했습니다.');
+      pushPptxProgressStep(jobId, '📝 문서에 반영 중...', undefined, 'slide-draft-apply');
+      updateContent(withSlideDraftMarker(next, nextDraftVersion));
+      setViewMode('slideshow');
+      pushPptxProgressStep(jobId, '✅ 슬라이드 초안 반영 완료');
+    } catch (err) {
+      console.error('[slide_draft] failed:', err);
+      alert(`슬라이드 초안 생성에 실패했습니다.\n${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      clearPptxProgress();
+    }
+  }, [beginPptxProgress, clearPptxProgress, content, isDirty, pptxOptions, pushPptxProgressStep, updateContent]);
+
+  // 고급: PPTX 내보내기 — AI가 최종 슬라이드 JSON까지 만든다.
   const handleExportPptx = useCallback(async () => {
+    if (content.trim().length === 0) return;
+    if (SLIDE_REVIEW_MARKER_RE.test(content)) {
+      const ok = await confirmAction(
+        '코멘트나 검토 필요 표시가 남아 있습니다. 그래도 파워포인트를 생성할까요?',
+        { title: '코멘트 확인', kind: 'warning' },
+      );
+      if (!ok) return;
+    }
+
     // 모든 AI 작업은 전역 회사/인증/모델 선택(Settings > 기본 설정)을 따른다.
     const sel = getAIModelSelection();
     const baseName = (fileName || 'Untitled').replace(/\.(md|markdown|mdx|txt)$/i, '');
     try {
-      const [{ save }, { invoke }, { markdownToSlides, slidesFromLlmJson }, { buildPptx }] =
+      const [{ save }, { invoke }, { markdownToSlides, slidesFromLlmJson }, { buildPptx }, { normalizeSlidesForPptx, validateSlideDeck, summarizeSlideIssues }] =
         await Promise.all([
           import('@tauri-apps/plugin-dialog'),
           import('@tauri-apps/api/core'),
           import('./lib/markdownToSlides'),
           import('./lib/buildPptx'),
+          import('./lib/slideValidation'),
         ]);
       const path = await save({
         defaultPath: `${baseName}.pptx`,
@@ -395,15 +572,29 @@ function App() {
       });
       if (!path) return; // 사용자 취소
 
-      const companyLabel = AI_CATALOG[sel.company].label;
-      setPptxBusy(`AI 슬라이드 생성 중… (${companyLabel})`);
+      const jobId = beginPptxProgress('파워포인트 생성 중…');
+      const slideTheme = applySlideDesignOptions(getSlideTheme(pptxOptions.themeId), pptxOptions);
 
       const raw = await invoke<string>('generate_slides_llm', {
         markdown: content,
         company: sel.company,
         auth: sel.auth,
         model: sel.model,
+        jobId,
+        options: {
+          designLayout: pptxOptions.designLayout?.trim() || null,
+          visualDensity: pptxOptions.visualDensity?.trim() || null,
+          imagePolicy: pptxOptions.imagePolicy?.trim() || null,
+          fontPreference: pptxOptions.fontPreference?.trim() || null,
+          fontFamily: pptxOptions.fontFamily?.trim() || null,
+          marginPreference: pptxOptions.marginPreference?.trim() || null,
+          extraInstructions: pptxOptions.extraInstructions?.trim() || null,
+          designRules: markMindPptxDesignRulesText(pptxOptions.designRules),
+          themeName: slideTheme.name,
+          themeRules: slideTheme.rules,
+        },
       });
+      pushPptxProgressStep(jobId, '🔍 AI 응답 검증 중...', undefined, 'pptx-validate-response');
       let slides = slidesFromLlmJson(raw);
       console.log(
         `[export_pptx] AI(${sel.company}/${sel.auth}) 응답 ${raw.length}자 → 슬라이드 ${slides?.length ?? 0}장`,
@@ -415,17 +606,24 @@ function App() {
         slides = markdownToSlides(content);
       }
 
-      setPptxBusy('PPTX 파일 생성 중…');
+      pushPptxProgressStep(jobId, '📊 슬라이드 레이아웃 검증 중...', undefined, 'pptx-layout-qa');
+      slides = normalizeSlidesForPptx(slides);
+      const report = validateSlideDeck(slides);
+      const issueSummary = summarizeSlideIssues(report);
+      if (issueSummary) console.warn('[export_pptx] slide QA warnings:\n' + issueSummary);
       const baseDir = filePath ? filePath.replace(/\/[^/]*$/, '') : undefined;
-      const buf = await buildPptx(slides, { title: baseName, baseDir });
+      pushPptxProgressStep(jobId, '💾 PPTX 파일 생성 중...', undefined, 'pptx-build');
+      const buf = await buildPptx(slides, { title: baseName, baseDir, theme: slideTheme });
+      pushPptxProgressStep(jobId, '💾 PPTX 저장 중...', undefined, 'pptx-save');
       await invoke('save_pptx', { path, data: Array.from(new Uint8Array(buf)) });
+      pushPptxProgressStep(jobId, '✅ 파워포인트 생성 완료');
     } catch (err) {
       console.error('[export_pptx] failed:', err);
       alert(`PPTX 내보내기에 실패했습니다.\n${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      setPptxBusy(null);
+      clearPptxProgress();
     }
-  }, [fileName, filePath, content]);
+  }, [beginPptxProgress, clearPptxProgress, content, fileName, filePath, pptxOptions, pushPptxProgressStep]);
 
   // AI
   const ai = useAI();
@@ -1909,9 +2107,13 @@ function App() {
           ocrDropped={ocrDropped}
           onConsumeAudioDropped={() => setAudioDropped(null)}
           onConsumeOcrDropped={() => setOcrDropped(null)}
+          onGenerateSlideDraft={handleGenerateSlideDraft}
           onExportPptx={handleExportPptx}
           pptxAvailable={pptxAiReady}
           pptxBusy={pptxBusy}
+          pptxThemes={BUILTIN_SLIDE_THEMES}
+          pptxOptions={pptxOptions}
+          onPptxOptionsChange={setPptxOptions}
           onInsertGeneratedImage={handleInsertGeneratedImage}
           imageGenRefDropped={imageGenRefDropped}
           onConsumeImageGenRefDropped={() => setImageGenRefDropped(null)}
@@ -1926,8 +2128,16 @@ function App() {
       {pptxBusy && (
         <div className="pptx-busy-overlay" role="status" aria-live="polite">
           <div className="pptx-busy-card">
-            <Loader2 size={20} className="spinning" />
-            <span>{pptxBusy}</span>
+            <div className="pptx-busy-head">
+              <Loader2 size={20} className="spinning" />
+              <span>{pptxBusy}</span>
+            </div>
+            <ProgressPanel
+              state={pptxProgress}
+              newestFirst={false}
+              showStepProgress={false}
+              modelDetailMode="running"
+            />
           </div>
         </div>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -630,7 +630,7 @@ function App() {
         slides = markdownToSlides(content);
       }
       if (slideImagePolicyMode(pptxOptions.imagePolicy) === 'sourceOnly') {
-        slides = preserveSourceImagesForPptx(slides, markdownToSlides(content));
+        slides = preserveSourceImagesForPptx(slides, content);
       }
 
       pushPptxProgressStep(jobId, '📊 슬라이드 레이아웃 검증 중...', undefined, 'pptx-layout-qa');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -401,6 +401,7 @@ function App() {
     designLayout: 'auto content-aware layout mix with strong variety',
     visualDensity: 'balanced text density with readable slide capacity',
     imagePolicy: 'add image intent only when it materially improves the slide',
+    imageSourceMode: 'auto choose stock photos, logos, or generated images based on slide intent',
     fontPreference: 'free multilingual sans font pairing',
     marginPreference: 'theme default balanced margins',
   });
@@ -575,6 +576,7 @@ function App() {
         { buildPptx },
         { normalizeSlidesForPptx, validateSlideDeck, summarizeSlideIssues },
         { resolveSlideAssets },
+        { saveSlideAssetBundle },
       ] =
         await Promise.all([
           import('@tauri-apps/plugin-dialog'),
@@ -583,6 +585,7 @@ function App() {
           import('./lib/buildPptx'),
           import('./lib/slideValidation'),
           import('./services/slideAssets'),
+          import('./services/slideAssetBundle'),
         ]);
       const path = await save({
         defaultPath: `${baseName}.pptx`,
@@ -604,6 +607,7 @@ function App() {
           designLayout: pptxOptions.designLayout?.trim() || null,
           visualDensity: pptxOptions.visualDensity?.trim() || null,
           imagePolicy: pptxOptions.imagePolicy?.trim() || null,
+          imageSourceMode: pptxOptions.imageSourceMode?.trim() || null,
           fontPreference: pptxOptions.fontPreference?.trim() || null,
           fontFamily: pptxOptions.fontFamily?.trim() || null,
           marginPreference: pptxOptions.marginPreference?.trim() || null,
@@ -651,6 +655,18 @@ function App() {
       const buf = await buildPptx(slides, { title: baseName, baseDir, theme: slideTheme, masterSpec: aiDeck?.masterSpec });
       pushPptxProgressStep(jobId, '💾 PPTX 저장 중...', undefined, 'pptx-save');
       await invoke('save_pptx', { path, data: Array.from(new Uint8Array(buf)) });
+      if (assetResult.assets.length > 0) {
+        pushPptxProgressStep(jobId, '💾 이미지 에셋 저장 중...', `${assetResult.assets.length}개`, 'pptx-assets-save');
+        try {
+          const savedAssets = await saveSlideAssetBundle(path, assetResult.assets);
+          if (savedAssets) {
+            pushPptxProgressStep(jobId, '✅ 이미지 에셋 저장 완료', `${savedAssets.saved}개`, 'pptx-assets-save');
+          }
+        } catch (assetErr) {
+          console.warn('[export_pptx] 이미지 에셋 저장 실패:', assetErr);
+          pushPptxProgressStep(jobId, '⚠️ 이미지 에셋 저장 실패', undefined, 'pptx-assets-save');
+        }
+      }
       pushPptxProgressStep(jobId, '✅ 파워포인트 생성 완료');
     } catch (err) {
       console.error('[export_pptx] failed:', err);

--- a/src/components/AIPanel.css
+++ b/src/components/AIPanel.css
@@ -354,6 +354,10 @@
     grid-template-columns: repeat(3, 1fr);
 }
 
+.ai-pptx-segments.five {
+    grid-template-columns: repeat(5, 1fr);
+}
+
 .ai-pptx-segments button:hover {
     border-color: var(--accent, #3b82f6);
     color: var(--text-primary);

--- a/src/components/AIPanel.css
+++ b/src/components/AIPanel.css
@@ -100,13 +100,13 @@
     margin: 0;
 }
 
-/* ─── 슬라이드 만들기(pptx) 모드 ──────────────────── */
+/* ─── 슬라이드 생성(pptx) 모드 ──────────────────── */
 
 .ai-pptx-mode {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    padding: 12px 0;
+    gap: 10px;
+    padding: 4px 8px 8px;
 }
 
 .ai-pptx-desc {
@@ -120,6 +120,249 @@
     font-size: 12px;
     color: var(--text-tertiary);
     text-align: center;
+}
+
+.ai-pptx-config {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.ai-pptx-task-group {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 2px 0;
+}
+
+.ai-pptx-task {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.ai-pptx-task:hover {
+    color: var(--text-primary);
+}
+
+.ai-pptx-task.active {
+    color: var(--accent, #3b82f6);
+}
+
+.ai-pptx-task input[type="radio"] {
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    accent-color: var(--accent, #3b82f6);
+}
+
+.ai-pptx-task strong {
+    display: block;
+    font-size: 12px;
+    line-height: 1.25;
+    font-weight: 600;
+}
+
+.ai-pptx-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+}
+
+.ai-pptx-actions .ai-btn {
+    justify-content: center;
+    width: 100%;
+}
+
+.ai-pptx-authline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    color: var(--text-tertiary);
+    font-size: 11px;
+}
+
+.ai-pptx-authline button {
+    border: none;
+    background: transparent;
+    color: var(--accent, #3b82f6);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.ai-pptx-field {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+
+.ai-pptx-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+}
+
+.ai-pptx-field input,
+.ai-pptx-field textarea,
+.ai-pptx-field select {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 12px;
+    padding: 7px 8px;
+}
+
+.ai-pptx-field textarea {
+    resize: vertical;
+}
+
+.ai-pptx-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.ai-pptx-theme-trigger {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 16px 1fr 14px;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    padding: 8px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.ai-pptx-theme-trigger strong,
+.ai-pptx-theme-option strong {
+    display: block;
+    font-size: 12px;
+    line-height: 1.25;
+}
+
+.ai-pptx-theme-trigger small,
+.ai-pptx-theme-option small {
+    display: block;
+    margin-top: 2px;
+    font-size: 10px;
+    line-height: 1.25;
+    color: var(--text-tertiary);
+}
+
+.ai-pptx-theme-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+.ai-pptx-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+}
+
+.ai-pptx-theme-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px;
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
+}
+
+.ai-pptx-theme-option {
+    display: grid;
+    grid-template-columns: 42px 1fr;
+    align-items: center;
+    gap: 8px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-primary);
+    padding: 7px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.ai-pptx-theme-option:hover,
+.ai-pptx-theme-option.active {
+    background: var(--bg-hover);
+}
+
+.ai-pptx-palette {
+    display: grid;
+    grid-template-columns: repeat(2, 16px);
+    gap: 2px;
+}
+
+.ai-pptx-palette i {
+    width: 16px;
+    height: 12px;
+    border-radius: 2px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.ai-pptx-segments {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4px;
+}
+
+.ai-pptx-segments button {
+    min-height: 30px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.ai-pptx-segments.three {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.ai-pptx-segments button:hover {
+    border-color: var(--accent, #3b82f6);
+    color: var(--text-primary);
+}
+
+.ai-pptx-segments button.active {
+    border-color: var(--accent, #3b82f6);
+    color: var(--accent, #3b82f6);
+    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
 }
 
 /* ─── Mode Selection ─────────────────────────────── */
@@ -844,4 +1087,3 @@
     padding-top: 4px;
     border-top: 1px solid var(--border-primary);
 }
-

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -1,16 +1,16 @@
 /**
  * AI 에이전트 사이드 패널 — 단일 진입점(#60).
- * 8 모드: 음성 인식(stt) / 이미지 인식(ocr) / 회의록 작성 / 슬라이드 만들기(pptx) /
+ * 8 모드: 음성 인식(stt) / 이미지 인식(ocr) / 회의록 작성 / 슬라이드 생성(pptx) /
  *         문서 개선 / 문법 교정 / 번역 / 마인드맵 정리(structurize).
  *  - stt/ocr: 기존 AudioTab/OcrTab 을 그대로 mount(변환 로직 재사용). converter 자체 키 사용.
- *  - pptx: 현재 문서를 AI 레이아웃으로 .pptx 내보내기(onExportPptx).
+ *  - pptx: 슬라이드 Markdown 초안 생성 + AI 기반 PPTX 생성.
  *  - 나머지: prompt → onRun → InlineDiff / ResultCard.
  * 모드별 옵션 UI 는 sub-component 로 분리 (ModeSelector, LlmSelector, NotesOptions, NotesResultCard).
  */
 
 import { useState, useRef, useEffect, ReactNode } from 'react';
 import { AIMode, TranslateLanguage, AITurn } from '../types/ai';
-import { Sparkles, Send, Loader2, AlertCircle, Presentation } from 'lucide-react';
+import { Sparkles, Send, Loader2, AlertCircle } from 'lucide-react';
 import type { NotesJobResult, TemplateInfo } from '../types/converter';
 import type { useConverter } from '../hooks/useConverter';
 import type { DroppedFile } from './convert/types';
@@ -27,8 +27,10 @@ import { ConversationTimeline } from './ai/ConversationTimeline';
 import { NotesOptions } from './ai/NotesOptions';
 import { NotesResultCard } from './ai/NotesResultCard';
 import { ImageGenPanel } from './ai/ImageGenPanel';
+import { SlideExportPanel } from './ai/SlideExportPanel';
 import { AudioTab } from './convert/AudioTab';
 import { OcrTab } from './convert/OcrTab';
+import type { SlideExportOptions, SlideTheme } from '../lib/slideTheme';
 import './AIPanel.css';
 
 interface AIPanelProps {
@@ -61,10 +63,14 @@ interface AIPanelProps {
     ocrDropped: DroppedFile | null;
     onConsumeAudioDropped: () => void;
     onConsumeOcrDropped: () => void;
-    // ── 슬라이드 만들기(pptx) ──
+    // ── 슬라이드 생성(pptx) ──
+    onGenerateSlideDraft: () => void;
     onExportPptx: () => void;
     pptxAvailable: boolean;
     pptxBusy: string | null;
+    pptxThemes: SlideTheme[];
+    pptxOptions: SlideExportOptions;
+    onPptxOptionsChange: (next: SlideExportOptions) => void;
     // ── 이미지 생성(image-gen) ──
     onInsertGeneratedImage: (dataUrl: string) => void;
     imageGenRefDropped: string[] | null;
@@ -117,9 +123,13 @@ export function AIPanel({
     ocrDropped,
     onConsumeAudioDropped,
     onConsumeOcrDropped,
+    onGenerateSlideDraft,
     onExportPptx,
     pptxAvailable,
     pptxBusy,
+    pptxThemes,
+    pptxOptions,
+    onPptxOptionsChange,
     onInsertGeneratedImage,
     imageGenRefDropped,
     onConsumeImageGenRefDropped,
@@ -228,30 +238,17 @@ export function AIPanel({
 
             {isPptxMode && (
                 <div className="ai-pptx-mode">
-                    {!pptxAvailable ? (
-                        <div className="ai-no-key">
-                            <AlertCircle size={20} />
-                            <p>슬라이드 레이아웃에 Claude 또는 Gemini 키가 필요합니다</p>
-                            <button className="ai-btn primary" onClick={onShowSettings}>
-                                설정하기
-                            </button>
-                        </div>
-                    ) : (
-                        <>
-                            <div className="ai-prompt-actions">
-                                <button
-                                    className="ai-btn primary"
-                                    onClick={onExportPptx}
-                                    disabled={!!pptxBusy || content.trim().length === 0}
-                                    title="슬라이드 만들기"
-                                >
-                                    {pptxBusy ? <Loader2 size={14} className="spinning" /> : <Presentation size={14} />}
-                                    {pptxBusy ? '생성 중...' : '슬라이드 만들기'}
-                                </button>
-                                {pptxBusy && <div className="ai-pptx-busy">{pptxBusy}</div>}
-                            </div>
-                        </>
-                    )}
+                    <SlideExportPanel
+                        content={content}
+                        available={pptxAvailable}
+                        busy={pptxBusy}
+                        themes={pptxThemes}
+                        options={pptxOptions}
+                        onOptionsChange={onPptxOptionsChange}
+                        onGenerateDraft={onGenerateSlideDraft}
+                        onExportDirect={onExportPptx}
+                        onShowSettings={onShowSettings}
+                    />
                 </div>
             )}
 

--- a/src/components/ai/ModeSelector.tsx
+++ b/src/components/ai/ModeSelector.tsx
@@ -1,6 +1,6 @@
 /**
  * AI 에이전트 모드 라디오 그룹 — AIPanel 에서 분리.
- * 순서: 편집(개선/문법/번역) → 이미지 생성 → 변환(음성/이미지 텍스트) → 생성(회의록/슬라이드).
+ * 순서: 편집(개선/문법/번역) → 이미지/슬라이드 생성 → 변환(음성/이미지 텍스트) → 회의록.
  * 'structurize'(마인드맵 정리)는 마인드맵 뷰 상단 버튼으로 이동(#60).
  */
 
@@ -19,10 +19,10 @@ const MODES: { value: AIMode; label: string; Icon: LucideIcon }[] = [
     { value: 'grammar', label: '문법 교정', Icon: SpellCheck },
     { value: 'translate', label: '번역', Icon: Languages },
     { value: 'image-gen', label: '이미지 생성', Icon: ImagePlus },
+    { value: 'pptx', label: '슬라이드 생성', Icon: Presentation },
     { value: 'stt', label: '음성 → 텍스트 변환', Icon: Mic },
     { value: 'ocr', label: '이미지 → 텍스트 변환', Icon: ScanText },
     { value: 'meeting-notes', label: '녹취록 → 회의록 변환', Icon: FileText },
-    { value: 'pptx', label: '슬라이드 만들기', Icon: Presentation },
 ];
 
 export function ModeSelector({ mode, onChange }: ModeSelectorProps) {

--- a/src/components/ai/SlideExportPanel.tsx
+++ b/src/components/ai/SlideExportPanel.tsx
@@ -64,7 +64,7 @@ const PPTX_LAYOUTS = [
 const IMAGE_POLICIES = [
   { value: 'use source images only; do not add new image intent', label: '원문만' },
   { value: 'add image intent only when it materially improves the slide', label: '필요시' },
-  { value: 'actively add visual image intent for cover, section, and concept slides', label: '적극 추가' },
+  { value: 'actively add ambient and supporting visuals to spacious body slides as well as cover and section slides', label: '적극 추가' },
 ];
 
 const MARGIN_OPTIONS = [

--- a/src/components/ai/SlideExportPanel.tsx
+++ b/src/components/ai/SlideExportPanel.tsx
@@ -67,6 +67,14 @@ const IMAGE_POLICIES = [
   { value: 'actively add ambient and supporting visuals to spacious body slides as well as cover and section slides', label: '적극 추가' },
 ];
 
+const IMAGE_SOURCE_MODES = [
+  { value: 'auto choose stock photos, logos, or generated images based on slide intent', label: '자동' },
+  { value: 'prefer stock photos and logos, then generate only when stock fails', label: 'Stock 우선' },
+  { value: 'prefer generated images for concepts and ambient visuals, then use stock for factual subjects', label: '생성 우선' },
+  { value: 'use stock photos and logos only; do not generate images', label: 'Stock만' },
+  { value: 'use generated images only; do not search stock photos or logos', label: '생성만' },
+];
+
 const MARGIN_OPTIONS = [
   { value: 'wide margins with generous whitespace', label: '넓게' },
   { value: 'theme default balanced margins', label: '표준' },
@@ -403,6 +411,22 @@ export function SlideExportPanel({
                   </button>
                 ))}
               </div>
+            </div>
+          </div>
+
+          <div className="ai-pptx-field">
+            <span className="ai-pptx-label">이미지 소스</span>
+            <div className="ai-pptx-segments five">
+              {IMAGE_SOURCE_MODES.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  className={item.value === (options.imageSourceMode ?? 'auto choose stock photos, logos, or generated images based on slide intent') ? 'active' : ''}
+                  onClick={() => patch({ imageSourceMode: item.value })}
+                >
+                  {item.label}
+                </button>
+              ))}
             </div>
           </div>
 

--- a/src/components/ai/SlideExportPanel.tsx
+++ b/src/components/ai/SlideExportPanel.tsx
@@ -1,0 +1,491 @@
+import { useEffect, useState } from 'react';
+import { ChevronDown, FileText, Loader2, Sparkles } from 'lucide-react';
+import type { SlideExportOptions, SlideTheme } from '../../lib/slideTheme';
+import { isTauri } from '../../services/platform';
+
+interface SlideExportPanelProps {
+  content: string;
+  available: boolean;
+  busy: string | null;
+  themes: SlideTheme[];
+  options: SlideExportOptions;
+  onOptionsChange: (next: SlideExportOptions) => void;
+  onGenerateDraft: () => void;
+  onExportDirect: () => void;
+  onShowSettings: () => void;
+}
+
+const LANGUAGES = [
+  { value: '', label: '문서와 동일' },
+  { value: 'ko', label: '한국어' },
+  { value: 'en', label: 'English' },
+  { value: 'ja', label: '日本語' },
+];
+
+const DRAFT_PURPOSES = [
+  { value: 'executive briefing for decision makers', label: '경영 보고' },
+  { value: 'persuasive pitch deck', label: '설득 제안' },
+  { value: 'teaching material', label: '강의 자료' },
+  { value: 'interactive workshop deck', label: '워크숍' },
+];
+
+const DRAFT_STRUCTURES = [
+  { value: 'choose the strongest narrative structure', label: '자동 구성' },
+  { value: 'problem-solution structure', label: '문제-해결' },
+  { value: 'agenda-driven structure', label: '목차형' },
+  { value: 'storyline structure', label: '스토리라인' },
+];
+
+const DRAFT_DEPTHS = [
+  { value: 'concise', label: '간결' },
+  { value: 'standard', label: '표준' },
+  { value: 'detailed', label: '상세' },
+];
+
+const COMMENT_MODES = [
+  { value: 'add frequent reviewer comments and questions for gaps, assumptions, and choices', label: '코멘트 표시' },
+  { value: 'do not add reviewer comments; produce a clean editable draft', label: '코멘트 없음' },
+];
+
+const REVISION_MODES = [
+  { value: 'apply detailed instructions while preserving the current slide order and count unless explicitly requested', label: '지시 반영' },
+  { value: 'strengthen emphasis and sharpen key messages without changing the deck structure', label: '강조' },
+  { value: 'shorten and clean the existing draft while preserving meaning and slide order', label: '간결화' },
+  { value: 'restructure the existing draft when it improves flow while preserving source facts', label: '재구성' },
+];
+
+const PPTX_LAYOUTS = [
+  { value: 'auto content-aware layout mix with strong variety', label: '자동' },
+  { value: 'prefer two-column and comparison layouts for parallel ideas', label: '2열 중심' },
+  { value: 'use comparison, timeline, quote, and stat layouts when they fit', label: '비교/흐름' },
+  { value: 'use clear section divider slides and rhythmic deck pacing', label: '섹션 리듬' },
+];
+
+const IMAGE_POLICIES = [
+  { value: 'use source images only; do not add new image intent', label: '원문만' },
+  { value: 'add image intent only when it materially improves the slide', label: '필요시' },
+  { value: 'actively add visual image intent for cover, section, and concept slides', label: '적극 추가' },
+];
+
+const MARGIN_OPTIONS = [
+  { value: 'wide margins with generous whitespace', label: '넓게' },
+  { value: 'theme default balanced margins', label: '표준' },
+  { value: 'compact margins for information-heavy decks', label: '적게' },
+];
+
+const FALLBACK_FONT_FAMILIES = [
+  'Pretendard',
+  'Apple SD Gothic Neo',
+  'Noto Sans',
+  'Noto Sans Display',
+  'Helvetica Neue',
+  'Arial',
+  'Avenir Next',
+  'Georgia',
+  'Times New Roman',
+  'Menlo',
+];
+
+const DENSITY_OPTIONS = [
+  { value: 'minimal text with strong whitespace and visual hierarchy', label: '저밀도' },
+  { value: 'balanced text density with readable slide capacity', label: '균형' },
+  { value: 'information-dense but still readable slide composition', label: '고밀도' },
+];
+
+type SlideTask = 'draft' | 'pptx';
+
+const SLIDE_DRAFT_MARKER_RE = /^\s*(?:<!--\s*markmind:slide-draft\b[^>]*-->|&lt;!--\s*markmind:slide-draft\b.*?--&gt;)\s*$/im;
+
+export function SlideExportPanel({
+  content,
+  available,
+  busy,
+  themes,
+  options,
+  onOptionsChange,
+  onGenerateDraft,
+  onExportDirect,
+  onShowSettings,
+}: SlideExportPanelProps) {
+  const [themeOpen, setThemeOpen] = useState(false);
+  const [fontFamilies, setFontFamilies] = useState<string[]>([]);
+  const [fontFamiliesLoading, setFontFamiliesLoading] = useState(false);
+  const [task, setTask] = useState<SlideTask>('draft');
+  const selectedTheme = themes.find((t) => t.id === options.themeId) ?? themes[0];
+  const patch = (partial: Partial<SlideExportOptions>) => onOptionsChange({ ...options, ...partial });
+  const empty = content.trim().length === 0;
+  const isDraft = task === 'draft';
+  const isExistingDraft = SLIDE_DRAFT_MARKER_RE.test(content);
+  const draftLabel = isExistingDraft ? '슬라이드 초안 수정' : '슬라이드 초안';
+  const draftButtonLabel = isExistingDraft ? '슬라이드 초안 수정' : '슬라이드 초안 만들기';
+  const draftInstructionLabel = isExistingDraft ? '수정 지시' : '상세 지시';
+  const draftInstructionPlaceholder = isExistingDraft
+    ? '예: 3장의 메시지를 더 강하게, 마지막 장에 실행 계획 추가'
+    : '예: 각 장 끝에 발표자 메모를 넣기';
+  const preferredFonts = FALLBACK_FONT_FAMILIES.filter((font) => fontFamilies.includes(font));
+  const otherFonts = fontFamilies.filter((font) => !FALLBACK_FONT_FAMILIES.includes(font));
+  const fontOptions = Array.from(
+    new Set([
+      ...(options.fontFamily?.trim() ? [options.fontFamily.trim()] : []),
+      ...preferredFonts,
+      ...otherFonts,
+      ...FALLBACK_FONT_FAMILIES,
+    ]),
+  );
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    let cancelled = false;
+    setFontFamiliesLoading(true);
+    import('@tauri-apps/api/core')
+      .then(({ invoke }) => invoke<string[]>('list_installed_font_families'))
+      .then((families) => {
+        if (cancelled) return;
+        setFontFamilies(families.filter((font) => font && !font.startsWith('.')));
+      })
+      .catch((err) => {
+        console.warn('[slide_export] installed font list failed:', err);
+      })
+      .finally(() => {
+        if (!cancelled) setFontFamiliesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="ai-pptx-config">
+      <div className="ai-pptx-task-group" role="radiogroup" aria-label="슬라이드 작업">
+        <label className={`ai-pptx-task${task === 'draft' ? ' active' : ''}`}>
+          <input
+            type="radio"
+            name="slide-task"
+            value="draft"
+            checked={task === 'draft'}
+            onChange={() => setTask('draft')}
+          />
+          <span>
+            <strong>{draftLabel}</strong>
+          </span>
+        </label>
+        <label className={`ai-pptx-task${task === 'pptx' ? ' active' : ''}`}>
+          <input
+            type="radio"
+            name="slide-task"
+            value="pptx"
+            checked={task === 'pptx'}
+            onChange={() => setTask('pptx')}
+          />
+          <span>
+            <strong>파워포인트 생성</strong>
+          </span>
+        </label>
+      </div>
+
+      {!isDraft && (
+        <div className="ai-pptx-field">
+          <span className="ai-pptx-label">테마</span>
+          <button className="ai-pptx-theme-trigger" type="button" onClick={() => setThemeOpen(true)}>
+            <span className="ai-pptx-theme-swatch" style={{ background: `#${selectedTheme.palette.accent}` }} />
+            <span>
+              <strong>{selectedTheme.name}</strong>
+              <small>{selectedTheme.description}</small>
+            </span>
+            <ChevronDown size={14} />
+          </button>
+          {themeOpen && (
+            <>
+              <div className="ai-pptx-backdrop" onClick={() => setThemeOpen(false)} aria-hidden="true" />
+              <div className="ai-pptx-theme-menu">
+                {themes.map((theme) => (
+                  <button
+                    key={theme.id}
+                    type="button"
+                    className={`ai-pptx-theme-option${theme.id === selectedTheme.id ? ' active' : ''}`}
+                    onClick={() => {
+                      patch({ themeId: theme.id });
+                      setThemeOpen(false);
+                    }}
+                  >
+                    <span className="ai-pptx-palette">
+                      <i style={{ background: `#${theme.palette.title}` }} />
+                      <i style={{ background: `#${theme.palette.bg}` }} />
+                      <i style={{ background: `#${theme.palette.accent}` }} />
+                      <i style={{ background: `#${theme.palette.accent2}` }} />
+                    </span>
+                    <span>
+                      <strong>{theme.name}</strong>
+                      <small>{theme.description}</small>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {isDraft ? (
+        <>
+          <div className="ai-pptx-grid">
+            <label className="ai-pptx-field">
+              <span className="ai-pptx-label">대상</span>
+              <input
+                value={options.audience ?? ''}
+                onChange={(e) => patch({ audience: e.target.value })}
+                placeholder="예: 투자자"
+              />
+            </label>
+            <label className="ai-pptx-field">
+              <span className="ai-pptx-label">톤</span>
+              <input
+                value={options.tone ?? ''}
+                onChange={(e) => patch({ tone: e.target.value })}
+                placeholder="예: 설득력 있게"
+              />
+            </label>
+          </div>
+
+          {isExistingDraft ? (
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">수정 방식</span>
+              <div className="ai-pptx-segments">
+                {REVISION_MODES.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={item.value === (options.draftRevisionMode ?? 'apply detailed instructions while preserving the current slide order and count unless explicitly requested') ? 'active' : ''}
+                    onClick={() => patch({ draftRevisionMode: item.value })}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="ai-pptx-grid">
+              <div className="ai-pptx-field">
+                <span className="ai-pptx-label">목적</span>
+                <div className="ai-pptx-segments">
+                  {DRAFT_PURPOSES.map((item) => (
+                    <button
+                      key={item.value}
+                      type="button"
+                      className={item.value === (options.draftPurpose ?? 'executive briefing for decision makers') ? 'active' : ''}
+                      onClick={() => patch({ draftPurpose: item.value })}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="ai-pptx-field">
+                <span className="ai-pptx-label">구성 방식</span>
+                <div className="ai-pptx-segments">
+                  {DRAFT_STRUCTURES.map((item) => (
+                    <button
+                      key={item.value}
+                      type="button"
+                      className={item.value === (options.draftStructure ?? 'choose the strongest narrative structure') ? 'active' : ''}
+                      onClick={() => patch({ draftStructure: item.value })}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="ai-pptx-grid">
+            {!isExistingDraft && (
+              <div className="ai-pptx-field">
+                <span className="ai-pptx-label">상세도</span>
+                <div className="ai-pptx-segments three">
+                  {DRAFT_DEPTHS.map((item) => (
+                    <button
+                      key={item.value}
+                      type="button"
+                      className={item.value === (options.draftDepth ?? 'standard') ? 'active' : ''}
+                      onClick={() => patch({ draftDepth: item.value })}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">코멘트</span>
+              <div className="ai-pptx-segments">
+                {COMMENT_MODES.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={item.value === (options.draftReviewMode ?? 'add frequent reviewer comments and questions for gaps, assumptions, and choices') ? 'active' : ''}
+                    onClick={() => patch({ draftReviewMode: item.value })}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {isExistingDraft && (
+              <label className="ai-pptx-field">
+                <span className="ai-pptx-label">슬라이드 길이</span>
+                <input
+                  value={options.slideCountHint ?? ''}
+                  onChange={(e) => patch({ slideCountHint: e.target.value })}
+                  placeholder="예: 유지, 8장"
+                />
+              </label>
+            )}
+          </div>
+
+          <div className={isExistingDraft ? 'ai-pptx-field' : 'ai-pptx-grid'}>
+            {!isExistingDraft && (
+              <label className="ai-pptx-field">
+                <span className="ai-pptx-label">슬라이드 길이</span>
+                <input
+                  value={options.slideCountHint ?? ''}
+                  onChange={(e) => patch({ slideCountHint: e.target.value })}
+                  placeholder="예: 8-10"
+                />
+              </label>
+            )}
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">언어</span>
+              <div className="ai-pptx-segments">
+                {LANGUAGES.map((lang) => (
+                  <button
+                    key={lang.value}
+                    type="button"
+                    className={lang.value === (options.language ?? '') ? 'active' : ''}
+                    onClick={() => patch({ language: lang.value })}
+                  >
+                    {lang.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="ai-pptx-grid">
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">레이아웃</span>
+              <div className="ai-pptx-segments">
+                {PPTX_LAYOUTS.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={item.value === (options.designLayout ?? 'auto content-aware layout mix with strong variety') ? 'active' : ''}
+                    onClick={() => patch({ designLayout: item.value })}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">이미지</span>
+              <div className="ai-pptx-segments three">
+                {IMAGE_POLICIES.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={item.value === (options.imagePolicy ?? 'add image intent only when it materially improves the slide') ? 'active' : ''}
+                    onClick={() => patch({ imagePolicy: item.value })}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="ai-pptx-grid">
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">여백</span>
+              <div className="ai-pptx-segments three">
+                {MARGIN_OPTIONS.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={item.value === (options.marginPreference ?? 'theme default balanced margins') ? 'active' : ''}
+                    onClick={() => patch({ marginPreference: item.value })}
+                  >
+                    {item.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="ai-pptx-field">
+              <span className="ai-pptx-label">서체</span>
+              <select
+                value={options.fontFamily ?? ''}
+                onChange={(e) => patch({ fontFamily: e.target.value || undefined })}
+                disabled={fontFamiliesLoading && fontOptions.length === 0}
+              >
+                <option value="">테마 기본</option>
+                {fontOptions.map((font) => (
+                  <option key={font} value={font}>
+                    {font}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="ai-pptx-field">
+            <span className="ai-pptx-label">정보 밀도</span>
+            <div className="ai-pptx-segments three">
+              {DENSITY_OPTIONS.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  className={item.value === (options.visualDensity ?? 'balanced text density with readable slide capacity') ? 'active' : ''}
+                  onClick={() => patch({ visualDensity: item.value })}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      <label className="ai-pptx-field">
+        <span className="ai-pptx-label">{isDraft ? draftInstructionLabel : '추가 지시'}</span>
+        <textarea
+          value={options.extraInstructions ?? ''}
+          onChange={(e) => patch({ extraInstructions: e.target.value })}
+          placeholder={isDraft ? draftInstructionPlaceholder : '예: 마지막 장에 실행 계획을 넣기'}
+          rows={isDraft ? 5 : 4}
+        />
+      </label>
+
+      {!available && (
+        <div className="ai-pptx-authline">
+          <span>{isDraft ? 'AI 초안 생성에는 모델 설정이 필요합니다' : '파워포인트 생성에는 모델 설정이 필요합니다'}</span>
+          <button type="button" onClick={onShowSettings}>설정</button>
+        </div>
+      )}
+
+      <div className="ai-pptx-actions">
+        <button
+          className="ai-btn primary"
+          onClick={isDraft ? onGenerateDraft : onExportDirect}
+          disabled={!available || !!busy || empty}
+          title={isDraft ? draftButtonLabel : '파워포인트 생성'}
+        >
+          {busy ? <Loader2 size={14} className="spinning" /> : isDraft ? <Sparkles size={14} /> : <FileText size={14} />}
+          {busy ? '작업 중...' : isDraft ? draftButtonLabel : '파워포인트 생성'}
+        </button>
+      </div>
+      {busy && <div className="ai-pptx-busy">{busy}</div>}
+    </div>
+  );
+}

--- a/src/components/convert/ProgressPanel.tsx
+++ b/src/components/convert/ProgressPanel.tsx
@@ -11,7 +11,7 @@ import { AI_CATALOG, getSelectionDisplay } from '../../services/aiModelConfig';
 import {
     Upload, Clock, AudioLines, CheckCircle2, Binoculars, Notebook, Scissors,
     AlertTriangle, MessagesSquare, FastForward, Combine, Waypoints,
-    HardDriveDownload, Search, BarChart3, FileText, Save, Loader2,
+    HardDriveDownload, Search, BarChart3, FileText, Save, Loader2, Image as ImageIcon,
 } from 'lucide-react';
 
 interface ProgressPanelProps {
@@ -46,6 +46,7 @@ function iconFor(step: string): { icon: ReactNode; text: string } {
         { pattern: /^🔍\s*/, icon: <Search size={14} /> },
         { pattern: /^📊\s*/, icon: <BarChart3 size={14} /> },
         { pattern: /^📑\s*/, icon: <FileText size={14} /> },
+        { pattern: /^🖼️?\s*/, icon: <ImageIcon size={14} /> },
         { pattern: /^💾\s*/, icon: <Save size={14} /> },
         { pattern: /^📡\s*/, icon: <Upload size={14} /> },
         { pattern: /^⏳\s*/, icon: <Loader2 size={14} className="spinning" /> },
@@ -71,6 +72,7 @@ function ModelDetail({ step, mode }: { step: ProgressStep; mode: 'all' | 'runnin
             {display.logo && <img src={display.logo} alt="" className="step-model-logo" />}
             <span className="step-model-label">{display.label}</span>
             {display.sub && <span className="step-model-sub">구독</span>}
+            {step.detail && <span className="step-model-extra">{step.detail}</span>}
         </div>
     );
 }

--- a/src/components/convert/ProgressPanel.tsx
+++ b/src/components/convert/ProgressPanel.tsx
@@ -6,7 +6,8 @@
  */
 
 import { ReactNode } from 'react';
-import { JobState } from '../../types/converter';
+import { JobState, ProgressStep } from '../../types/converter';
+import { AI_CATALOG, getSelectionDisplay } from '../../services/aiModelConfig';
 import {
     Upload, Clock, AudioLines, CheckCircle2, Binoculars, Notebook, Scissors,
     AlertTriangle, MessagesSquare, FastForward, Combine, Waypoints,
@@ -15,6 +16,9 @@ import {
 
 interface ProgressPanelProps {
     state: JobState;
+    newestFirst?: boolean;
+    showStepProgress?: boolean;
+    modelDetailMode?: 'all' | 'running';
 }
 
 /** emoji → lucide icon 매핑. doc-converter step 메시지의 모든 prefix 대응. */
@@ -54,8 +58,32 @@ function iconFor(step: string): { icon: ReactNode; text: string } {
     return { icon: null, text: step };
 }
 
-export function ProgressPanel({ state }: ProgressPanelProps) {
+function ModelDetail({ step, mode }: { step: ProgressStep; mode: 'all' | 'running' }) {
+    if (!step.model) return step.detail ? <div className="step-detail">{step.detail}</div> : null;
+    if (mode === 'running' && !/^⏳\s*/.test(step.step)) return null;
+    const display = getSelectionDisplay(AI_CATALOG, {
+        company: step.model.company,
+        auth: step.model.auth,
+        model: step.model.model,
+    });
+    return (
+        <div className="step-detail step-model-detail" title={step.detail ?? step.model.model}>
+            {display.logo && <img src={display.logo} alt="" className="step-model-logo" />}
+            <span className="step-model-label">{display.label}</span>
+            {display.sub && <span className="step-model-sub">구독</span>}
+        </div>
+    );
+}
+
+export function ProgressPanel({
+    state,
+    newestFirst = true,
+    showStepProgress = true,
+    modelDetailMode = 'all',
+}: ProgressPanelProps) {
     if (state.phase === 'idle' && state.steps.length === 0) return null;
+
+    const steps = newestFirst ? state.steps.slice().reverse() : state.steps;
 
     return (
         <div className={`convert-progress phase-${state.phase}`}>
@@ -65,22 +93,19 @@ export function ProgressPanel({ state }: ProgressPanelProps) {
                 </div>
             )}
             <ol className="convert-progress-steps">
-                {/* 최신이 위로 — slice() 로 원본 보존 후 reverse */}
-                {state.steps
-                    .slice()
-                    .reverse()
+                {steps
                     .map((s, i) => {
                         const { icon, text } = iconFor(s.step);
                         return (
                             <li
-                                key={s.stepId ?? `${state.steps.length - 1 - i}`}
+                                key={s.stepId ?? `${newestFirst ? state.steps.length - 1 - i : i}`}
                                 className="convert-progress-step"
                             >
                                 <div className="step-main">
                                     {icon && <span className="step-icon">{icon}</span>}
                                     <span className="step-text">{text}</span>
                                 </div>
-                                {typeof s.progress === 'number' && (
+                                {showStepProgress && typeof s.progress === 'number' && (
                                     <div className="step-progress-bar">
                                         <div
                                             className="step-progress-fill"
@@ -88,7 +113,7 @@ export function ProgressPanel({ state }: ProgressPanelProps) {
                                         />
                                     </div>
                                 )}
-                                {s.detail && <div className="step-detail">{s.detail}</div>}
+                                <ModelDetail step={s} mode={modelDetailMode} />
                             </li>
                         );
                     })}

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -401,6 +401,7 @@
 .step-model-detail {
     display: inline-flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
     min-width: 0;
     word-break: normal;
@@ -429,6 +430,12 @@
     color: var(--accent, #3b82f6);
     font-size: 10px;
     font-weight: 600;
+}
+.step-model-extra {
+    min-width: 0;
+    color: var(--text-tertiary, var(--text-secondary));
+    font-weight: 400;
+    overflow-wrap: anywhere;
 }
 /* step 자체에 progress bar (heartbeat row) — % 시각화 */
 .step-progress-bar {

--- a/src/components/convert/convert.css
+++ b/src/components/convert/convert.css
@@ -398,6 +398,38 @@
     word-break: break-all;
     overflow-wrap: anywhere;
 }
+.step-model-detail {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    word-break: normal;
+    overflow-wrap: normal;
+}
+.step-model-logo {
+    width: 15px;
+    height: 15px;
+    object-fit: contain;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.step-model-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+.step-model-sub {
+    flex-shrink: 0;
+    padding: 1px 5px;
+    border-radius: 999px;
+    background: var(--accent-bg, rgba(59, 130, 246, 0.1));
+    color: var(--accent, #3b82f6);
+    font-size: 10px;
+    font-weight: 600;
+}
 /* step 자체에 progress bar (heartbeat row) — % 시각화 */
 .step-progress-bar {
     margin: 4px 0 0 22px;

--- a/src/lib/buildPptx.test.ts
+++ b/src/lib/buildPptx.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import JSZip from 'jszip';
 import { buildPptx } from './buildPptx';
 import { parseInline, type Slide } from './markdownToSlides';
@@ -161,6 +161,41 @@ describe('buildPptx', () => {
 
     for (const xml of slideXml) {
       expect(xml).toContain('<p:pic>');
+    }
+  });
+
+  it('does not leave an empty special-layout image panel when image resolution fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const slides: Slide[] = [
+      {
+        title: 'Broken Quote Visual',
+        layout: 'quote',
+        body: [],
+        quote: { text: 'Text should use the full visual area.', attribution: 'MarkMind' },
+        image: { src: 'missing-quote-image.png', alt: 'missing visual', role: 'support' },
+      },
+      {
+        title: 'Broken Stat Visual',
+        layout: 'stat',
+        body: [],
+        stat: { value: '0', label: 'No visual should leave an empty panel' },
+        image: { src: 'missing-stat-image.png', alt: 'missing visual', role: 'support' },
+      },
+    ];
+
+    try {
+      const pptx = await buildPptx(slides, { title: 'Broken Special Layout Images' });
+      const zip = await JSZip.loadAsync(pptx);
+      const slideXml = await Promise.all(
+        [1, 2].map((n) => zip.file(`ppt/slides/slide${n}.xml`)?.async('string')),
+      );
+
+      for (const xml of slideXml) {
+        expect(xml).not.toContain('<p:pic>');
+        expect(xml).not.toContain('EAF1F7');
+      }
+    } finally {
+      warn.mockRestore();
     }
   });
 });

--- a/src/lib/buildPptx.test.ts
+++ b/src/lib/buildPptx.test.ts
@@ -4,6 +4,9 @@ import { buildPptx } from './buildPptx';
 import { parseInline, type Slide } from './markdownToSlides';
 
 describe('buildPptx', () => {
+  const tinyPng =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l0cZ1QAAAABJRU5ErkJggg==';
+
   it('renders two-column slides without relying on static PptxGenJS ShapeType', async () => {
     const slides: Slide[] = [
       {
@@ -26,5 +29,116 @@ describe('buildPptx', () => {
     expect(slideXml).toContain('<a:lnSpc>');
     const paragraphSpace = [...(slideXml?.matchAll(/<a:spcAft><a:spcPts val="(\d+)"/g) ?? [])].map((m) => Number(m[1]));
     expect(Math.max(...paragraphSpace)).toBeGreaterThanOrEqual(1200);
+  });
+
+  it('renders deck-wide master chrome from SlideMasterSpec', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Master Chrome',
+        layout: 'content',
+        body: [{ kind: 'bullet', spans: parseInline('Shared footer should live on the master'), indent: 0 }],
+      },
+    ];
+
+    const pptx = await buildPptx(slides, {
+      title: 'Master Chrome',
+      masterSpec: {
+        slideNumber: { enabled: true, includeOn: ['content', 'section'], position: 'bottom-center' },
+        footer: { text: 'Confidential', includeOn: ['content'], position: 'bottom-left' },
+      },
+    });
+
+    const zip = await JSZip.loadAsync(pptx);
+    const pptxXmlPaths = Object.keys(zip.files).filter(
+      (path) =>
+        (path.startsWith('ppt/slideMasters/') || path.startsWith('ppt/slideLayouts/') || path.startsWith('ppt/slides/')) &&
+        path.endsWith('.xml'),
+    );
+    const pptxXml = (
+      await Promise.all(pptxXmlPaths.map((path) => zip.file(path)?.async('string')))
+    ).join('\n');
+
+    expect(pptxXml).toContain('Confidential');
+    expect(pptxXml).toContain('type="sldNum"');
+  });
+
+  it('adds structural spacing before subsequent subhead groups', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Grouped Content',
+        layout: 'content',
+        body: [
+          { kind: 'subhead', text: 'First group', level: 3 },
+          { kind: 'bullet', spans: parseInline('First point'), indent: 0 },
+          { kind: 'subhead', text: 'Second group', level: 3 },
+          { kind: 'bullet', spans: parseInline('Second point'), indent: 0 },
+        ],
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Subhead Spacing' });
+    const zip = await JSZip.loadAsync(pptx);
+    const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+    const beforeSpaces = [...(slideXml?.matchAll(/<a:spcBef><a:spcPts val="(\d+)"/g) ?? [])].map((m) => Number(m[1]));
+
+    expect(Math.max(...beforeSpaces)).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('renders resolved slide image assets on ordinary content slides', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Visual Content',
+        layout: 'content',
+        body: [{ kind: 'bullet', spans: parseInline('Generated image should be visible'), indent: 0 }],
+        image: { src: tinyPng, alt: 'generated visual', role: 'support' },
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Resolved Image' });
+    const zip = await JSZip.loadAsync(pptx);
+    const mediaPaths = Object.keys(zip.files).filter((path) => path.startsWith('ppt/media/'));
+    const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+
+    expect(mediaPaths.length).toBeGreaterThan(0);
+    expect(slideXml).toContain('Generated image should be visible');
+  });
+
+  it('renders resolved slide image assets on special visual layouts', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Two Column Visual',
+        layout: 'two-column',
+        body: [],
+        columns: [
+          [{ kind: 'bullet', spans: parseInline('Left point'), indent: 0 }],
+          [{ kind: 'bullet', spans: parseInline('Right point'), indent: 0 }],
+        ],
+        image: { src: tinyPng, alt: 'supporting visual', role: 'support' },
+      },
+      {
+        title: 'Quote Visual',
+        layout: 'quote',
+        body: [],
+        quote: { text: 'Visuals should not be dropped.', attribution: 'MarkMind' },
+        image: { src: tinyPng, alt: 'quote visual', role: 'support' },
+      },
+      {
+        title: 'Stat Visual',
+        layout: 'stat',
+        body: [],
+        stat: { value: '8/8', label: 'Image assets resolved', context: 'Every resolved asset should have a render path.' },
+        image: { src: tinyPng, alt: 'stat visual', role: 'support' },
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Special Layout Images' });
+    const zip = await JSZip.loadAsync(pptx);
+    const slideXml = await Promise.all(
+      [1, 2, 3].map((n) => zip.file(`ppt/slides/slide${n}.xml`)?.async('string')),
+    );
+
+    for (const xml of slideXml) {
+      expect(xml).toContain('<p:pic>');
+    }
   });
 });

--- a/src/lib/buildPptx.test.ts
+++ b/src/lib/buildPptx.test.ts
@@ -6,6 +6,8 @@ import { parseInline, type Slide } from './markdownToSlides';
 describe('buildPptx', () => {
   const tinyPng =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l0cZ1QAAAABJRU5ErkJggg==';
+  const widePng =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAJCAYAAAA7KqwyAAAAFklEQVR4nGOQm/D/PyWYYdSAUQOAGADaQ4DQ/rxYmwAAAABJRU5ErkJggg==';
 
   it('renders two-column slides without relying on static PptxGenJS ShapeType', async () => {
     const slides: Slide[] = [
@@ -101,6 +103,26 @@ describe('buildPptx', () => {
 
     expect(mediaPaths.length).toBeGreaterThan(0);
     expect(slideXml).toContain('Generated image should be visible');
+  });
+
+  it('preserves resolved image aspect ratio instead of stretching to the slot', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Wide Visual',
+        layout: 'content',
+        body: [{ kind: 'bullet', spans: parseInline('Wide image should keep its original ratio'), indent: 0 }],
+        image: { src: widePng, alt: 'wide visual', role: 'support' },
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Image Ratio' });
+    const zip = await JSZip.loadAsync(pptx);
+    const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+    const pic = slideXml?.match(/<p:pic>[\s\S]*?<a:ext cx="(\d+)" cy="(\d+)"/);
+    expect(pic).toBeTruthy();
+    const ratio = Number(pic?.[1]) / Number(pic?.[2]);
+    expect(ratio).toBeGreaterThan(1.72);
+    expect(ratio).toBeLessThan(1.83);
   });
 
   it('renders resolved slide image assets on special visual layouts', async () => {

--- a/src/lib/buildPptx.test.ts
+++ b/src/lib/buildPptx.test.ts
@@ -33,6 +33,29 @@ describe('buildPptx', () => {
     expect(Math.max(...paragraphSpace)).toBeGreaterThanOrEqual(1200);
   });
 
+  it('renders all accepted three-column slide content', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Three Column',
+        layout: 'comparison',
+        body: [],
+        columns: [
+          [{ kind: 'bullet', spans: parseInline('First point'), indent: 0 }],
+          [{ kind: 'bullet', spans: parseInline('Second point'), indent: 0 }],
+          [{ kind: 'bullet', spans: parseInline('Third point'), indent: 0 }],
+        ],
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Three Column Regression' });
+    const zip = await JSZip.loadAsync(pptx);
+    const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+
+    expect(slideXml).toContain('First point');
+    expect(slideXml).toContain('Second point');
+    expect(slideXml).toContain('Third point');
+  });
+
   it('renders deck-wide master chrome from SlideMasterSpec', async () => {
     const slides: Slide[] = [
       {

--- a/src/lib/buildPptx.test.ts
+++ b/src/lib/buildPptx.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { buildPptx } from './buildPptx';
+import { parseInline, type Slide } from './markdownToSlides';
+
+describe('buildPptx', () => {
+  it('renders two-column slides without relying on static PptxGenJS ShapeType', async () => {
+    const slides: Slide[] = [
+      {
+        title: 'Two Column',
+        layout: 'two-column',
+        body: [],
+        columns: [
+          [{ kind: 'bullet', spans: parseInline('Left point'), indent: 0 }],
+          [{ kind: 'bullet', spans: parseInline('Right point'), indent: 0 }],
+        ],
+      },
+    ];
+
+    const pptx = await buildPptx(slides, { title: 'Shape Regression' });
+    expect(pptx.byteLength).toBeGreaterThan(0);
+
+    const zip = await JSZip.loadAsync(pptx);
+    const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+    expect(slideXml).toContain('<a:spcAft>');
+    expect(slideXml).toContain('<a:lnSpc>');
+    const paragraphSpace = [...(slideXml?.matchAll(/<a:spcAft><a:spcPts val="(\d+)"/g) ?? [])].map((m) => Number(m[1]));
+    expect(Math.max(...paragraphSpace)).toBeGreaterThanOrEqual(1200);
+  });
+});

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -1,76 +1,22 @@
-// Slide[] → .pptx (ArrayBuffer) — 이슈 #6 PPTX 내보내기
-//
-// PptxGenJS 로 네이티브 편집 가능 pptx 를 생성한다. WKWebView 의 blob:// 다운로드
-// 버그(WebKit #216918) 때문에 writeFile()/blob 대신 outputType:'arraybuffer' 로
-// 받아 Rust(save_pptx)가 fs::write 한다.
-//
-// "검정 글씨/흰 배경" 빈약 슬라이드를 피하려고 슬라이드 마스터(테마)를 정의한다.
+// Slide[] -> .pptx (ArrayBuffer) — PptxGenJS 기반 결정론적 렌더러.
 
 import PptxGenJS from 'pptxgenjs';
 import type { Slide, SlideBlock, InlineSpan } from './markdownToSlides';
+import { DEFAULT_SLIDE_THEME, type SlideTheme } from './slideTheme';
+import { pptxFontFaceForText } from './pptxDesignSystem';
 
-// ─── 테마 상수 (MarkMind 톤) ───
-const COLORS = {
-  accent: '2F6FED', // 헤더 막대 / 강조
-  title: '1A1A2E',
-  body: '2D2D3A',
-  subhead: '2F6FED',
-  codeBg: 'F4F5F7',
-  codeFg: '24292F',
-  faint: '9AA0A6',
-  bg: 'FFFFFF',
-};
-const FONT = 'Helvetica Neue';
-const MONO = 'Courier New';
-
-// 16:9 inch 기준 본문 영역
 const PAGE_W = 13.333;
-const BODY = { x: 0.7, top: 1.55, bottom: 7.0, w: PAGE_W - 1.4 };
+const PAGE_H = 7.5;
 
 type Pptx = InstanceType<typeof PptxGenJS>;
+type PptxSlide = ReturnType<Pptx['addSlide']>;
 
-function defineMasters(pptx: Pptx) {
-  pptx.defineSlideMaster({
-    title: 'TITLE_SLIDE',
-    background: { color: COLORS.bg },
-    objects: [
-      { rect: { x: 0, y: 3.95, w: PAGE_W, h: 0.05, fill: { color: COLORS.accent } } },
-    ],
-  });
-  pptx.defineSlideMaster({
-    title: 'CONTENT',
-    background: { color: COLORS.bg },
-    objects: [
-      // 상단 제목 영역 액센트 막대
-      { rect: { x: 0, y: 1.25, w: PAGE_W, h: 0.035, fill: { color: COLORS.accent } } },
-    ],
-    slideNumber: { x: PAGE_W - 0.9, y: 7.05, color: COLORS.faint, fontSize: 10 },
-  });
-}
+const RECT_SHAPE = 'rect' as PptxGenJS.ShapeType;
 
-/** InlineSpan[] → PptxGenJS rich-text 배열. */
-function spansToRich(
-  spans: InlineSpan[],
-  base: { bullet?: boolean; indentLevel?: number; breakLine?: boolean; fontSize?: number; color?: string },
-) {
-  return spans.map((s, idx) => ({
-    text: s.text,
-    options: {
-      bold: s.bold,
-      italic: s.italic,
-      fontFace: s.code ? MONO : FONT,
-      // 첫 run 에만 bullet/indent/breakLine 적용
-      ...(idx === 0
-        ? {
-            bullet: base.bullet ? { indent: 14 } : undefined,
-            indentLevel: base.indentLevel,
-            breakLine: base.breakLine,
-          }
-        : {}),
-      fontSize: base.fontSize,
-      color: base.color,
-    },
-  }));
+function fontFaceForTheme(text: string, theme: SlideTheme, role: 'heading' | 'body' | 'mono' = 'body'): string {
+  const themeFont = role === 'heading' ? theme.fonts.heading : role === 'mono' ? theme.fonts.mono : theme.fonts.body;
+  if (role !== 'mono' && theme.fonts.useLanguageFallback === false) return themeFont;
+  return pptxFontFaceForText(text, themeFont, role);
 }
 
 const ext = (src: string) => src.split('.').pop()?.toLowerCase() ?? '';
@@ -84,10 +30,96 @@ const MIME: Record<string, string> = {
   bmp: 'image/bmp',
 };
 
-/**
- * 본문 이미지 경로 → PptxGenJS addImage 인자. 로컬 파일은 base64 data URL 로 읽어
- * 넣고(WKWebView 가 직접 못 가져옴), http(s)/data URL 은 path 로 전달. 실패 시 null.
- */
+const flattenText = (blocks: SlideBlock[]) =>
+  blocks
+    .map((b) => {
+      if (b.kind === 'text' || b.kind === 'bullet') return b.spans.map((s) => s.text).join('');
+      if (b.kind === 'subhead' || b.kind === 'code') return b.text;
+      if (b.kind === 'image') return b.alt || '';
+      if (b.kind === 'table') return b.rows.map((r) => r.join(' ')).join(' ');
+      return '';
+    })
+    .filter(Boolean)
+    .join(' ');
+
+function defineMasters(pptx: Pptx, theme: SlideTheme) {
+  const footer = { x: PAGE_W - 0.9, y: 7.06, color: theme.palette.muted, fontSize: 9 };
+  pptx.defineSlideMaster({
+    title: 'TITLE_SLIDE',
+    background: { color: theme.palette.title },
+    objects: [
+      { rect: { x: 0, y: 0, w: PAGE_W, h: PAGE_H, fill: { color: theme.palette.title }, line: { color: theme.palette.title } } },
+      ...motifObjects(theme, true),
+    ],
+  });
+  pptx.defineSlideMaster({
+    title: 'CONTENT',
+    background: { color: theme.palette.bg },
+    objects: motifObjects(theme, false),
+    slideNumber: footer,
+  });
+  pptx.defineSlideMaster({
+    title: 'SECTION',
+    background: { color: theme.palette.title },
+    objects: motifObjects(theme, true),
+  });
+}
+
+function motifObjects(theme: SlideTheme, inverse: boolean) {
+  const accent = inverse ? theme.palette.accent2 : theme.palette.accent;
+  const quiet = inverse ? theme.palette.accent : theme.palette.surfaceAlt;
+  if (theme.shape.motif === 'corner-block') {
+    return [
+      { rect: { x: PAGE_W - 2.2, y: 0, w: 2.2, h: 1.15, fill: { color: accent }, line: { color: accent } } },
+      { rect: { x: 0, y: PAGE_H - 0.34, w: 2.8, h: 0.34, fill: { color: quiet }, line: { color: quiet } } },
+    ];
+  }
+  if (theme.shape.motif === 'frame') {
+    return [
+      { rect: { x: 0.18, y: 0.18, w: PAGE_W - 0.36, h: PAGE_H - 0.36, fill: { color: inverse ? theme.palette.title : theme.palette.bg, transparency: 100 }, line: { color: accent, width: 1.2 } } },
+    ];
+  }
+  return [
+    { rect: { x: 0, y: 0, w: 0.12, h: PAGE_H, fill: { color: accent }, line: { color: accent } } },
+    { rect: { x: PAGE_W - 2.15, y: 0, w: 2.15, h: 0.18, fill: { color: quiet }, line: { color: quiet } } },
+    { rect: { x: 0.12, y: PAGE_H - 0.08, w: PAGE_W - 0.12, h: 0.08, fill: { color: accent }, line: { color: accent } } },
+  ];
+}
+
+function spansToRich(
+  spans: InlineSpan[],
+  theme: SlideTheme,
+  base: {
+    bullet?: boolean;
+    indentLevel?: number;
+    breakLine?: boolean;
+    fontSize?: number;
+    color?: string;
+    lineSpacingMultiple?: number;
+    paraSpaceAfter?: number;
+  },
+) {
+  return spans.map((s, idx) => ({
+    text: s.text,
+    options: {
+      bold: s.bold,
+      italic: s.italic,
+      fontFace: s.code ? fontFaceForTheme(s.text, theme, 'mono') : fontFaceForTheme(s.text, theme),
+      ...(idx === 0
+        ? {
+            bullet: base.bullet ? { indent: 14 } : undefined,
+            indentLevel: base.indentLevel,
+            breakLine: base.breakLine,
+          }
+        : {}),
+      lineSpacingMultiple: base.lineSpacingMultiple,
+      paraSpaceAfter: base.paraSpaceAfter,
+      fontSize: base.fontSize,
+      color: base.color,
+    },
+  }));
+}
+
 async function resolveImage(
   src: string,
   baseDir?: string,
@@ -96,73 +128,341 @@ async function resolveImage(
   if (/^https?:\/\//i.test(src)) return { path: src };
   try {
     const { readFile } = await import('@tauri-apps/plugin-fs');
-    // asset:// 또는 상대/절대 로컬 경로
     let p = src.replace(/^asset:\/\/(localhost\/)?/i, '');
     p = decodeURIComponent(p);
     if (!p.startsWith('/') && baseDir) p = `${baseDir.replace(/\/$/, '')}/${p}`;
     const bytes = await readFile(p);
     let bin = '';
     for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-    const b64 = btoa(bin);
     const mime = MIME[ext(p)] ?? 'image/png';
-    return { data: `data:${mime};base64,${b64}` };
+    return { data: `data:${mime};base64,${btoa(bin)}` };
   } catch (e) {
     console.warn('[buildPptx] 이미지 로드 실패, 건너뜀:', src, e);
     return null;
   }
 }
 
-function renderTitleSlide(pptx: Pptx, slide: Slide) {
+function headingLevelFor(slide: Slide): number {
+  if (slide.sourceLevel && slide.sourceLevel >= 1 && slide.sourceLevel <= 6) return slide.sourceLevel;
+  if (slide.layout === 'title' || slide.layout === 'section') return 1;
+  return 2;
+}
+
+function titleMetrics(slide: Slide, theme: SlideTheme) {
+  const level = headingLevelFor(slide);
+  if (level <= 1) {
+    return { y: theme.spacing.titleY, h: 0.9, fontSize: theme.typeScale.title + 4 };
+  }
+  if (level === 2) {
+    return { y: theme.spacing.titleY + 0.08, h: 0.78, fontSize: theme.typeScale.title };
+  }
+  return { y: theme.spacing.titleY + 0.2, h: 0.64, fontSize: Math.max(21, theme.typeScale.title - 5) };
+}
+
+function bodyTopFor(slide: Slide, theme: SlideTheme): number {
+  if (sectionTrail(slide)) return Math.max(theme.spacing.bodyTop, 1.58);
+  if (headingLevelFor(slide) >= 3) return Math.max(1.34, theme.spacing.bodyTop - 0.12);
+  return theme.spacing.bodyTop;
+}
+
+function sectionTrail(slide: Slide): string {
+  const path = (slide.sectionPath ?? [])
+    .map((p) => p.trim())
+    .filter((p) => p && !/^\(?root\)?$/i.test(p) && !/^document(?: opening)?$/i.test(p));
+  if (path.length === 0) return '';
+  const title = slide.title.trim();
+  const visible = path.filter((p) => p !== title).slice(-2);
+  return visible.join(' / ');
+}
+
+function addSectionTrail(s: PptxSlide, slide: Slide, theme: SlideTheme, inverse = false) {
+  const trail = sectionTrail(slide);
+  if (!trail) return;
+  s.addText(trail, {
+    x: theme.spacing.marginX,
+    y: 0.22,
+    w: PAGE_W - theme.spacing.marginX * 2,
+    h: 0.22,
+    fontFace: fontFaceForTheme(trail, theme),
+    fontSize: Math.max(9, theme.typeScale.caption - 1),
+    bold: true,
+    color: inverse ? theme.palette.inverseText : theme.palette.muted,
+    transparency: inverse ? 16 : 0,
+    margin: 0,
+    fit: 'shrink',
+  });
+}
+
+function subheadFontSize(level: number | undefined, theme: SlideTheme): number {
+  if (!level || level <= 2) return theme.typeScale.body + 4;
+  if (level === 3) return theme.typeScale.body + 2;
+  return theme.typeScale.body + 1;
+}
+
+type BlockRenderProfile = {
+  bodyFontSize: number;
+  lineSpacingMultiple: number;
+  paraSpaceAfter: number;
+  gap: number;
+};
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function blockText(block: SlideBlock): string {
+  if (block.kind === 'text' || block.kind === 'bullet') return block.spans.map((s) => s.text).join('');
+  if (block.kind === 'subhead' || block.kind === 'code') return block.text;
+  if (block.kind === 'table') return block.rows.map((row) => row.join(' ')).join(' ');
+  if (block.kind === 'image') return block.alt || block.src;
+  return '';
+}
+
+function estimatedTextWidthPt(text: string, fontSize: number): number {
+  let units = 0;
+  for (const ch of text) {
+    if (/\s/.test(ch)) units += 0.32;
+    else if (/[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af\u3040-\u30ff\u3400-\u9fff]/.test(ch)) units += 0.92;
+    else if (/[A-Z0-9]/.test(ch)) units += 0.58;
+    else if (/[.,:;'"`|!()\[\]{}]/.test(ch)) units += 0.3;
+    else units += 0.52;
+  }
+  return units * fontSize;
+}
+
+function estimatedLineCount(text: string, boxW: number, fontSize: number, indent = 0): number {
+  const usableWidthPt = Math.max(40, boxW * 72 - indent * 18);
+  const paragraphs = text.split(/\n+/).filter(Boolean);
+  if (paragraphs.length === 0) return 1;
+  return paragraphs.reduce(
+    (sum, paragraph) => sum + Math.max(1, Math.ceil(estimatedTextWidthPt(paragraph, fontSize) / usableWidthPt)),
+    0,
+  );
+}
+
+function fontSizeForBlock(block: SlideBlock, theme: SlideTheme, profile: BlockRenderProfile): number {
+  if (block.kind === 'subhead') {
+    const delta = subheadFontSize(block.level, theme) - theme.typeScale.body;
+    return clamp(profile.bodyFontSize + delta, profile.bodyFontSize + 1, profile.bodyFontSize + 5);
+  }
+  return profile.bodyFontSize;
+}
+
+function defaultBlockProfile(theme: SlideTheme): BlockRenderProfile {
+  return {
+    bodyFontSize: theme.typeScale.body,
+    lineSpacingMultiple: 1.12,
+    paraSpaceAfter: 3,
+    gap: theme.spacing.gap,
+  };
+}
+
+function estimateTextRunHeight(
+  blocks: SlideBlock[],
+  theme: SlideTheme,
+  boxW: number,
+  profile: BlockRenderProfile,
+): number {
+  if (blocks.length === 0) return 0;
+  const height = blocks.reduce((sum, block) => {
+    const fontSize = fontSizeForBlock(block, theme, profile);
+    const indent = block.kind === 'bullet' ? 1 + block.indent : 0;
+    const lines = estimatedLineCount(blockText(block), boxW, fontSize, indent);
+    const lineHeight = (fontSize * profile.lineSpacingMultiple) / 72;
+    const paragraphBreath = block.kind === 'subhead' ? 0.05 : 0.015;
+    const paragraphSpace = block === blocks[blocks.length - 1] ? 0 : profile.paraSpaceAfter / 72;
+    return sum + Math.max(0.24, lines * lineHeight) + paragraphSpace + paragraphBreath;
+  }, 0);
+  return Math.max(0.46, height + 0.02);
+}
+
+function estimateBlocksHeight(
+  blocks: SlideBlock[],
+  theme: SlideTheme,
+  boxW: number,
+  profile: BlockRenderProfile,
+): number {
+  let height = 0;
+  let textRun: SlideBlock[] = [];
+  const addGap = () => {
+    if (height > 0) height += profile.gap;
+  };
+  const flush = () => {
+    if (textRun.length === 0) return;
+    addGap();
+    height += estimateTextRunHeight(textRun, theme, boxW, profile);
+    textRun = [];
+  };
+
+  for (const block of blocks) {
+    if (block.kind === 'text' || block.kind === 'bullet' || block.kind === 'subhead') {
+      textRun.push(block);
+      continue;
+    }
+    flush();
+    addGap();
+    if (block.kind === 'code') height += Math.max(0.52, block.text.split('\n').length * 0.25 + 0.28);
+    else if (block.kind === 'table') height += Math.max(0.45, block.rows.length * 0.38);
+    else if (block.kind === 'image') height += 3.15;
+  }
+  flush();
+  return height;
+}
+
+function isTextDominant(blocks: SlideBlock[]): boolean {
+  return blocks.every((b) => b.kind === 'text' || b.kind === 'bullet' || b.kind === 'subhead');
+}
+
+function blockRenderProfile(blocks: SlideBlock[], theme: SlideTheme, box: { w: number; h: number }): BlockRenderProfile {
+  const base = defaultBlockProfile(theme);
+  const estimatedHeight = estimateBlocksHeight(blocks, theme, box.w, base);
+  const usage = estimatedHeight / Math.max(1, box.h);
+  const textBlockCount = blocks.filter((b) => b.kind === 'text' || b.kind === 'bullet' || b.kind === 'subhead').length;
+
+  if (usage < 0.55 && textBlockCount > 0 && textBlockCount <= 10 && isTextDominant(blocks)) {
+    const maxFont =
+      textBlockCount <= 4
+        ? Math.min(30, theme.typeScale.body + 12)
+        : textBlockCount <= 7
+          ? Math.min(26, theme.typeScale.body + 9)
+          : Math.min(23, theme.typeScale.body + 6);
+    const targetUsage = textBlockCount <= 4 ? 0.5 : textBlockCount <= 7 ? 0.56 : 0.62;
+    let best = base;
+
+    for (let bodyFontSize = theme.typeScale.body + 1; bodyFontSize <= maxFont; bodyFontSize += 1) {
+      const growth = bodyFontSize - theme.typeScale.body;
+      const candidate: BlockRenderProfile = {
+        bodyFontSize,
+        lineSpacingMultiple: clamp(1.14 + growth * 0.014, 1.16, 1.34),
+        paraSpaceAfter: clamp(4 + growth * 1.35, 5, 18),
+        gap: Math.min(0.34, theme.spacing.gap + growth * 0.012),
+      };
+      const candidateUsage = estimateBlocksHeight(blocks, theme, box.w, candidate) / Math.max(1, box.h);
+      if (candidateUsage <= targetUsage || best === base) {
+        best = candidate;
+        continue;
+      }
+      break;
+    }
+    return best;
+  }
+  if (usage > 0.92) {
+    return {
+      bodyFontSize: clamp(theme.typeScale.body - 2, 12, theme.typeScale.body),
+      lineSpacingMultiple: 1.04,
+      paraSpaceAfter: 1,
+      gap: Math.max(0.08, theme.spacing.gap - 0.04),
+    };
+  }
+  if (usage > 0.72) {
+    return {
+      bodyFontSize: clamp(theme.typeScale.body - 1, 13, theme.typeScale.body),
+      lineSpacingMultiple: 1.08,
+      paraSpaceAfter: 2,
+      gap: Math.max(0.1, theme.spacing.gap - 0.02),
+    };
+  }
+  return base;
+}
+
+function addTitle(s: PptxSlide, slide: Slide, theme: SlideTheme, inverse = false) {
+  addSectionTrail(s, slide, theme, inverse);
+  const metrics = titleMetrics(slide, theme);
+  s.addText(slide.title, {
+    x: theme.spacing.marginX,
+    y: metrics.y,
+    w: PAGE_W - theme.spacing.marginX * 2,
+    h: metrics.h,
+    fontFace: fontFaceForTheme(slide.title, theme, 'heading'),
+    fontSize: metrics.fontSize,
+    bold: true,
+    color: inverse ? theme.palette.inverseText : theme.palette.title,
+    valign: 'middle',
+    margin: 0,
+    fit: 'shrink',
+  });
+}
+
+function renderTitleSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   const s = pptx.addSlide({ masterName: 'TITLE_SLIDE' });
   s.addText(slide.title || 'Untitled', {
     x: 0.8,
-    y: 2.7,
+    y: 2.28,
     w: PAGE_W - 1.6,
-    h: 1.2,
-    fontFace: FONT,
-    fontSize: 40,
+    h: 1.35,
+    fontFace: fontFaceForTheme(slide.title || 'Untitled', theme, 'heading'),
+    fontSize: theme.typeScale.coverTitle,
     bold: true,
-    color: COLORS.title,
+    color: theme.palette.inverseText,
     align: 'left',
     valign: 'bottom',
+    margin: 0,
+    fit: 'shrink',
   });
-  // 본문 첫 text/bullet 를 부제로
-  const sub = slide.body.find((b) => b.kind === 'text' || b.kind === 'bullet');
-  if (sub && (sub.kind === 'text' || sub.kind === 'bullet')) {
-    s.addText(sub.spans.map((x) => x.text).join(''), {
-      x: 0.8,
-      y: 4.15,
-      w: PAGE_W - 1.6,
-      h: 0.8,
-      fontFace: FONT,
+  const sub = flattenText(slide.body).slice(0, 180);
+  if (sub) {
+    s.addText(sub, {
+      x: 0.82,
+      y: 3.85,
+      w: PAGE_W - 1.9,
+      h: 0.74,
+      fontFace: fontFaceForTheme(sub, theme),
       fontSize: 18,
-      color: COLORS.faint,
-      align: 'left',
+      color: theme.palette.inverseText,
+      transparency: 12,
+      margin: 0,
+      fit: 'shrink',
     });
   }
   if (slide.notes) s.addNotes(slide.notes);
 }
 
-async function renderContentSlide(pptx: Pptx, slide: Slide, baseDir?: string) {
-  const s = pptx.addSlide({ masterName: 'CONTENT' });
-  if (slide.title) {
-    s.addText(slide.title, {
-      x: BODY.x,
-      y: 0.4,
-      w: BODY.w,
-      h: 0.8,
-      fontFace: FONT,
-      fontSize: 26,
-      bold: true,
-      color: COLORS.title,
-      valign: 'middle',
+function renderSectionSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+  const s = pptx.addSlide({ masterName: 'SECTION' });
+  addSectionTrail(s, slide, theme, true);
+  const level = headingLevelFor(slide);
+  s.addText(slide.title || flattenText(slide.body) || 'Section', {
+    x: 0.82,
+    y: level <= 1 ? 2.62 : 2.72,
+    w: PAGE_W - 1.64,
+    h: 1.2,
+    fontFace: fontFaceForTheme(slide.title || flattenText(slide.body) || 'Section', theme, 'heading'),
+    fontSize: level <= 1 ? theme.typeScale.section : Math.max(28, theme.typeScale.section - 4),
+    bold: true,
+    color: theme.palette.inverseText,
+    align: 'left',
+    valign: 'middle',
+    margin: 0,
+    fit: 'shrink',
+  });
+  const sub = flattenText(slide.body).slice(0, 150);
+  if (sub) {
+    s.addText(sub, {
+      x: 0.86,
+      y: 4.0,
+      w: PAGE_W - 2.4,
+      h: 0.62,
+      fontFace: fontFaceForTheme(sub, theme),
+      fontSize: 16,
+      color: theme.palette.inverseText,
+      transparency: 10,
+      margin: 0,
+      fit: 'shrink',
     });
   }
+  if (slide.notes) s.addNotes(slide.notes);
+}
 
-  // 블록을 위→아래 커서로 배치. text/bullet/subhead 는 연속 그룹으로 묶어 하나의
-  // 텍스트박스(fit:shrink)로, table/image/code 는 개별 박스로.
-  let y = BODY.top;
-  const avail = () => BODY.bottom - y;
+async function renderBlocks(
+  s: PptxSlide,
+  blocks: SlideBlock[],
+  theme: SlideTheme,
+  box: { x: number; y: number; w: number; h: number },
+  baseDir?: string,
+) {
+  let y = box.y;
+  const avail = () => box.y + box.h - y;
+  const profile = blockRenderProfile(blocks, theme, box);
   let textRun: SlideBlock[] = [];
 
   const flushText = () => {
@@ -171,148 +471,342 @@ async function renderContentSlide(pptx: Pptx, slide: Slide, baseDir?: string) {
     for (const b of textRun) {
       if (b.kind === 'subhead') {
         rich.push(
-          ...spansToRich([{ text: b.text, bold: true }], {
+          ...spansToRich([{ text: b.text, bold: true }], theme, {
             breakLine: true,
-            fontSize: 18,
-            color: COLORS.subhead,
+            fontSize: fontSizeForBlock(b, theme, profile),
+            color: theme.palette.accent,
+            lineSpacingMultiple: profile.lineSpacingMultiple,
+            paraSpaceAfter: Math.max(profile.paraSpaceAfter + 1, 4),
           }),
         );
       } else if (b.kind === 'bullet') {
         rich.push(
-          ...spansToRich(b.spans, {
+          ...spansToRich(b.spans, theme, {
             bullet: true,
             indentLevel: b.indent,
             breakLine: true,
-            fontSize: 16,
-            color: COLORS.body,
+            fontSize: profile.bodyFontSize,
+            color: theme.palette.body,
+            lineSpacingMultiple: profile.lineSpacingMultiple,
+            paraSpaceAfter: profile.paraSpaceAfter,
           }),
         );
       } else if (b.kind === 'text') {
         rich.push(
-          ...spansToRich(b.spans, {
+          ...spansToRich(b.spans, theme, {
             breakLine: true,
-            fontSize: 16,
-            color: COLORS.body,
+            fontSize: profile.bodyFontSize,
+            color: theme.palette.body,
+            lineSpacingMultiple: profile.lineSpacingMultiple,
+            paraSpaceAfter: profile.paraSpaceAfter,
           }),
         );
       }
     }
-    const lines = textRun.length;
-    const h = Math.min(avail(), Math.max(0.5, lines * 0.42));
+    const runH = estimateTextRunHeight(textRun, theme, box.w, profile);
+    const h = Math.min(avail(), Math.max(0.48, runH));
     s.addText(rich, {
-      x: BODY.x,
+      x: box.x,
       y,
-      w: BODY.w,
+      w: box.w,
       h,
       valign: 'top',
       align: 'left',
-      lineSpacingMultiple: 1.15,
+      lineSpacingMultiple: profile.lineSpacingMultiple,
       fit: 'shrink',
+      margin: 0,
     });
-    y += h + 0.12;
+    y += h + profile.gap;
     textRun = [];
   };
 
-  for (const b of slide.body) {
+  for (const b of blocks) {
     if (b.kind === 'text' || b.kind === 'bullet' || b.kind === 'subhead') {
       textRun.push(b);
       continue;
     }
     flushText();
-    if (avail() < 0.6) break; // 공간 소진
+    if (avail() < 0.48) break;
     if (b.kind === 'code') {
-      const codeLines = b.text.split('\n').length;
-      const h = Math.min(avail(), Math.max(0.5, codeLines * 0.26 + 0.3));
+      const h = Math.min(avail(), Math.max(0.52, b.text.split('\n').length * 0.25 + 0.28));
       s.addText(b.text, {
-        x: BODY.x,
+        x: box.x,
         y,
-        w: BODY.w,
+        w: box.w,
         h,
-        fontFace: MONO,
-        fontSize: 12,
-        color: COLORS.codeFg,
-        fill: { color: COLORS.codeBg },
+        fontFace: fontFaceForTheme(b.text, theme, 'mono'),
+        fontSize: 11,
+        color: theme.palette.codeFg,
+        fill: { color: theme.palette.codeBg },
         align: 'left',
         valign: 'top',
         margin: 6,
         fit: 'shrink',
       });
-      y += h + 0.12;
+      y += h + profile.gap;
     } else if (b.kind === 'table') {
       const rows = b.rows.map((r, ri) =>
         r.map((cell) => ({
           text: cell,
           options: {
             bold: ri === 0,
-            color: ri === 0 ? 'FFFFFF' : COLORS.body,
-            fill: { color: ri === 0 ? COLORS.accent : 'FFFFFF' },
-            fontFace: FONT,
-            fontSize: 13,
+            color: ri === 0 ? theme.palette.inverseText : theme.palette.body,
+            fill: { color: ri === 0 ? theme.palette.accent : theme.palette.surface },
+            fontFace: fontFaceForTheme(cell, theme),
+            fontSize: 12,
           },
         })),
       );
-      const h = Math.min(avail(), Math.max(0.4, b.rows.length * 0.4));
+      const h = Math.min(avail(), Math.max(0.45, b.rows.length * 0.38));
       s.addTable(rows, {
-        x: BODY.x,
+        x: box.x,
         y,
-        w: BODY.w,
+        w: box.w,
         h,
-        border: { type: 'solid', pt: 0.5, color: 'D7DAE0' },
+        border: { type: 'solid', pt: 0.5, color: theme.palette.border },
         valign: 'middle',
       });
-      y += h + 0.15;
+      y += h + profile.gap;
     } else if (b.kind === 'image') {
       const img = await resolveImage(b.src, baseDir);
-      const h = Math.min(avail(), 3.2);
+      const h = Math.min(avail(), 3.15);
       if (img) {
-        s.addImage({
-          ...img,
-          x: BODY.x,
-          y,
-          w: BODY.w,
-          h,
-          sizing: { type: 'contain', w: BODY.w, h },
-          altText: b.alt,
-        });
+        s.addImage({ ...img, x: box.x, y, w: box.w, h, sizing: { type: 'contain', w: box.w, h }, altText: b.alt });
       } else {
         s.addText(`[이미지: ${b.alt || b.src}]`, {
-          x: BODY.x,
+          x: box.x,
           y,
-          w: BODY.w,
-          h: 0.5,
-          fontFace: FONT,
-          fontSize: 12,
+          w: box.w,
+          h: 0.45,
+          fontFace: fontFaceForTheme(b.alt || b.src, theme),
+          fontSize: theme.typeScale.caption,
           italic: true,
-          color: COLORS.faint,
+          color: theme.palette.muted,
+          margin: 0,
         });
-        y -= h - 0.5;
       }
-      y += h + 0.15;
+      y += h + profile.gap;
     }
   }
   flushText();
+}
 
+async function renderContentSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  if (slide.title) addTitle(s, slide, theme);
+  const bodyTop = bodyTopFor(slide, theme);
+  await renderBlocks(
+    s,
+    slide.body,
+    theme,
+    {
+      x: theme.spacing.marginX,
+      y: bodyTop,
+      w: PAGE_W - theme.spacing.marginX * 2,
+      h: theme.spacing.bodyBottom - bodyTop,
+    },
+    baseDir,
+  );
   if (slide.notes) s.addNotes(slide.notes);
 }
 
-/**
- * Slide[] → .pptx ArrayBuffer.
- * @param baseDir 현재 문서 디렉토리(상대 이미지 경로 해석용, 옵션)
- */
+async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  if (slide.title) addTitle(s, slide, theme);
+  const x = theme.spacing.marginX;
+  const y = bodyTopFor(slide, theme);
+  const w = PAGE_W - x * 2;
+  const gap = Math.max(0.34, theme.spacing.columnGap);
+  const colW = (w - gap) / 2;
+  const columns = slide.columns?.length ? slide.columns : [slide.body.slice(0, Math.ceil(slide.body.length / 2)), slide.body.slice(Math.ceil(slide.body.length / 2))];
+  const cardPadX = 0.22;
+  const cardPadY = 0.18;
+  const cardY = y - 0.06;
+  const maxCardH = Math.max(1.52, theme.spacing.bodyBottom - cardY);
+  const innerW = colW - cardPadX * 1.55;
+  const maxInnerH = Math.max(0.9, maxCardH - cardPadY * 2);
+  const leftProfile = blockRenderProfile(columns[0] ?? [], theme, { w: innerW, h: maxInnerH });
+  const rightProfile = blockRenderProfile(columns[1] ?? [], theme, { w: innerW, h: maxInnerH });
+  const leftH = estimateBlocksHeight(columns[0] ?? [], theme, innerW, leftProfile);
+  const rightH = estimateBlocksHeight(columns[1] ?? [], theme, innerW, rightProfile);
+  const cardH = Math.min(maxCardH, Math.max(1.72, leftH, rightH) + cardPadY * 2 + 0.16);
+  const cardBoxes = [
+    { x, accent: theme.palette.accent },
+    { x: x + colW + gap, accent: theme.palette.accent2 },
+  ];
+
+  for (const box of cardBoxes) {
+    s.addShape(RECT_SHAPE, {
+      x: box.x,
+      y: cardY,
+      w: colW,
+      h: cardH,
+      fill: { color: theme.palette.surface, transparency: 0 },
+      line: { color: theme.palette.border, width: 0.7 },
+    });
+    s.addShape(RECT_SHAPE, {
+      x: box.x,
+      y: cardY,
+      w: 0.06,
+      h: cardH,
+      fill: { color: box.accent, transparency: 0 },
+      line: { color: box.accent, transparency: 100 },
+    });
+  }
+
+  await renderBlocks(s, columns[0] ?? [], theme, { x: x + cardPadX, y: y + cardPadY, w: innerW, h: cardH - cardPadY * 2 }, baseDir);
+  await renderBlocks(s, columns[1] ?? [], theme, { x: x + colW + gap + cardPadX, y: y + cardPadY, w: innerW, h: cardH - cardPadY * 2 }, baseDir);
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
+function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  addSectionTrail(s, slide, theme);
+  const quote = slide.quote?.text || flattenText(slide.body) || slide.title;
+  s.addText('“', {
+    x: theme.spacing.marginX,
+    y: 1.08,
+    w: 1.0,
+    h: 0.8,
+    fontFace: fontFaceForTheme('“', theme, 'heading'),
+    fontSize: 54,
+    color: theme.palette.accent,
+    margin: 0,
+  });
+  s.addText(quote, {
+    x: theme.spacing.marginX + 0.55,
+    y: 1.75,
+    w: PAGE_W - theme.spacing.marginX * 2 - 0.7,
+    h: 2.2,
+    fontFace: fontFaceForTheme(quote, theme, 'heading'),
+    fontSize: 28,
+    bold: true,
+    color: theme.palette.title,
+    margin: 0,
+    fit: 'shrink',
+  });
+  const attribution = slide.quote?.attribution || slide.title;
+  if (attribution) {
+    s.addText(attribution, {
+      x: theme.spacing.marginX + 0.6,
+      y: 4.24,
+      w: PAGE_W - 2.2,
+      h: 0.45,
+      fontFace: fontFaceForTheme(attribution, theme),
+      fontSize: theme.typeScale.body,
+      color: theme.palette.muted,
+      margin: 0,
+    });
+  }
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
+function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  if (slide.title) addTitle(s, slide, theme);
+  const stat = slide.stat;
+  s.addText(stat?.value || 'Key point', {
+    x: theme.spacing.marginX,
+    y: 2.05,
+    w: PAGE_W - theme.spacing.marginX * 2,
+    h: 1.25,
+    fontFace: fontFaceForTheme(stat?.value || 'Key point', theme, 'heading'),
+    fontSize: theme.typeScale.stat,
+    bold: true,
+    color: theme.palette.accent,
+    margin: 0,
+    fit: 'shrink',
+  });
+  const statLabel = stat?.label || flattenText(slide.body).slice(0, 140);
+  s.addText(statLabel, {
+    x: theme.spacing.marginX + 0.05,
+    y: 3.45,
+    w: PAGE_W - theme.spacing.marginX * 2,
+    h: 0.75,
+    fontFace: fontFaceForTheme(statLabel, theme),
+    fontSize: 20,
+    bold: true,
+    color: theme.palette.title,
+    margin: 0,
+    fit: 'shrink',
+  });
+  if (stat?.context) {
+    s.addText(stat.context, {
+      x: theme.spacing.marginX + 0.05,
+      y: 4.35,
+      w: PAGE_W - theme.spacing.marginX * 2 - 1.4,
+      h: 0.8,
+      fontFace: fontFaceForTheme(stat.context, theme),
+      fontSize: theme.typeScale.body,
+      color: theme.palette.body,
+      margin: 0,
+      fit: 'shrink',
+    });
+  }
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
+async function renderImageFocusSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
+  const s = pptx.addSlide({ masterName: 'CONTENT' });
+  const src = slide.image?.src || slide.body.find((b): b is Extract<SlideBlock, { kind: 'image' }> => b.kind === 'image')?.src;
+  const img = src ? await resolveImage(src, baseDir) : null;
+  if (img) {
+    s.addImage({ ...img, x: 0, y: 0, w: PAGE_W, h: PAGE_H, sizing: { type: 'cover', w: PAGE_W, h: PAGE_H }, altText: slide.image?.alt });
+    s.addShape(RECT_SHAPE, { x: 0, y: 0, w: PAGE_W * 0.45, h: PAGE_H, fill: { color: theme.palette.title, transparency: 10 }, line: { color: theme.palette.title, transparency: 100 } });
+    s.addText(slide.title, {
+      x: 0.72,
+      y: 1.0,
+      w: PAGE_W * 0.36,
+      h: 1.3,
+      fontFace: fontFaceForTheme(slide.title, theme, 'heading'),
+      fontSize: titleMetrics(slide, theme).fontSize,
+      bold: true,
+      color: theme.palette.inverseText,
+      margin: 0,
+      fit: 'shrink',
+    });
+    const body = flattenText(slide.body.filter((b) => b.kind !== 'image')).slice(0, 210);
+    if (body) {
+      s.addText(body, {
+        x: 0.74,
+        y: 2.55,
+        w: PAGE_W * 0.34,
+        h: 2.0,
+        fontFace: fontFaceForTheme(body, theme),
+        fontSize: theme.typeScale.body,
+        color: theme.palette.inverseText,
+        margin: 0,
+        fit: 'shrink',
+      });
+    }
+  } else {
+    if (slide.title) addTitle(s, slide, theme);
+    const bodyTop = bodyTopFor(slide, theme);
+    await renderBlocks(s, slide.body, theme, { x: theme.spacing.marginX, y: bodyTop, w: PAGE_W - theme.spacing.marginX * 2, h: theme.spacing.bodyBottom - bodyTop }, baseDir);
+  }
+  if (slide.notes) s.addNotes(slide.notes);
+}
+
 export async function buildPptx(
   slides: Slide[],
-  opts?: { title?: string; baseDir?: string },
+  opts?: { title?: string; baseDir?: string; theme?: SlideTheme },
 ): Promise<ArrayBuffer> {
+  const theme = opts?.theme ?? DEFAULT_SLIDE_THEME;
   const pptx = new PptxGenJS();
-  pptx.defineLayout({ name: 'MM_16x9', width: PAGE_W, height: 7.5 });
+  pptx.defineLayout({ name: 'MM_16x9', width: PAGE_W, height: PAGE_H });
   pptx.layout = 'MM_16x9';
   pptx.author = 'MarkMind';
   if (opts?.title) pptx.title = opts.title;
-  defineMasters(pptx);
+  defineMasters(pptx, theme);
 
   for (const slide of slides) {
-    if (slide.layout === 'title') renderTitleSlide(pptx, slide);
-    else await renderContentSlide(pptx, slide, opts?.baseDir);
+    if (slide.layout === 'title') renderTitleSlide(pptx, slide, theme);
+    else if (slide.layout === 'section') renderSectionSlide(pptx, slide, theme);
+    else if (slide.layout === 'two-column' || slide.layout === 'comparison') await renderTwoColumnSlide(pptx, slide, theme, opts?.baseDir);
+    else if (slide.layout === 'quote') renderQuoteSlide(pptx, slide, theme);
+    else if (slide.layout === 'stat') renderStatSlide(pptx, slide, theme);
+    else if (slide.layout === 'image-focus') await renderImageFocusSlide(pptx, slide, theme, opts?.baseDir);
+    else await renderContentSlide(pptx, slide, theme, opts?.baseDir);
   }
 
   return (await pptx.write({ outputType: 'arraybuffer' })) as ArrayBuffer;

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -4,6 +4,15 @@ import PptxGenJS from 'pptxgenjs';
 import type { Slide, SlideBlock, InlineSpan } from './markdownToSlides';
 import { DEFAULT_SLIDE_THEME, type SlideTheme } from './slideTheme';
 import { pptxFontFaceForText } from './pptxDesignSystem';
+import {
+  masterSpecIncludes,
+  resolveSlideMasterSpec,
+  type MasterElementStyle,
+  type MasterTextPosition,
+  type SlideMasterRole,
+  type SlideMasterSpec,
+  type SlideMasterTextSpec,
+} from './slideMaster';
 
 const PAGE_W = 13.333;
 const PAGE_H = 7.5;
@@ -30,6 +39,8 @@ const MIME: Record<string, string> = {
   bmp: 'image/bmp',
 };
 
+type MasterObject = NonNullable<PptxGenJS.SlideMasterProps['objects']>[number];
+
 const flattenText = (blocks: SlideBlock[]) =>
   blocks
     .map((b) => {
@@ -42,26 +53,102 @@ const flattenText = (blocks: SlideBlock[]) =>
     .filter(Boolean)
     .join(' ');
 
-function defineMasters(pptx: Pptx, theme: SlideTheme) {
-  const footer = { x: PAGE_W - 0.9, y: 7.06, color: theme.palette.muted, fontSize: 9 };
+function masterTextColor(theme: SlideTheme, role: SlideMasterRole, style: MasterElementStyle = 'muted'): string {
+  if (style === 'accent') return role === 'content' ? theme.palette.accent : theme.palette.accent2;
+  if (style === 'inverse') return role === 'content' ? theme.palette.title : theme.palette.inverseText;
+  if (role === 'content') return style === 'minimal' ? theme.palette.border : theme.palette.muted;
+  return style === 'minimal' ? theme.palette.accent : theme.palette.inverseText;
+}
+
+function masterTextPlacement(
+  position: MasterTextPosition = 'bottom-right',
+  textWidth = 0.9,
+  marginX = 0.72,
+): { x: number; y: number; w: number; h: number; align: 'left' | 'center' | 'right' } {
+  const w = Math.min(4.4, Math.max(0.72, textWidth));
+  if (position === 'bottom-left') return { x: marginX, y: 7.06, w, h: 0.24, align: 'left' };
+  if (position === 'bottom-center') return { x: (PAGE_W - w) / 2, y: 7.06, w, h: 0.24, align: 'center' };
+  return { x: PAGE_W - marginX - w, y: 7.06, w, h: 0.24, align: 'right' };
+}
+
+function estimatedMasterTextWidth(text: string): number {
+  return Math.min(4.4, Math.max(1.2, Array.from(text).length * 0.078));
+}
+
+function slideNumberProps(
+  spec: SlideMasterTextSpec | undefined,
+  role: SlideMasterRole,
+  theme: SlideTheme,
+): PptxGenJS.SlideNumberProps | undefined {
+  if (!masterSpecIncludes(spec, role)) return undefined;
+  return {
+    ...masterTextPlacement(spec?.position, 0.74, theme.spacing.marginX),
+    fontFace: fontFaceForTheme('9', theme),
+    fontSize: 9,
+    color: masterTextColor(theme, role, spec?.style),
+    margin: 0,
+  };
+}
+
+function masterTextObject(
+  text: string | undefined,
+  spec: (SlideMasterTextSpec & { text?: string }) | undefined,
+  role: SlideMasterRole,
+  theme: SlideTheme,
+): MasterObject | undefined {
+  if (!text || !masterSpecIncludes(spec, role)) return undefined;
+  const placement = masterTextPlacement(spec?.position, estimatedMasterTextWidth(text), theme.spacing.marginX);
+  return {
+    text: {
+      text,
+      options: {
+        ...placement,
+        fontFace: fontFaceForTheme(text, theme),
+        fontSize: 9,
+        color: masterTextColor(theme, role, spec?.style),
+        margin: 0,
+        fit: 'shrink',
+      },
+    },
+  };
+}
+
+function masterChromeObjects(
+  theme: SlideTheme,
+  role: SlideMasterRole,
+  inverse: boolean,
+  spec: SlideMasterSpec,
+): MasterObject[] {
+  const objects: MasterObject[] = motifObjects(theme, inverse);
+  const footer = masterTextObject(spec.footer?.text, spec.footer, role, theme);
+  const date = masterTextObject(spec.date?.text, spec.date, role, theme);
+  if (footer) objects.push(footer);
+  if (date) objects.push(date);
+  return objects;
+}
+
+function defineMasters(pptx: Pptx, theme: SlideTheme, inputMasterSpec?: SlideMasterSpec) {
+  const masterSpec = resolveSlideMasterSpec(inputMasterSpec);
   pptx.defineSlideMaster({
     title: 'TITLE_SLIDE',
     background: { color: theme.palette.title },
     objects: [
       { rect: { x: 0, y: 0, w: PAGE_W, h: PAGE_H, fill: { color: theme.palette.title }, line: { color: theme.palette.title } } },
-      ...motifObjects(theme, true),
+      ...masterChromeObjects(theme, 'title', true, masterSpec),
     ],
+    slideNumber: slideNumberProps(masterSpec.slideNumber, 'title', theme),
   });
   pptx.defineSlideMaster({
     title: 'CONTENT',
     background: { color: theme.palette.bg },
-    objects: motifObjects(theme, false),
-    slideNumber: footer,
+    objects: masterChromeObjects(theme, 'content', false, masterSpec),
+    slideNumber: slideNumberProps(masterSpec.slideNumber, 'content', theme),
   });
   pptx.defineSlideMaster({
     title: 'SECTION',
     background: { color: theme.palette.title },
-    objects: motifObjects(theme, true),
+    objects: masterChromeObjects(theme, 'section', true, masterSpec),
+    slideNumber: slideNumberProps(masterSpec.slideNumber, 'section', theme),
   });
 }
 
@@ -97,6 +184,7 @@ function spansToRich(
     color?: string;
     lineSpacingMultiple?: number;
     paraSpaceAfter?: number;
+    paraSpaceBefore?: number;
   },
 ) {
   return spans.map((s, idx) => ({
@@ -114,6 +202,7 @@ function spansToRich(
         : {}),
       lineSpacingMultiple: base.lineSpacingMultiple,
       paraSpaceAfter: base.paraSpaceAfter,
+      paraSpaceBefore: base.paraSpaceBefore,
       fontSize: base.fontSize,
       color: base.color,
     },
@@ -140,6 +229,67 @@ async function resolveImage(
     console.warn('[buildPptx] 이미지 로드 실패, 건너뜀:', src, e);
     return null;
   }
+}
+
+function slideImageSrc(slide: Slide): string | undefined {
+  return slide.image?.src?.trim() || undefined;
+}
+
+async function addSlideImage(
+  s: PptxSlide,
+  slide: Slide,
+  baseDir: string | undefined,
+  box: { x: number; y: number; w: number; h: number },
+  sizing: 'contain' | 'cover' = 'contain',
+): Promise<boolean> {
+  const src = slideImageSrc(slide);
+  if (!src) return false;
+  const img = await resolveImage(src, baseDir);
+  if (!img) return false;
+  s.addImage({
+    ...img,
+    ...box,
+    sizing: { type: sizing, w: box.w, h: box.h },
+    altText: slide.image?.alt || slide.title,
+  });
+  return true;
+}
+
+async function addSlideBackgroundImage(
+  s: PptxSlide,
+  slide: Slide,
+  theme: SlideTheme,
+  baseDir?: string,
+): Promise<boolean> {
+  const added = await addSlideImage(s, slide, baseDir, { x: 0, y: 0, w: PAGE_W, h: PAGE_H }, 'cover');
+  if (!added) return false;
+  s.addShape(RECT_SHAPE, {
+    x: 0,
+    y: 0,
+    w: PAGE_W,
+    h: PAGE_H,
+    fill: { color: theme.palette.title, transparency: 18 },
+    line: { color: theme.palette.title, transparency: 100 },
+  });
+  return true;
+}
+
+async function addSlideImagePanel(
+  s: PptxSlide,
+  slide: Slide,
+  theme: SlideTheme,
+  baseDir: string | undefined,
+  box: { x: number; y: number; w: number; h: number },
+  sizing: 'contain' | 'cover' = 'cover',
+): Promise<boolean> {
+  const added = await addSlideImage(s, slide, baseDir, box, sizing);
+  if (!added) return false;
+  s.addShape(RECT_SHAPE, {
+    ...box,
+    fill: { color: theme.palette.surface, transparency: 100 },
+    line: { color: theme.palette.border, transparency: 12, width: 0.7 },
+  });
+  return true;
 }
 
 function headingLevelFor(slide: Slide): number {
@@ -203,6 +353,7 @@ type BlockRenderProfile = {
   bodyFontSize: number;
   lineSpacingMultiple: number;
   paraSpaceAfter: number;
+  subheadSpaceBefore: number;
   gap: number;
 };
 
@@ -253,6 +404,7 @@ function defaultBlockProfile(theme: SlideTheme): BlockRenderProfile {
     bodyFontSize: theme.typeScale.body,
     lineSpacingMultiple: 1.12,
     paraSpaceAfter: 3,
+    subheadSpaceBefore: 10,
     gap: theme.spacing.gap,
   };
 }
@@ -264,14 +416,15 @@ function estimateTextRunHeight(
   profile: BlockRenderProfile,
 ): number {
   if (blocks.length === 0) return 0;
-  const height = blocks.reduce((sum, block) => {
+  const height = blocks.reduce((sum, block, idx) => {
     const fontSize = fontSizeForBlock(block, theme, profile);
     const indent = block.kind === 'bullet' ? 1 + block.indent : 0;
     const lines = estimatedLineCount(blockText(block), boxW, fontSize, indent);
     const lineHeight = (fontSize * profile.lineSpacingMultiple) / 72;
     const paragraphBreath = block.kind === 'subhead' ? 0.05 : 0.015;
+    const groupSpace = block.kind === 'subhead' && idx > 0 ? profile.subheadSpaceBefore / 72 : 0;
     const paragraphSpace = block === blocks[blocks.length - 1] ? 0 : profile.paraSpaceAfter / 72;
-    return sum + Math.max(0.24, lines * lineHeight) + paragraphSpace + paragraphBreath;
+    return sum + groupSpace + Math.max(0.24, lines * lineHeight) + paragraphSpace + paragraphBreath;
   }, 0);
   return Math.max(0.46, height + 0.02);
 }
@@ -335,6 +488,7 @@ function blockRenderProfile(blocks: SlideBlock[], theme: SlideTheme, box: { w: n
         bodyFontSize,
         lineSpacingMultiple: clamp(1.14 + growth * 0.014, 1.16, 1.34),
         paraSpaceAfter: clamp(4 + growth * 1.35, 5, 18),
+        subheadSpaceBefore: clamp(11 + growth * 1.25, 12, 20),
         gap: Math.min(0.34, theme.spacing.gap + growth * 0.012),
       };
       const candidateUsage = estimateBlocksHeight(blocks, theme, box.w, candidate) / Math.max(1, box.h);
@@ -351,6 +505,7 @@ function blockRenderProfile(blocks: SlideBlock[], theme: SlideTheme, box: { w: n
       bodyFontSize: clamp(theme.typeScale.body - 2, 12, theme.typeScale.body),
       lineSpacingMultiple: 1.04,
       paraSpaceAfter: 1,
+      subheadSpaceBefore: 6,
       gap: Math.max(0.08, theme.spacing.gap - 0.04),
     };
   }
@@ -359,6 +514,7 @@ function blockRenderProfile(blocks: SlideBlock[], theme: SlideTheme, box: { w: n
       bodyFontSize: clamp(theme.typeScale.body - 1, 13, theme.typeScale.body),
       lineSpacingMultiple: 1.08,
       paraSpaceAfter: 2,
+      subheadSpaceBefore: 8,
       gap: Math.max(0.1, theme.spacing.gap - 0.02),
     };
   }
@@ -383,8 +539,9 @@ function addTitle(s: PptxSlide, slide: Slide, theme: SlideTheme, inverse = false
   });
 }
 
-function renderTitleSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+async function renderTitleSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
   const s = pptx.addSlide({ masterName: 'TITLE_SLIDE' });
+  await addSlideBackgroundImage(s, slide, theme, baseDir);
   s.addText(slide.title || 'Untitled', {
     x: 0.8,
     y: 2.28,
@@ -417,8 +574,9 @@ function renderTitleSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   if (slide.notes) s.addNotes(slide.notes);
 }
 
-function renderSectionSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+async function renderSectionSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
   const s = pptx.addSlide({ masterName: 'SECTION' });
+  await addSlideBackgroundImage(s, slide, theme, baseDir);
   addSectionTrail(s, slide, theme, true);
   const level = headingLevelFor(slide);
   s.addText(slide.title || flattenText(slide.body) || 'Section', {
@@ -468,7 +626,8 @@ async function renderBlocks(
   const flushText = () => {
     if (textRun.length === 0) return;
     const rich: ReturnType<typeof spansToRich> = [];
-    for (const b of textRun) {
+    for (let idx = 0; idx < textRun.length; idx++) {
+      const b = textRun[idx];
       if (b.kind === 'subhead') {
         rich.push(
           ...spansToRich([{ text: b.text, bold: true }], theme, {
@@ -476,6 +635,7 @@ async function renderBlocks(
             fontSize: fontSizeForBlock(b, theme, profile),
             color: theme.palette.accent,
             lineSpacingMultiple: profile.lineSpacingMultiple,
+            paraSpaceBefore: idx > 0 ? profile.subheadSpaceBefore : undefined,
             paraSpaceAfter: Math.max(profile.paraSpaceAfter + 1, 4),
           }),
         );
@@ -595,14 +755,26 @@ async function renderContentSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, b
   const s = pptx.addSlide({ masterName: 'CONTENT' });
   if (slide.title) addTitle(s, slide, theme);
   const bodyTop = bodyTopFor(slide, theme);
+  const hasResolvedImage = Boolean(slideImageSrc(slide));
+  const totalX = theme.spacing.marginX;
+  const totalW = PAGE_W - theme.spacing.marginX * 2;
+  const imageW = hasResolvedImage ? Math.min(4.25, totalW * 0.38) : 0;
+  const imageGap = hasResolvedImage ? Math.max(0.34, theme.spacing.columnGap) : 0;
+  const imageBox = {
+    x: totalX + totalW - imageW,
+    y: bodyTop,
+    w: imageW,
+    h: theme.spacing.bodyBottom - bodyTop,
+  };
+  const imageAdded = hasResolvedImage ? await addSlideImage(s, slide, baseDir, imageBox, 'contain') : false;
   await renderBlocks(
     s,
     slide.body,
     theme,
     {
-      x: theme.spacing.marginX,
+      x: totalX,
       y: bodyTop,
-      w: PAGE_W - theme.spacing.marginX * 2,
+      w: imageAdded ? Math.max(3.8, totalW - imageW - imageGap) : totalW,
       h: theme.spacing.bodyBottom - bodyTop,
     },
     baseDir,
@@ -616,13 +788,24 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
   const x = theme.spacing.marginX;
   const y = bodyTopFor(slide, theme);
   const w = PAGE_W - x * 2;
-  const gap = Math.max(0.34, theme.spacing.columnGap);
-  const colW = (w - gap) / 2;
   const columns = slide.columns?.length ? slide.columns : [slide.body.slice(0, Math.ceil(slide.body.length / 2)), slide.body.slice(Math.ceil(slide.body.length / 2))];
   const cardPadX = 0.22;
   const cardPadY = 0.18;
   const cardY = y - 0.06;
   const maxCardH = Math.max(1.52, theme.spacing.bodyBottom - cardY);
+  const hasResolvedImage = Boolean(slideImageSrc(slide));
+  const imageW = hasResolvedImage ? Math.min(3.05, w * 0.28) : 0;
+  const imageGap = hasResolvedImage ? Math.max(0.34, theme.spacing.columnGap) : 0;
+  const imageBox = {
+    x: x + w - imageW,
+    y: cardY,
+    w: imageW,
+    h: maxCardH,
+  };
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const contentW = imageAdded ? w - imageW - imageGap : w;
+  const gap = Math.max(0.34, theme.spacing.columnGap);
+  const colW = (contentW - gap) / 2;
   const innerW = colW - cardPadX * 1.55;
   const maxInnerH = Math.max(0.9, maxCardH - cardPadY * 2);
   const leftProfile = blockRenderProfile(columns[0] ?? [], theme, { w: innerW, h: maxInnerH });
@@ -659,10 +842,23 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
   if (slide.notes) s.addNotes(slide.notes);
 }
 
-function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+async function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
   const s = pptx.addSlide({ masterName: 'CONTENT' });
   addSectionTrail(s, slide, theme);
   const quote = slide.quote?.text || flattenText(slide.body) || slide.title;
+  const hasResolvedImage = Boolean(slideImageSrc(slide));
+  const imageW = hasResolvedImage ? 3.75 : 0;
+  const imageBox = {
+    x: PAGE_W - theme.spacing.marginX - imageW,
+    y: 1.16,
+    w: imageW,
+    h: 4.52,
+  };
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const quoteX = theme.spacing.marginX + 0.55;
+  const quoteW = imageAdded
+    ? Math.max(5.4, imageBox.x - quoteX - Math.max(0.42, theme.spacing.columnGap))
+    : PAGE_W - theme.spacing.marginX * 2 - 0.7;
   s.addText('“', {
     x: theme.spacing.marginX,
     y: 1.08,
@@ -674,9 +870,9 @@ function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
     margin: 0,
   });
   s.addText(quote, {
-    x: theme.spacing.marginX + 0.55,
+    x: quoteX,
     y: 1.75,
-    w: PAGE_W - theme.spacing.marginX * 2 - 0.7,
+    w: quoteW,
     h: 2.2,
     fontFace: fontFaceForTheme(quote, theme, 'heading'),
     fontSize: 28,
@@ -688,9 +884,9 @@ function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   const attribution = slide.quote?.attribution || slide.title;
   if (attribution) {
     s.addText(attribution, {
-      x: theme.spacing.marginX + 0.6,
+      x: quoteX + 0.05,
       y: 4.24,
-      w: PAGE_W - 2.2,
+      w: quoteW,
       h: 0.45,
       fontFace: fontFaceForTheme(attribution, theme),
       fontSize: theme.typeScale.body,
@@ -701,14 +897,27 @@ function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   if (slide.notes) s.addNotes(slide.notes);
 }
 
-function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
+async function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, baseDir?: string) {
   const s = pptx.addSlide({ masterName: 'CONTENT' });
   if (slide.title) addTitle(s, slide, theme);
   const stat = slide.stat;
+  const hasResolvedImage = Boolean(slideImageSrc(slide));
+  const imageW = hasResolvedImage ? 3.55 : 0;
+  const imageBox = {
+    x: PAGE_W - theme.spacing.marginX - imageW,
+    y: bodyTopFor(slide, theme),
+    w: imageW,
+    h: theme.spacing.bodyBottom - bodyTopFor(slide, theme),
+  };
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const textX = theme.spacing.marginX;
+  const textW = imageAdded
+    ? Math.max(5.5, imageBox.x - textX - Math.max(0.46, theme.spacing.columnGap))
+    : PAGE_W - theme.spacing.marginX * 2;
   s.addText(stat?.value || 'Key point', {
-    x: theme.spacing.marginX,
+    x: textX,
     y: 2.05,
-    w: PAGE_W - theme.spacing.marginX * 2,
+    w: textW,
     h: 1.25,
     fontFace: fontFaceForTheme(stat?.value || 'Key point', theme, 'heading'),
     fontSize: theme.typeScale.stat,
@@ -719,9 +928,9 @@ function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   });
   const statLabel = stat?.label || flattenText(slide.body).slice(0, 140);
   s.addText(statLabel, {
-    x: theme.spacing.marginX + 0.05,
+    x: textX + 0.05,
     y: 3.45,
-    w: PAGE_W - theme.spacing.marginX * 2,
+    w: textW,
     h: 0.75,
     fontFace: fontFaceForTheme(statLabel, theme),
     fontSize: 20,
@@ -732,9 +941,9 @@ function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme) {
   });
   if (stat?.context) {
     s.addText(stat.context, {
-      x: theme.spacing.marginX + 0.05,
+      x: textX + 0.05,
       y: 4.35,
-      w: PAGE_W - theme.spacing.marginX * 2 - 1.4,
+      w: Math.max(3.8, textW - 1.4),
       h: 0.8,
       fontFace: fontFaceForTheme(stat.context, theme),
       fontSize: theme.typeScale.body,
@@ -789,7 +998,7 @@ async function renderImageFocusSlide(pptx: Pptx, slide: Slide, theme: SlideTheme
 
 export async function buildPptx(
   slides: Slide[],
-  opts?: { title?: string; baseDir?: string; theme?: SlideTheme },
+  opts?: { title?: string; baseDir?: string; theme?: SlideTheme; masterSpec?: SlideMasterSpec },
 ): Promise<ArrayBuffer> {
   const theme = opts?.theme ?? DEFAULT_SLIDE_THEME;
   const pptx = new PptxGenJS();
@@ -797,14 +1006,14 @@ export async function buildPptx(
   pptx.layout = 'MM_16x9';
   pptx.author = 'MarkMind';
   if (opts?.title) pptx.title = opts.title;
-  defineMasters(pptx, theme);
+  defineMasters(pptx, theme, opts?.masterSpec);
 
   for (const slide of slides) {
-    if (slide.layout === 'title') renderTitleSlide(pptx, slide, theme);
-    else if (slide.layout === 'section') renderSectionSlide(pptx, slide, theme);
+    if (slide.layout === 'title') await renderTitleSlide(pptx, slide, theme, opts?.baseDir);
+    else if (slide.layout === 'section') await renderSectionSlide(pptx, slide, theme, opts?.baseDir);
     else if (slide.layout === 'two-column' || slide.layout === 'comparison') await renderTwoColumnSlide(pptx, slide, theme, opts?.baseDir);
-    else if (slide.layout === 'quote') renderQuoteSlide(pptx, slide, theme);
-    else if (slide.layout === 'stat') renderStatSlide(pptx, slide, theme);
+    else if (slide.layout === 'quote') await renderQuoteSlide(pptx, slide, theme, opts?.baseDir);
+    else if (slide.layout === 'stat') await renderStatSlide(pptx, slide, theme, opts?.baseDir);
     else if (slide.layout === 'image-focus') await renderImageFocusSlide(pptx, slide, theme, opts?.baseDir);
     else await renderContentSlide(pptx, slide, theme, opts?.baseDir);
   }

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -867,7 +867,12 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
   const x = theme.spacing.marginX;
   const y = bodyTopFor(slide, theme);
   const w = PAGE_W - x * 2;
-  const columns = slide.columns?.length ? slide.columns : [slide.body.slice(0, Math.ceil(slide.body.length / 2)), slide.body.slice(Math.ceil(slide.body.length / 2))];
+  const rawColumns = slide.columns?.length
+    ? slide.columns
+    : [slide.body.slice(0, Math.ceil(slide.body.length / 2)), slide.body.slice(Math.ceil(slide.body.length / 2))];
+  const columnCount = Math.max(2, Math.min(3, rawColumns.length || 2));
+  const columns = rawColumns.slice(0, columnCount);
+  while (columns.length < columnCount) columns.push([]);
   const cardPadX = 0.22;
   const cardPadY = 0.18;
   const cardY = y - 0.06;
@@ -883,19 +888,18 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
   };
   const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'contain') : false;
   const contentW = imageAdded ? w - imageW - imageGap : w;
-  const gap = Math.max(0.34, theme.spacing.columnGap);
-  const colW = (contentW - gap) / 2;
-  const innerW = colW - cardPadX * 1.55;
+  const gap = Math.max(0.28, theme.spacing.columnGap * (columnCount === 3 ? 0.78 : 1));
+  const colW = (contentW - gap * (columnCount - 1)) / columnCount;
+  const innerW = Math.max(1.05, colW - cardPadX * 1.55);
   const maxInnerH = Math.max(0.9, maxCardH - cardPadY * 2);
-  const leftProfile = blockRenderProfile(columns[0] ?? [], theme, { w: innerW, h: maxInnerH });
-  const rightProfile = blockRenderProfile(columns[1] ?? [], theme, { w: innerW, h: maxInnerH });
-  const leftH = estimateBlocksHeight(columns[0] ?? [], theme, innerW, leftProfile);
-  const rightH = estimateBlocksHeight(columns[1] ?? [], theme, innerW, rightProfile);
-  const cardH = Math.min(maxCardH, Math.max(1.72, leftH, rightH) + cardPadY * 2 + 0.16);
-  const cardBoxes = [
-    { x, accent: theme.palette.accent },
-    { x: x + colW + gap, accent: theme.palette.accent2 },
-  ];
+  const columnProfiles = columns.map((column) => blockRenderProfile(column, theme, { w: innerW, h: maxInnerH }));
+  const columnHeights = columns.map((column, index) => estimateBlocksHeight(column, theme, innerW, columnProfiles[index]));
+  const cardH = Math.min(maxCardH, Math.max(1.72, ...columnHeights) + cardPadY * 2 + 0.16);
+  const accents = [theme.palette.accent, theme.palette.accent2, ...theme.palette.chart];
+  const cardBoxes = Array.from({ length: columnCount }, (_, index) => ({
+    x: x + index * (colW + gap),
+    accent: accents[index % accents.length],
+  }));
 
   for (const box of cardBoxes) {
     s.addShape(RECT_SHAPE, {
@@ -916,8 +920,15 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
     });
   }
 
-  await renderBlocks(s, columns[0] ?? [], theme, { x: x + cardPadX, y: y + cardPadY, w: innerW, h: cardH - cardPadY * 2 }, baseDir);
-  await renderBlocks(s, columns[1] ?? [], theme, { x: x + colW + gap + cardPadX, y: y + cardPadY, w: innerW, h: cardH - cardPadY * 2 }, baseDir);
+  for (let index = 0; index < columnCount; index += 1) {
+    await renderBlocks(
+      s,
+      columns[index] ?? [],
+      theme,
+      { x: x + index * (colW + gap) + cardPadX, y: y + cardPadY, w: innerW, h: cardH - cardPadY * 2 },
+      baseDir,
+    );
+  }
   if (slide.notes) s.addNotes(slide.notes);
 }
 

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -344,13 +344,23 @@ async function addSlideImagePanel(
   box: { x: number; y: number; w: number; h: number },
   sizing: 'contain' | 'cover' = 'contain',
 ): Promise<boolean> {
+  const src = slideImageSrc(slide);
+  if (!src) return false;
+  const img = await resolveImage(src, baseDir);
+  if (!img) return false;
+
   s.addShape(RECT_SHAPE, {
     ...box,
     fill: { color: theme.palette.surfaceAlt, transparency: 0 },
     line: { color: theme.palette.border, transparency: 100 },
   });
-  const added = await addSlideImage(s, slide, baseDir, box, sizing);
-  if (!added) return false;
+  const { width: _width, height: _height, ...imgProps } = img;
+  const fitted = fitImageBox(img, box, sizing);
+  s.addImage({
+    ...imgProps,
+    ...fitted,
+    altText: slide.image?.alt || slide.title,
+  });
   s.addShape(RECT_SHAPE, {
     ...box,
     fill: { color: theme.palette.surface, transparency: 100 },

--- a/src/lib/buildPptx.ts
+++ b/src/lib/buildPptx.ts
@@ -19,6 +19,7 @@ const PAGE_H = 7.5;
 
 type Pptx = InstanceType<typeof PptxGenJS>;
 type PptxSlide = ReturnType<Pptx['addSlide']>;
+type ResolvedImage = { data?: string; path?: string; width?: number; height?: number };
 
 const RECT_SHAPE = 'rect' as PptxGenJS.ShapeType;
 
@@ -212,8 +213,8 @@ function spansToRich(
 async function resolveImage(
   src: string,
   baseDir?: string,
-): Promise<{ data?: string; path?: string } | null> {
-  if (src.startsWith('data:')) return { data: src };
+): Promise<ResolvedImage | null> {
+  if (src.startsWith('data:')) return { data: src, ...imageDimensionsFromDataUrl(src) };
   if (/^https?:\/\//i.test(src)) return { path: src };
   try {
     const { readFile } = await import('@tauri-apps/plugin-fs');
@@ -224,11 +225,71 @@ async function resolveImage(
     let bin = '';
     for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
     const mime = MIME[ext(p)] ?? 'image/png';
-    return { data: `data:${mime};base64,${btoa(bin)}` };
+    const data = `data:${mime};base64,${btoa(bin)}`;
+    return { data, ...imageDimensionsFromBytes(bytes, mime) };
   } catch (e) {
     console.warn('[buildPptx] 이미지 로드 실패, 건너뜀:', src, e);
     return null;
   }
+}
+
+function bytesFromDataUrl(dataUrl: string): { bytes: Uint8Array; mime: string } | null {
+  const match = dataUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s);
+  if (!match) return null;
+  const raw = match[2] ? atob(match[3] || '') : decodeURIComponent(match[3] || '');
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+  return { bytes, mime: match[1] || 'image/png' };
+}
+
+function imageDimensionsFromDataUrl(dataUrl: string): { width?: number; height?: number } {
+  const parsed = bytesFromDataUrl(dataUrl);
+  return parsed ? imageDimensionsFromBytes(parsed.bytes, parsed.mime) : {};
+}
+
+function imageDimensionsFromBytes(bytes: Uint8Array, mime: string): { width?: number; height?: number } {
+  if (mime.includes('png') && bytes.length >= 24) {
+    const width = (bytes[16] << 24) | (bytes[17] << 16) | (bytes[18] << 8) | bytes[19];
+    const height = (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23];
+    if (width > 0 && height > 0) return { width, height };
+  }
+  if (mime.includes('jpeg') || mime.includes('jpg')) {
+    for (let i = 2; i + 9 < bytes.length;) {
+      if (bytes[i] !== 0xff) break;
+      const marker = bytes[i + 1];
+      const len = (bytes[i + 2] << 8) | bytes[i + 3];
+      if (len < 2) break;
+      if (marker >= 0xc0 && marker <= 0xc3) {
+        const height = (bytes[i + 5] << 8) | bytes[i + 6];
+        const width = (bytes[i + 7] << 8) | bytes[i + 8];
+        if (width > 0 && height > 0) return { width, height };
+      }
+      i += 2 + len;
+    }
+  }
+  if (mime.includes('svg')) {
+    const text = new TextDecoder().decode(bytes);
+    const viewBox = text.match(/viewBox=["']\s*[-.\d]+\s+[-.\d]+\s+([.\d]+)\s+([.\d]+)\s*["']/i);
+    if (viewBox) return { width: Number(viewBox[1]), height: Number(viewBox[2]) };
+    const width = text.match(/\bwidth=["']([.\d]+)(?:px)?["']/i);
+    const height = text.match(/\bheight=["']([.\d]+)(?:px)?["']/i);
+    if (width && height) return { width: Number(width[1]), height: Number(height[1]) };
+  }
+  return {};
+}
+
+function fitImageBox(
+  img: ResolvedImage,
+  box: { x: number; y: number; w: number; h: number },
+  mode: 'contain' | 'cover',
+): { x: number; y: number; w: number; h: number } {
+  if (!img.width || !img.height || img.width <= 0 || img.height <= 0) return box;
+  const imageRatio = img.width / img.height;
+  const boxRatio = box.w / box.h;
+  const fitByWidth = mode === 'contain' ? imageRatio >= boxRatio : imageRatio < boxRatio;
+  const w = fitByWidth ? box.w : box.h * imageRatio;
+  const h = fitByWidth ? box.w / imageRatio : box.h;
+  return { x: box.x + (box.w - w) / 2, y: box.y + (box.h - h) / 2, w, h };
 }
 
 function slideImageSrc(slide: Slide): string | undefined {
@@ -246,10 +307,11 @@ async function addSlideImage(
   if (!src) return false;
   const img = await resolveImage(src, baseDir);
   if (!img) return false;
+  const { width: _width, height: _height, ...imgProps } = img;
+  const fitted = fitImageBox(img, box, sizing);
   s.addImage({
-    ...img,
-    ...box,
-    sizing: { type: sizing, w: box.w, h: box.h },
+    ...imgProps,
+    ...fitted,
     altText: slide.image?.alt || slide.title,
   });
   return true;
@@ -280,8 +342,13 @@ async function addSlideImagePanel(
   theme: SlideTheme,
   baseDir: string | undefined,
   box: { x: number; y: number; w: number; h: number },
-  sizing: 'contain' | 'cover' = 'cover',
+  sizing: 'contain' | 'cover' = 'contain',
 ): Promise<boolean> {
+  s.addShape(RECT_SHAPE, {
+    ...box,
+    fill: { color: theme.palette.surfaceAlt, transparency: 0 },
+    line: { color: theme.palette.border, transparency: 100 },
+  });
   const added = await addSlideImage(s, slide, baseDir, box, sizing);
   if (!added) return false;
   s.addShape(RECT_SHAPE, {
@@ -731,7 +798,9 @@ async function renderBlocks(
       const img = await resolveImage(b.src, baseDir);
       const h = Math.min(avail(), 3.15);
       if (img) {
-        s.addImage({ ...img, x: box.x, y, w: box.w, h, sizing: { type: 'contain', w: box.w, h }, altText: b.alt });
+        const { width: _width, height: _height, ...imgProps } = img;
+        const fitted = fitImageBox(img, { x: box.x, y, w: box.w, h }, 'contain');
+        s.addImage({ ...imgProps, ...fitted, altText: b.alt });
       } else {
         s.addText(`[이미지: ${b.alt || b.src}]`, {
           x: box.x,
@@ -802,7 +871,7 @@ async function renderTwoColumnSlide(pptx: Pptx, slide: Slide, theme: SlideTheme,
     w: imageW,
     h: maxCardH,
   };
-  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'contain') : false;
   const contentW = imageAdded ? w - imageW - imageGap : w;
   const gap = Math.max(0.34, theme.spacing.columnGap);
   const colW = (contentW - gap) / 2;
@@ -854,7 +923,7 @@ async function renderQuoteSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, bas
     w: imageW,
     h: 4.52,
   };
-  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'contain') : false;
   const quoteX = theme.spacing.marginX + 0.55;
   const quoteW = imageAdded
     ? Math.max(5.4, imageBox.x - quoteX - Math.max(0.42, theme.spacing.columnGap))
@@ -909,7 +978,7 @@ async function renderStatSlide(pptx: Pptx, slide: Slide, theme: SlideTheme, base
     w: imageW,
     h: theme.spacing.bodyBottom - bodyTopFor(slide, theme),
   };
-  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'cover') : false;
+  const imageAdded = hasResolvedImage ? await addSlideImagePanel(s, slide, theme, baseDir, imageBox, 'contain') : false;
   const textX = theme.spacing.marginX;
   const textW = imageAdded
     ? Math.max(5.5, imageBox.x - textX - Math.max(0.46, theme.spacing.columnGap))
@@ -960,7 +1029,9 @@ async function renderImageFocusSlide(pptx: Pptx, slide: Slide, theme: SlideTheme
   const src = slide.image?.src || slide.body.find((b): b is Extract<SlideBlock, { kind: 'image' }> => b.kind === 'image')?.src;
   const img = src ? await resolveImage(src, baseDir) : null;
   if (img) {
-    s.addImage({ ...img, x: 0, y: 0, w: PAGE_W, h: PAGE_H, sizing: { type: 'cover', w: PAGE_W, h: PAGE_H }, altText: slide.image?.alt });
+    const { width: _width, height: _height, ...imgProps } = img;
+    const fitted = fitImageBox(img, { x: 0, y: 0, w: PAGE_W, h: PAGE_H }, 'cover');
+    s.addImage({ ...imgProps, ...fitted, altText: slide.image?.alt });
     s.addShape(RECT_SHAPE, { x: 0, y: 0, w: PAGE_W * 0.45, h: PAGE_H, fill: { color: theme.palette.title, transparency: 10 }, line: { color: theme.palette.title, transparency: 100 } });
     s.addText(slide.title, {
       x: 0.72,

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -303,6 +303,20 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.alt).toBe('chart');
   });
 
+  it('source-only PPTX 경로에서 리스트 안의 원본 이미지도 보강', () => {
+    const markdown = ['# Report', 'Intro paragraph.', '## Evidence', '- ![chart](assets/chart.png)', 'Details'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [{ title: 'Evidence', layout: 'content', sourceIds: ['S2'], bullets: ['Details'] }],
+      }),
+    );
+
+    const merged = preserveSourceImagesForPptx(aiSlides ?? [], markdown);
+
+    expect(merged[0].image?.src).toBe('assets/chart.png');
+    expect(merged[0].image?.alt).toBe('chart');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { markdownToSlides, parseInline, slideDeckFromLlmJson, slidesFromLlmJson } from './markdownToSlides';
+import {
+  markdownToSlides,
+  parseInline,
+  preserveSourceImagesForPptx,
+  slideDeckFromLlmJson,
+  slidesFromLlmJson,
+} from './markdownToSlides';
 
 describe('markdownToSlides — 분할 규칙', () => {
   it('수평선(---) 으로 슬라이드를 나눈다', () => {
@@ -263,6 +269,20 @@ describe('slidesFromLlmJson', () => {
     });
     const slides = slidesFromLlmJson(raw);
     expect(slides?.[0].image?.sourcePreference).toBe('none');
+  });
+
+  it('source-only PPTX 경로에서 원본 Markdown 이미지 src를 보강', () => {
+    const sourceSlides = markdownToSlides(['# Visual evidence', '![diagram](assets/diagram.png)', 'supporting text'].join('\n'));
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [{ title: 'Visual evidence', layout: 'content', sourceIds: ['S1'], bullets: ['supporting text'] }],
+      }),
+    );
+
+    const merged = preserveSourceImagesForPptx(aiSlides ?? [], sourceSlides);
+
+    expect(merged[0].image?.src).toBe('assets/diagram.png');
+    expect(merged[0].image?.alt).toBe('diagram');
   });
 
   it('완전 비 JSON 은 null', () => {

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -257,6 +257,14 @@ describe('slidesFromLlmJson', () => {
     });
   });
 
+  it('이미지 제외 의도만 있는 image 객체도 보존', () => {
+    const raw = JSON.stringify({
+      slides: [{ title: 'No visual', layout: 'content', image: { sourcePreference: 'none' }, bullets: ['text only'] }],
+    });
+    const slides = slidesFromLlmJson(raw);
+    expect(slides?.[0].image?.sourcePreference).toBe('none');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -285,6 +285,24 @@ describe('slidesFromLlmJson', () => {
     expect(merged[0].image?.alt).toBe('diagram');
   });
 
+  it('source-only PPTX 경로에서 sourceIds를 원본 source section ID로 매핑', () => {
+    const markdown = ['# Report', 'Intro paragraph.', '## Evidence', '![chart](assets/chart.png)', 'Details'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          { title: 'Report', layout: 'title', sourceIds: ['S1'], bullets: ['Intro paragraph.'] },
+          { title: 'Evidence', layout: 'content', sourceIds: ['S2'], bullets: ['Details'] },
+        ],
+      }),
+    );
+
+    const merged = preserveSourceImagesForPptx(aiSlides ?? [], markdown);
+
+    expect(merged[0].image?.src).toBeUndefined();
+    expect(merged[1].image?.src).toBe('assets/chart.png');
+    expect(merged[1].image?.alt).toBe('chart');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { markdownToSlides, parseInline, slidesFromLlmJson } from './markdownToSlides';
+import { markdownToSlides, parseInline, slideDeckFromLlmJson, slidesFromLlmJson } from './markdownToSlides';
 
 describe('markdownToSlides — 분할 규칙', () => {
   it('수평선(---) 으로 슬라이드를 나눈다', () => {
@@ -168,6 +168,23 @@ describe('slidesFromLlmJson', () => {
     expect(slides?.[0].title).toBe('T');
   });
 
+  it('상위 master 사양을 슬라이드 덱 메타데이터로 보존', () => {
+    const raw = JSON.stringify({
+      master: {
+        slideNumber: { enabled: true, includeOn: ['content', 'section'], position: 'bottom-center' },
+        footer: { text: 'Confidential', includeOn: ['content'], position: 'bottom-left' },
+        date: { enabled: false, text: '2026-06-23' },
+      },
+      slides: [{ title: 'T', layout: 'content', bullets: ['x'] }],
+    });
+    const deck = slideDeckFromLlmJson(raw);
+    expect(deck?.slides.length).toBe(1);
+    expect(deck?.masterSpec?.slideNumber?.includeOn).toEqual(['content', 'section']);
+    expect(deck?.masterSpec?.footer?.text).toBe('Confidential');
+    expect(deck?.masterSpec?.date?.enabled).toBe(false);
+    expect(slidesFromLlmJson(raw)?.[0].title).toBe('T');
+  });
+
   it('잘린 JSON 에서 완성된 슬라이드만 부분 복구', () => {
     // 마지막 객체가 토큰 한도로 잘린 상황
     const raw =
@@ -203,6 +220,18 @@ describe('slidesFromLlmJson', () => {
           layout: 'quote',
           quote: { text: 'Design is a system.', attribution: 'Team note' },
         },
+        {
+          title: 'Visual',
+          layout: 'image-focus',
+          image: {
+            query: 'clean renewable energy infrastructure',
+            entity: 'renewable energy',
+            role: 'hero',
+            aspect: '16:9',
+            sourcePreference: 'auto',
+            licenseStrictness: 'open',
+          },
+        },
       ],
     });
     const slides = slidesFromLlmJson(raw);
@@ -214,6 +243,14 @@ describe('slidesFromLlmJson', () => {
     expect(slides?.[2].columns?.length).toBe(2);
     expect(slides?.[2].columns?.[1][0]).toMatchObject({ kind: 'subhead', level: 3 });
     expect(slides?.[3].quote?.attribution).toBe('Team note');
+    expect(slides?.[4].image).toMatchObject({
+      query: 'clean renewable energy infrastructure',
+      entity: 'renewable energy',
+      role: 'hero',
+      aspect: '16:9',
+      sourcePreference: 'auto',
+      licenseStrictness: 'open',
+    });
   });
 
   it('완전 비 JSON 은 null', () => {

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -202,6 +202,8 @@ describe('slidesFromLlmJson', () => {
         {
           title: 'Why now',
           layout: 'stat',
+          importance: 92,
+          importanceReason: 'core evidence slide',
           sourceIds: ['S2', 'S3'],
           source: { headingLevel: 2, sectionPath: ['Market'] },
           stat: { value: '73%', label: 'teams need cleaner slides', context: 'Survey summary' },
@@ -236,6 +238,8 @@ describe('slidesFromLlmJson', () => {
     });
     const slides = slidesFromLlmJson(raw);
     expect(slides?.[1].layout).toBe('stat');
+    expect(slides?.[1].importance).toBe(92);
+    expect(slides?.[1].importanceReason).toBe('core evidence slide');
     expect(slides?.[1].sourceIds).toEqual(['S2', 'S3']);
     expect(slides?.[1].sourceLevel).toBe(2);
     expect(slides?.[1].sectionPath).toEqual(['Market']);

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -31,6 +31,15 @@ describe('markdownToSlides — 분할 규칙', () => {
     expect(slides.map((s) => s.title)).toEqual(['First', 'Second']);
   });
 
+  it('MarkMind 슬라이드 초안 마커는 PPTX 변환 대상에서 제외한다', () => {
+    const md = ['<!-- markmind:slide-draft v1 -->', '# First', 'content', '---', '# Second'].join('\n');
+    const slides = markdownToSlides(md);
+    expect(slides.map((s) => s.title)).toEqual(['First', 'Second']);
+    expect(slides[0].body.map((b) => ('spans' in b ? b.spans.map((s) => s.text).join('') : ''))).not.toContain(
+      '<!-- markmind:slide-draft v1 -->',
+    );
+  });
+
   it('H1 이 바로 H2 로 이어지면 slide-level=2, H1 은 타이틀 슬라이드', () => {
     const md = ['# Cover', '## Section A', 'a', '## Section B', 'b'].join('\n');
     const slides = markdownToSlides(md);
@@ -42,6 +51,29 @@ describe('markdownToSlides — 분할 규칙', () => {
     ]);
     expect(slides[0].layout).toBe('title');
     expect(slides[1].layout).toBe('content');
+  });
+
+  it('마크다운 헤딩 계층을 슬라이드 출처 정보로 보존', () => {
+    const md = [
+      '# Strategy',
+      '## Problem',
+      'Market is fragmented.',
+      '### Evidence',
+      '- Teams duplicate work',
+      '## Solution',
+      'Create a shared deck pipeline.',
+    ].join('\n');
+    const slides = markdownToSlides(md);
+
+    expect(slides.map((s) => s.title)).toEqual(['Strategy', 'Problem', 'Solution']);
+    expect(slides[0].sourceLevel).toBe(1);
+    expect(slides[0].sectionPath).toBeUndefined();
+    expect(slides[1].sourceLevel).toBe(2);
+    expect(slides[1].sectionPath).toEqual(['Strategy']);
+    expect(slides[2].sectionPath).toEqual(['Strategy']);
+
+    const subhead = slides[1].body.find((b) => b.kind === 'subhead');
+    expect(subhead).toMatchObject({ kind: 'subhead', text: 'Evidence', level: 3 });
   });
 
   it('펜스 코드블록 안의 --- 와 # 은 경계/헤딩이 아니다', () => {
@@ -144,6 +176,44 @@ describe('slidesFromLlmJson', () => {
       '{"title":"C","layout":"content","bullets":["c1",';
     const slides = slidesFromLlmJson(raw);
     expect(slides?.map((s) => s.title)).toEqual(['A', 'B']); // C 는 미완성 → 제외
+  });
+
+  it('확장 레이아웃 필드를 보존', () => {
+    const raw = JSON.stringify({
+      slides: [
+        { title: 'Cover', layout: 'title', bullets: ['subtitle'] },
+        {
+          title: 'Why now',
+          layout: 'stat',
+          sourceIds: ['S2', 'S3'],
+          source: { headingLevel: 2, sectionPath: ['Market'] },
+          stat: { value: '73%', label: 'teams need cleaner slides', context: 'Survey summary' },
+          notes: 'speaker note',
+        },
+        {
+          title: 'Options',
+          layout: 'two-column',
+          columns: [
+            ['Fast setup', 'Good defaults'],
+            [{ kind: 'subhead', text: 'Custom', level: 3 }, { kind: 'text', text: 'DESIGN.md later' }],
+          ],
+        },
+        {
+          title: 'Signal',
+          layout: 'quote',
+          quote: { text: 'Design is a system.', attribution: 'Team note' },
+        },
+      ],
+    });
+    const slides = slidesFromLlmJson(raw);
+    expect(slides?.[1].layout).toBe('stat');
+    expect(slides?.[1].sourceIds).toEqual(['S2', 'S3']);
+    expect(slides?.[1].sourceLevel).toBe(2);
+    expect(slides?.[1].sectionPath).toEqual(['Market']);
+    expect(slides?.[1].stat?.value).toBe('73%');
+    expect(slides?.[2].columns?.length).toBe(2);
+    expect(slides?.[2].columns?.[1][0]).toMatchObject({ kind: 'subhead', level: 3 });
+    expect(slides?.[3].quote?.attribution).toBe('Team note');
   });
 
   it('완전 비 JSON 은 null', () => {

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -317,6 +317,23 @@ describe('slidesFromLlmJson', () => {
     expect(merged[0].image?.alt).toBe('chart');
   });
 
+  it('source-only PPTX 경로에서 같은 sourceId의 원본 이미지를 순서대로 소비', () => {
+    const markdown = ['# Report', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          { title: 'First evidence', layout: 'content', sourceIds: ['S2'], bullets: ['first'] },
+          { title: 'Second evidence', layout: 'content', sourceIds: ['S2'], bullets: ['second'] },
+        ],
+      }),
+    );
+
+    const merged = preserveSourceImagesForPptx(aiSlides ?? [], markdown);
+
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBe('assets/second.png');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -469,7 +469,7 @@ function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
 }
 
 function sourceImageFromLine(line: string): SlideImageSpec | undefined {
-  const img = line.match(IMAGE_ONLY_RE);
+  const img = line.match(/!\[([^\]]*)\]\(([^)]+)\)/);
   if (!img) return undefined;
   return { src: img[2].trim(), alt: img[1], kind: 'source', role: 'support' };
 }
@@ -562,9 +562,11 @@ function sourceIndexFromId(id: string): number | undefined {
  */
 export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | string): Slide[] {
   const sourceSlides = typeof source === 'string' ? markdownToSlides(source) : source;
-  if (!sourceSlides.some(slideHasImageSrc)) return slides;
   const sourceImagesById = typeof source === 'string' ? sourceImageMapFromMarkdown(source) : new Map<string, SlideImageSpec>();
+  if (sourceImagesById.size === 0 && !sourceSlides.some(slideHasImageSrc)) return slides;
   const usedSourceIds = new Set<string>();
+  const sourceImageEntries = [...sourceImagesById.entries()];
+  let nextSourceImageIndex = 0;
   const usedSourceIndexes = new Set<number>();
   const takeSourceImage = (sourceId: string): SlideImageSpec | undefined => {
     const normalized = sourceId.trim().toUpperCase();
@@ -573,6 +575,15 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     if (!image) return undefined;
     usedSourceIds.add(normalized);
     return image;
+  };
+  const takeNextSourceImage = (): SlideImageSpec | undefined => {
+    while (nextSourceImageIndex < sourceImageEntries.length) {
+      const [id, image] = sourceImageEntries[nextSourceImageIndex++];
+      if (usedSourceIds.has(id)) continue;
+      usedSourceIds.add(id);
+      return image;
+    }
+    return undefined;
   };
   const takeImage = (sourceIndex: number | undefined): SlideImageSpec | undefined => {
     if (sourceIndex === undefined || sourceIndex < 0 || sourceIndex >= sourceSlides.length || usedSourceIndexes.has(sourceIndex)) {
@@ -590,6 +601,9 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     for (const sourceId of slide.sourceIds ?? []) {
       image = takeSourceImage(sourceId) ?? (sourceImagesById.size === 0 ? takeImage(sourceIndexFromId(sourceId)) : undefined);
       if (image) break;
+    }
+    if (!image && !slide.sourceIds?.length && sourceImagesById.size > 0) {
+      image = takeNextSourceImage();
     }
     if (!image && (!slide.sourceIds?.length || sourceImagesById.size === 0)) {
       image = takeImage(slideIndex);

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -64,6 +64,9 @@ export interface Slide {
   layout: SlideLayout;
   body: SlideBlock[];
   notes?: string;
+  /** 0-100 deck-level importance hint from the LLM. Renderer/pipeline may re-score deterministically. */
+  importance?: number;
+  importanceReason?: string;
   /** LLM path: source section IDs from the Rust source map, e.g. ["S2", "S5"]. */
   sourceIds?: string[];
   /** 원본 마크다운 헤딩 레벨(H1=1...). LLM 경로도 같은 힌트를 넣을 수 있다. */
@@ -285,6 +288,13 @@ function statFromUnknown(value: unknown): Slide['stat'] | undefined {
   };
 }
 
+function importanceFromUnknown(value: unknown): number | undefined {
+  const raw = typeof value === 'number' ? value : typeof value === 'string' ? Number.parseFloat(value) : NaN;
+  if (!Number.isFinite(raw) || raw <= 0) return undefined;
+  const normalized = raw <= 5 ? raw * 20 : raw;
+  return Math.max(0, Math.min(100, Math.round(normalized)));
+}
+
 function imageFromUnknown(value: unknown): Slide['image'] | undefined {
   if (!value || typeof value !== 'object') return undefined;
   const o = value as Record<string, unknown>;
@@ -343,6 +353,8 @@ function llmObjToSlide(o: Record<string, unknown>, index: number): Slide {
     layout,
     body,
     notes,
+    importance: importanceFromUnknown(o.importance),
+    importanceReason: typeof o.importanceReason === 'string' && o.importanceReason.trim() ? o.importanceReason.trim() : undefined,
     sourceIds,
     sourceLevel: source.sourceLevel,
     sectionPath: source.sectionPath,

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -302,10 +302,16 @@ function imageFromUnknown(value: unknown): Slide['image'] | undefined {
   const prompt = typeof o.prompt === 'string' && o.prompt.trim() ? o.prompt.trim() : undefined;
   const query = typeof o.query === 'string' && o.query.trim() ? o.query.trim() : undefined;
   const entity = typeof o.entity === 'string' && o.entity.trim() ? o.entity.trim() : undefined;
-  if (!src && !prompt && !query && !entity) return undefined;
   const role = oneOf<SlideImageRole>(o.role, ['cover', 'hero', 'support', 'logo', 'icon', 'background']);
   const sourcePreference = oneOf<SlideImageSourcePreference>(o.sourcePreference, ['auto', 'stock', 'logo', 'generated', 'none']);
   const licenseStrictness = oneOf<SlideImageLicenseStrictness>(o.licenseStrictness, ['presentation', 'open', 'internal-only']);
+  const alt = typeof o.alt === 'string' && o.alt.trim() ? o.alt.trim() : undefined;
+  const aspect = typeof o.aspect === 'string' && o.aspect.trim() ? o.aspect.trim() : undefined;
+  const style = typeof o.style === 'string' && o.style.trim() ? o.style.trim() : undefined;
+  const kind = typeof o.kind === 'string' && o.kind.trim() ? o.kind.trim() : undefined;
+  if (!src && !prompt && !query && !entity && !role && !sourcePreference && !licenseStrictness && !alt && !aspect && !style && !kind) {
+    return undefined;
+  }
   return {
     src,
     prompt,
@@ -314,10 +320,10 @@ function imageFromUnknown(value: unknown): Slide['image'] | undefined {
     role,
     sourcePreference,
     licenseStrictness,
-    alt: typeof o.alt === 'string' && o.alt.trim() ? o.alt.trim() : undefined,
-    aspect: typeof o.aspect === 'string' && o.aspect.trim() ? o.aspect.trim() : undefined,
-    style: typeof o.style === 'string' && o.style.trim() ? o.style.trim() : undefined,
-    kind: typeof o.kind === 'string' && o.kind.trim() ? o.kind.trim() : undefined,
+    alt,
+    aspect,
+    style,
+    kind,
   };
 }
 

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -457,6 +457,63 @@ export function slidesFromLlmJson(raw: string): Slide[] | null {
   return slideDeckFromLlmJson(raw)?.slides ?? null;
 }
 
+function slideHasImageSrc(slide: Slide): boolean {
+  return Boolean(slide.image?.src?.trim() || slide.body.some((block) => block.kind === 'image' && block.src.trim()));
+}
+
+function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
+  const src = slide.image?.src?.trim();
+  if (src) return { ...slide.image, src };
+  const block = slide.body.find((item): item is Extract<SlideBlock, { kind: 'image' }> => item.kind === 'image');
+  return block?.src.trim() ? { src: block.src.trim(), alt: block.alt, kind: 'source', role: 'support' } : undefined;
+}
+
+function sourceIndexFromId(id: string): number | undefined {
+  const match = id.trim().match(/^S(\d+)$/i);
+  if (!match) return undefined;
+  const index = Number.parseInt(match[1], 10) - 1;
+  return Number.isFinite(index) && index >= 0 ? index : undefined;
+}
+
+/**
+ * AI JSON 경로가 성공하더라도 source-only PPTX 내보내기에서는 원본 Markdown 이미지가
+ * 사라지면 안 된다. LLM이 이미지 src를 직접 복사하지 못한 경우 원본 파서 결과에서
+ * sourceIds 또는 같은 순번의 이미지 src를 결정론적으로 보강한다.
+ */
+export function preserveSourceImagesForPptx(slides: Slide[], sourceSlides: Slide[]): Slide[] {
+  if (!sourceSlides.some(slideHasImageSrc)) return slides;
+  const usedSourceIndexes = new Set<number>();
+  const takeImage = (sourceIndex: number | undefined): SlideImageSpec | undefined => {
+    if (sourceIndex === undefined || sourceIndex < 0 || sourceIndex >= sourceSlides.length || usedSourceIndexes.has(sourceIndex)) {
+      return undefined;
+    }
+    const image = firstSourceImage(sourceSlides[sourceIndex]);
+    if (!image) return undefined;
+    usedSourceIndexes.add(sourceIndex);
+    return image;
+  };
+
+  return slides.map((slide, slideIndex) => {
+    if (slideHasImageSrc(slide)) return slide;
+    let image: SlideImageSpec | undefined;
+    for (const sourceId of slide.sourceIds ?? []) {
+      image = takeImage(sourceIndexFromId(sourceId));
+      if (image) break;
+    }
+    image ??= takeImage(slideIndex);
+    if (!image) return slide;
+    return {
+      ...slide,
+      image: {
+        ...slide.image,
+        ...image,
+        src: image.src,
+        alt: image.alt ?? slide.image?.alt ?? slide.title,
+      },
+    };
+  });
+}
+
 /** slide-level 산정 — 내용이 바로 뒤따르는 최상위(가장 작은 번호) 헤딩 레벨. */
 function computeSlideLevel(lines: Line[]): number {
   let best = 7;

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -23,16 +23,37 @@ export interface InlineSpan {
 export type SlideBlock =
   | { kind: 'bullet'; spans: InlineSpan[]; indent: number }
   | { kind: 'text'; spans: InlineSpan[] }
-  | { kind: 'subhead'; text: string }
+  | { kind: 'subhead'; text: string; level?: number }
   | { kind: 'code'; text: string; lang?: string }
   | { kind: 'table'; rows: string[][] } // rows[0] = 헤더
   | { kind: 'image'; src: string; alt?: string };
 
+export type SlideLayout =
+  | 'title'
+  | 'content'
+  | 'section'
+  | 'two-column'
+  | 'image-focus'
+  | 'quote'
+  | 'stat'
+  | 'comparison'
+  | 'timeline';
+
 export interface Slide {
   title: string;
-  layout: 'title' | 'content';
+  layout: SlideLayout;
   body: SlideBlock[];
   notes?: string;
+  /** LLM path: source section IDs from the Rust source map, e.g. ["S2", "S5"]. */
+  sourceIds?: string[];
+  /** 원본 마크다운 헤딩 레벨(H1=1...). LLM 경로도 같은 힌트를 넣을 수 있다. */
+  sourceLevel?: number;
+  /** 현재 슬라이드의 상위 섹션 경로. 예: ["Product", "Strategy"]. */
+  sectionPath?: string[];
+  columns?: SlideBlock[][];
+  quote?: { text: string; attribution?: string };
+  stat?: { value: string; label?: string; context?: string };
+  image?: { src?: string; alt?: string; prompt?: string; kind?: string };
 }
 
 const HEADING_RE = /^(#{1,6})\s+(.*)$/;
@@ -42,6 +63,15 @@ const LIST_RE = /^(\s*)(?:[-*+]|\d+[.)])\s+(.*)$/;
 const TABLE_ROW_RE = /^\s*\|(.+)\|\s*$/;
 const TABLE_SEP_RE = /^\s*\|?[\s:|-]+\|?\s*$/; // |---|:--:| 류 구분행
 const IMAGE_ONLY_RE = /^\s*!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+const SLIDE_DRAFT_MARKER_LINE_RE =
+  /^\s*(?:<!--\s*markmind:slide-draft\b[^>]*-->|&lt;!--\s*markmind:slide-draft\b.*?--&gt;)\s*$/i;
+
+function stripSlideDraftMarker(md: string): string {
+  return md
+    .split('\n')
+    .filter((line) => !SLIDE_DRAFT_MARKER_LINE_RE.test(line))
+    .join('\n');
+}
 
 /** YAML frontmatter 제거 + 본문에서 `title:` 회수(덱 제목 폴백용). */
 function stripFrontmatter(md: string): { body: string; title?: string } {
@@ -114,20 +144,172 @@ export function parseInline(text: string): InlineSpan[] {
   return spans.length > 0 ? spans : [{ text }];
 }
 
-/** LLM 슬라이드 객체({title,layout,bullets,notes}) → Slide. */
+const SLIDE_LAYOUTS = new Set<SlideLayout>([
+  'title',
+  'content',
+  'section',
+  'two-column',
+  'image-focus',
+  'quote',
+  'stat',
+  'comparison',
+  'timeline',
+]);
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0)
+    : [];
+}
+
+function blocksFromBullets(bullets: string[], kind: 'text' | 'bullet' = 'bullet'): SlideBlock[] {
+  return bullets.map((b) =>
+    kind === 'text'
+      ? { kind: 'text', spans: parseInline(b) }
+      : { kind: 'bullet', spans: parseInline(b), indent: 0 },
+  );
+}
+
+function blocksFromUnknown(value: unknown): SlideBlock[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => {
+      if (typeof item === 'string') return blocksFromBullets([item]);
+      if (!item || typeof item !== 'object') return [];
+      const o = item as Record<string, unknown>;
+      const text = typeof o.text === 'string' ? o.text : typeof o.value === 'string' ? o.value : '';
+      if (!text.trim()) return [];
+      if (o.kind === 'subhead') {
+        const level = numberInRange(o.level, 1, 6) ?? numberInRange(o.headingLevel, 1, 6);
+        return [{ kind: 'subhead', text, level }];
+      }
+      return blocksFromBullets([text], o.kind === 'text' ? 'text' : 'bullet');
+    });
+  }
+  return [];
+}
+
+function numberInRange(value: unknown, min: number, max: number): number | undefined {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isInteger(n) && n >= min && n <= max ? n : undefined;
+}
+
+function stringPath(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const path = value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0).map((v) => v.trim());
+  return path.length > 0 ? path.slice(0, 6) : undefined;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function sourceFromUnknown(o: Record<string, unknown>): { sourceLevel?: number; sectionPath?: string[] } {
+  const source = o.source && typeof o.source === 'object' ? (o.source as Record<string, unknown>) : {};
+  return {
+    sourceLevel:
+      numberInRange(source.headingLevel, 1, 6) ??
+      numberInRange(source.level, 1, 6) ??
+      numberInRange(o.headingLevel, 1, 6) ??
+      numberInRange(o.sourceLevel, 1, 6) ??
+      numberInRange(o.level, 1, 6),
+    sectionPath: stringPath(source.sectionPath) ?? stringPath(o.sectionPath),
+  };
+}
+
+function sourceIdsFromUnknown(o: Record<string, unknown>): string[] | undefined {
+  const source = o.source && typeof o.source === 'object' ? (o.source as Record<string, unknown>) : {};
+  const ids = uniqueStrings([
+    ...stringList(o.sourceIds),
+    ...stringList(o.sources),
+    ...stringList(source.sourceIds),
+    ...stringList(source.ids),
+  ]);
+  return ids.length > 0 ? ids : undefined;
+}
+
+function quoteFromUnknown(value: unknown): Slide['quote'] | undefined {
+  if (typeof value === 'string' && value.trim()) return { text: value.trim() };
+  if (!value || typeof value !== 'object') return undefined;
+  const o = value as Record<string, unknown>;
+  const text = typeof o.text === 'string' ? o.text.trim() : '';
+  if (!text) return undefined;
+  return {
+    text,
+    attribution: typeof o.attribution === 'string' && o.attribution.trim() ? o.attribution.trim() : undefined,
+  };
+}
+
+function statFromUnknown(value: unknown): Slide['stat'] | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const o = value as Record<string, unknown>;
+  const statValue =
+    typeof o.value === 'string' ? o.value.trim() : typeof o.value === 'number' ? String(o.value) : '';
+  if (!statValue) return undefined;
+  return {
+    value: statValue,
+    label: typeof o.label === 'string' && o.label.trim() ? o.label.trim() : undefined,
+    context: typeof o.context === 'string' && o.context.trim() ? o.context.trim() : undefined,
+  };
+}
+
+function imageFromUnknown(value: unknown): Slide['image'] | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const o = value as Record<string, unknown>;
+  const src = typeof o.src === 'string' && o.src.trim() ? o.src.trim() : undefined;
+  const prompt = typeof o.prompt === 'string' && o.prompt.trim() ? o.prompt.trim() : undefined;
+  if (!src && !prompt) return undefined;
+  return {
+    src,
+    prompt,
+    alt: typeof o.alt === 'string' && o.alt.trim() ? o.alt.trim() : undefined,
+    kind: typeof o.kind === 'string' && o.kind.trim() ? o.kind.trim() : undefined,
+  };
+}
+
+/** LLM 슬라이드 객체 → Slide. 새 필드는 없으면 기존 bullets 기반으로 복구한다. */
 function llmObjToSlide(o: Record<string, unknown>, index: number): Slide {
   const title = typeof o.title === 'string' ? o.title : '';
-  const bullets = Array.isArray(o.bullets)
-    ? (o.bullets as unknown[]).filter((b): b is string => typeof b === 'string')
-    : [];
-  const layout: 'title' | 'content' =
-    o.layout === 'title' || (index === 0 && o.layout !== 'content') ? 'title' : 'content';
-  const body: SlideBlock[] =
-    layout === 'title'
-      ? bullets.slice(0, 1).map((b) => ({ kind: 'text', spans: parseInline(b) }))
-      : bullets.map((b) => ({ kind: 'bullet', spans: parseInline(b), indent: 0 }));
+  const bullets = stringList(o.bullets);
+  const source = sourceFromUnknown(o);
+  const sourceIds = sourceIdsFromUnknown(o);
+  const rawLayout = typeof o.layout === 'string' ? o.layout : '';
+  const layout: SlideLayout =
+    rawLayout && SLIDE_LAYOUTS.has(rawLayout as SlideLayout)
+      ? (rawLayout as SlideLayout)
+      : index === 0
+        ? 'title'
+        : 'content';
+  let body = blocksFromUnknown(o.blocks);
+  if (body.length === 0) {
+    body = layout === 'title' || layout === 'section'
+      ? blocksFromBullets(bullets.slice(0, 2), 'text')
+      : blocksFromBullets(bullets);
+  }
   const notes = typeof o.notes === 'string' && o.notes.trim() ? o.notes.trim() : undefined;
-  return { title, layout, body, notes };
+  const columns = Array.isArray(o.columns)
+    ? o.columns.map(blocksFromUnknown).filter((col) => col.length > 0).slice(0, 3)
+    : undefined;
+  return {
+    title,
+    layout,
+    body,
+    notes,
+    sourceIds,
+    sourceLevel: source.sourceLevel,
+    sectionPath: source.sectionPath,
+    columns,
+    quote: quoteFromUnknown(o.quote),
+    stat: statFromUnknown(o.stat),
+    image: imageFromUnknown(o.image),
+  };
 }
 
 /**
@@ -251,7 +433,7 @@ function parseBody(lines: Line[], slideLevel: number): SlideBlock[] {
       case 'heading':
         flushPara();
         if (ln.level > slideLevel)
-          blocks.push({ kind: 'subhead', text: ln.text });
+          blocks.push({ kind: 'subhead', text: ln.text, level: ln.level });
         // slide-level 이하 헤딩은 상위에서 슬라이드 경계로 소비됨(여기 안 옴)
         break;
       case 'list':
@@ -305,7 +487,7 @@ function extractNotes(body: string): { body: string; notes?: string } {
  * 수평선/slide-level 헤딩 경계로 분할 → 슬라이드별 본문 파싱.
  */
 export function markdownToSlides(markdown: string): Slide[] {
-  const { body: noFm } = stripFrontmatter(markdown);
+  const { body: noFm } = stripFrontmatter(stripSlideDraftMarker(markdown));
   const { body: noNotesBody, notes: docNotes } = extractNotes(noFm);
 
   // 1) 펜스 코드블록을 atomic 으로: 코드 라인은 분류하지 않고 통째 보관.
@@ -339,12 +521,13 @@ export function markdownToSlides(markdown: string): Slide[] {
   const slideLevel = computeSlideLevel(lineView);
 
   // 2) 경계 분할: 수평선 / slide-level 이하 헤딩에서 새 슬라이드.
-  type Seg = { title: string; level: number | null; items: Item[] };
+  type Seg = { title: string; level: number | null; sectionPath: string[]; items: Item[] };
   const segs: Seg[] = [];
   let cur: Seg | null = null;
+  const headingStack: string[] = [];
   const ensure = () => {
     if (!cur) {
-      cur = { title: '', level: null, items: [] };
+      cur = { title: '', level: null, sectionPath: headingStack.filter(Boolean), items: [] };
       segs.push(cur);
     }
     return cur;
@@ -360,7 +543,10 @@ export function markdownToSlides(markdown: string): Slide[] {
       continue;
     }
     if (ln.t === 'heading' && ln.level <= slideLevel) {
-      cur = { title: ln.text, level: ln.level, items: [] };
+      const parentPath = headingStack.slice(0, Math.max(0, ln.level - 1)).filter(Boolean);
+      headingStack[ln.level - 1] = ln.text;
+      headingStack.length = ln.level;
+      cur = { title: ln.text, level: ln.level, sectionPath: parentPath, items: [] };
       segs.push(cur);
       continue;
     }
@@ -402,6 +588,8 @@ export function markdownToSlides(markdown: string): Slide[] {
       title: seg.title,
       layout: isTitle ? 'title' : 'content',
       body: merged,
+      sourceLevel: seg.level ?? undefined,
+      sectionPath: seg.sectionPath.length > 0 ? seg.sectionPath : undefined,
     });
   }
 

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -468,6 +468,85 @@ function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
   return block?.src.trim() ? { src: block.src.trim(), alt: block.alt, kind: 'source', role: 'support' } : undefined;
 }
 
+function sourceImageFromLine(line: string): SlideImageSpec | undefined {
+  const img = line.match(IMAGE_ONLY_RE);
+  if (!img) return undefined;
+  return { src: img[2].trim(), alt: img[1], kind: 'source', role: 'support' };
+}
+
+function sourceImageMapFromMarkdown(markdown: string): Map<string, SlideImageSpec> {
+  const lines = stripSlideDraftMarker(markdown).split('\n');
+  const images = new Map<string, SlideImageSpec>();
+  let inFrontmatter = false;
+  let inFence = false;
+  let fenceMarker = '';
+  let nextId = 1;
+  let currentId: string | undefined;
+  let currentImage: SlideImageSpec | undefined;
+  let preludeHasContent = false;
+  let preludeImage: SlideImageSpec | undefined;
+
+  const rememberImage = (line: string) => {
+    const image = sourceImageFromLine(line);
+    if (!image) return;
+    if (currentId) currentImage ??= image;
+    else preludeImage ??= image;
+  };
+
+  const closeCurrent = () => {
+    if (currentId && currentImage) images.set(currentId, currentImage);
+    currentId = undefined;
+    currentImage = undefined;
+  };
+
+  const closePrelude = () => {
+    if (!preludeHasContent) return;
+    const id = `S${nextId++}`;
+    if (preludeImage) images.set(id, preludeImage);
+    preludeHasContent = false;
+    preludeImage = undefined;
+  };
+
+  lines.forEach((line, lineIndex) => {
+    const trimmed = line.trim();
+    if (lineIndex === 0 && trimmed === '---') {
+      inFrontmatter = true;
+      return;
+    }
+    if (inFrontmatter) {
+      if (trimmed === '---') inFrontmatter = false;
+      return;
+    }
+
+    const left = line.trimStart();
+    const fence = left.startsWith('```') ? '```' : left.startsWith('~~~') ? '~~~' : '';
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceMarker = fence;
+      } else if (left.startsWith(fenceMarker)) {
+        inFence = false;
+      }
+      if (!currentId && trimmed) preludeHasContent = true;
+      return;
+    }
+
+    if (!inFence && HEADING_RE.test(line)) {
+      if (currentId) closeCurrent();
+      else closePrelude();
+      currentId = `S${nextId++}`;
+      return;
+    }
+
+    if (!currentId && trimmed) preludeHasContent = true;
+    if (!inFence) rememberImage(line);
+  });
+
+  if (currentId) closeCurrent();
+  else closePrelude();
+  return images;
+}
+
 function sourceIndexFromId(id: string): number | undefined {
   const match = id.trim().match(/^S(\d+)$/i);
   if (!match) return undefined;
@@ -477,12 +556,24 @@ function sourceIndexFromId(id: string): number | undefined {
 
 /**
  * AI JSON 경로가 성공하더라도 source-only PPTX 내보내기에서는 원본 Markdown 이미지가
- * 사라지면 안 된다. LLM이 이미지 src를 직접 복사하지 못한 경우 원본 파서 결과에서
- * sourceIds 또는 같은 순번의 이미지 src를 결정론적으로 보강한다.
+ * 사라지면 안 된다. LLM이 이미지 src를 직접 복사하지 못한 경우 원본 Markdown을 Rust
+ * source map과 같은 heading-section 순서로 스캔해 sourceIds(S1, S2...)에 맞는 이미지
+ * src를 보강한다. 원본 Markdown 문자열이 없을 때만 기존 슬라이드 순번 fallback을 쓴다.
  */
-export function preserveSourceImagesForPptx(slides: Slide[], sourceSlides: Slide[]): Slide[] {
+export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | string): Slide[] {
+  const sourceSlides = typeof source === 'string' ? markdownToSlides(source) : source;
   if (!sourceSlides.some(slideHasImageSrc)) return slides;
+  const sourceImagesById = typeof source === 'string' ? sourceImageMapFromMarkdown(source) : new Map<string, SlideImageSpec>();
+  const usedSourceIds = new Set<string>();
   const usedSourceIndexes = new Set<number>();
+  const takeSourceImage = (sourceId: string): SlideImageSpec | undefined => {
+    const normalized = sourceId.trim().toUpperCase();
+    if (usedSourceIds.has(normalized)) return undefined;
+    const image = sourceImagesById.get(normalized);
+    if (!image) return undefined;
+    usedSourceIds.add(normalized);
+    return image;
+  };
   const takeImage = (sourceIndex: number | undefined): SlideImageSpec | undefined => {
     if (sourceIndex === undefined || sourceIndex < 0 || sourceIndex >= sourceSlides.length || usedSourceIndexes.has(sourceIndex)) {
       return undefined;
@@ -497,10 +588,12 @@ export function preserveSourceImagesForPptx(slides: Slide[], sourceSlides: Slide
     if (slideHasImageSrc(slide)) return slide;
     let image: SlideImageSpec | undefined;
     for (const sourceId of slide.sourceIds ?? []) {
-      image = takeImage(sourceIndexFromId(sourceId));
+      image = takeSourceImage(sourceId) ?? (sourceImagesById.size === 0 ? takeImage(sourceIndexFromId(sourceId)) : undefined);
       if (image) break;
     }
-    image ??= takeImage(slideIndex);
+    if (!image && (!slide.sourceIds?.length || sourceImagesById.size === 0)) {
+      image = takeImage(slideIndex);
+    }
     if (!image) return slide;
     return {
       ...slide,

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -468,43 +468,43 @@ function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
   return block?.src.trim() ? { src: block.src.trim(), alt: block.alt, kind: 'source', role: 'support' } : undefined;
 }
 
-function sourceImageFromLine(line: string): SlideImageSpec | undefined {
-  const img = line.match(/!\[([^\]]*)\]\(([^)]+)\)/);
-  if (!img) return undefined;
-  return { src: img[2].trim(), alt: img[1], kind: 'source', role: 'support' };
+function sourceImagesFromLine(line: string): SlideImageSpec[] {
+  return [...line.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)]
+    .map((img) => ({ src: img[2].trim(), alt: img[1], kind: 'source' as const, role: 'support' as const }))
+    .filter((image) => image.src.length > 0);
 }
 
-function sourceImageMapFromMarkdown(markdown: string): Map<string, SlideImageSpec> {
+function sourceImageMapFromMarkdown(markdown: string): Map<string, SlideImageSpec[]> {
   const lines = stripSlideDraftMarker(markdown).split('\n');
-  const images = new Map<string, SlideImageSpec>();
+  const images = new Map<string, SlideImageSpec[]>();
   let inFrontmatter = false;
   let inFence = false;
   let fenceMarker = '';
   let nextId = 1;
   let currentId: string | undefined;
-  let currentImage: SlideImageSpec | undefined;
+  let currentImages: SlideImageSpec[] = [];
   let preludeHasContent = false;
-  let preludeImage: SlideImageSpec | undefined;
+  let preludeImages: SlideImageSpec[] = [];
 
   const rememberImage = (line: string) => {
-    const image = sourceImageFromLine(line);
-    if (!image) return;
-    if (currentId) currentImage ??= image;
-    else preludeImage ??= image;
+    const lineImages = sourceImagesFromLine(line);
+    if (lineImages.length === 0) return;
+    if (currentId) currentImages.push(...lineImages);
+    else preludeImages.push(...lineImages);
   };
 
   const closeCurrent = () => {
-    if (currentId && currentImage) images.set(currentId, currentImage);
+    if (currentId && currentImages.length > 0) images.set(currentId, currentImages);
     currentId = undefined;
-    currentImage = undefined;
+    currentImages = [];
   };
 
   const closePrelude = () => {
     if (!preludeHasContent) return;
     const id = `S${nextId++}`;
-    if (preludeImage) images.set(id, preludeImage);
+    if (preludeImages.length > 0) images.set(id, preludeImages);
     preludeHasContent = false;
-    preludeImage = undefined;
+    preludeImages = [];
   };
 
   lines.forEach((line, lineIndex) => {
@@ -562,25 +562,29 @@ function sourceIndexFromId(id: string): number | undefined {
  */
 export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | string): Slide[] {
   const sourceSlides = typeof source === 'string' ? markdownToSlides(source) : source;
-  const sourceImagesById = typeof source === 'string' ? sourceImageMapFromMarkdown(source) : new Map<string, SlideImageSpec>();
+  const sourceImagesById = typeof source === 'string' ? sourceImageMapFromMarkdown(source) : new Map<string, SlideImageSpec[]>();
   if (sourceImagesById.size === 0 && !sourceSlides.some(slideHasImageSrc)) return slides;
-  const usedSourceIds = new Set<string>();
-  const sourceImageEntries = [...sourceImagesById.entries()];
+  const sourceImageOffsets = new Map<string, number>();
+  const sourceImageEntries = [...sourceImagesById.entries()].flatMap(([id, images]) =>
+    images.map((image, imageIndex) => ({ id, image, imageIndex })),
+  );
   let nextSourceImageIndex = 0;
   const usedSourceIndexes = new Set<number>();
   const takeSourceImage = (sourceId: string): SlideImageSpec | undefined => {
     const normalized = sourceId.trim().toUpperCase();
-    if (usedSourceIds.has(normalized)) return undefined;
-    const image = sourceImagesById.get(normalized);
+    const images = sourceImagesById.get(normalized);
+    const offset = sourceImageOffsets.get(normalized) ?? 0;
+    const image = images?.[offset];
     if (!image) return undefined;
-    usedSourceIds.add(normalized);
+    sourceImageOffsets.set(normalized, offset + 1);
     return image;
   };
   const takeNextSourceImage = (): SlideImageSpec | undefined => {
     while (nextSourceImageIndex < sourceImageEntries.length) {
-      const [id, image] = sourceImageEntries[nextSourceImageIndex++];
-      if (usedSourceIds.has(id)) continue;
-      usedSourceIds.add(id);
+      const { id, image, imageIndex } = sourceImageEntries[nextSourceImageIndex++];
+      const offset = sourceImageOffsets.get(id) ?? 0;
+      if (imageIndex !== offset) continue;
+      sourceImageOffsets.set(id, offset + 1);
       return image;
     }
     return undefined;

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -13,6 +13,8 @@
 // 이 파서의 출력(Slide[])은 buildPptx.ts 와 LLM 스마트 레이아웃 경로가 공유하는
 // 단일 스키마다(경로 통일).
 
+import { normalizeSlideMasterSpec, type SlideMasterSpec } from './slideMaster';
+
 export interface InlineSpan {
   text: string;
   bold?: boolean;
@@ -39,6 +41,24 @@ export type SlideLayout =
   | 'comparison'
   | 'timeline';
 
+export type SlideImageRole = 'cover' | 'hero' | 'support' | 'logo' | 'icon' | 'background';
+export type SlideImageSourcePreference = 'auto' | 'stock' | 'logo' | 'generated' | 'none';
+export type SlideImageLicenseStrictness = 'presentation' | 'open' | 'internal-only';
+
+export interface SlideImageSpec {
+  src?: string;
+  alt?: string;
+  prompt?: string;
+  kind?: string;
+  role?: SlideImageRole;
+  query?: string;
+  entity?: string;
+  aspect?: string;
+  style?: string;
+  sourcePreference?: SlideImageSourcePreference;
+  licenseStrictness?: SlideImageLicenseStrictness;
+}
+
 export interface Slide {
   title: string;
   layout: SlideLayout;
@@ -53,7 +73,12 @@ export interface Slide {
   columns?: SlideBlock[][];
   quote?: { text: string; attribution?: string };
   stat?: { value: string; label?: string; context?: string };
-  image?: { src?: string; alt?: string; prompt?: string; kind?: string };
+  image?: SlideImageSpec;
+}
+
+export interface SlideDeck {
+  slides: Slide[];
+  masterSpec?: SlideMasterSpec;
 }
 
 const HEADING_RE = /^(#{1,6})\s+(.*)$/;
@@ -265,13 +290,29 @@ function imageFromUnknown(value: unknown): Slide['image'] | undefined {
   const o = value as Record<string, unknown>;
   const src = typeof o.src === 'string' && o.src.trim() ? o.src.trim() : undefined;
   const prompt = typeof o.prompt === 'string' && o.prompt.trim() ? o.prompt.trim() : undefined;
-  if (!src && !prompt) return undefined;
+  const query = typeof o.query === 'string' && o.query.trim() ? o.query.trim() : undefined;
+  const entity = typeof o.entity === 'string' && o.entity.trim() ? o.entity.trim() : undefined;
+  if (!src && !prompt && !query && !entity) return undefined;
+  const role = oneOf<SlideImageRole>(o.role, ['cover', 'hero', 'support', 'logo', 'icon', 'background']);
+  const sourcePreference = oneOf<SlideImageSourcePreference>(o.sourcePreference, ['auto', 'stock', 'logo', 'generated', 'none']);
+  const licenseStrictness = oneOf<SlideImageLicenseStrictness>(o.licenseStrictness, ['presentation', 'open', 'internal-only']);
   return {
     src,
     prompt,
+    query,
+    entity,
+    role,
+    sourcePreference,
+    licenseStrictness,
     alt: typeof o.alt === 'string' && o.alt.trim() ? o.alt.trim() : undefined,
+    aspect: typeof o.aspect === 'string' && o.aspect.trim() ? o.aspect.trim() : undefined,
+    style: typeof o.style === 'string' && o.style.trim() ? o.style.trim() : undefined,
     kind: typeof o.kind === 'string' && o.kind.trim() ? o.kind.trim() : undefined,
   };
+}
+
+function oneOf<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+  return typeof value === 'string' && allowed.includes(value as T) ? (value as T) : undefined;
 }
 
 /** LLM 슬라이드 객체 → Slide. 새 필드는 없으면 기존 bullets 기반으로 복구한다. */
@@ -354,7 +395,7 @@ function extractBalancedObjects(s: string): string[] {
  *    `"slides"` 배열에서 완성된 `{...}` 객체만 추출해 살린다(우아한 degradation).
  * 둘 다 실패하면 null(→ 호출부가 규칙 기반으로 폴백).
  */
-export function slidesFromLlmJson(raw: string): Slide[] | null {
+export function slideDeckFromLlmJson(raw: string): SlideDeck | null {
   // 1) strict
   const start = raw.indexOf('{');
   const end = raw.lastIndexOf('}');
@@ -363,7 +404,13 @@ export function slidesFromLlmJson(raw: string): Slide[] | null {
       const obj = JSON.parse(raw.slice(start, end + 1));
       const arr = Array.isArray(obj) ? obj : obj.slides;
       if (Array.isArray(arr) && arr.length > 0) {
-        return arr.map((s, i) => llmObjToSlide((s ?? {}) as Record<string, unknown>, i));
+        const masterSpec = Array.isArray(obj)
+          ? undefined
+          : normalizeSlideMasterSpec(obj.masterSpec) ?? normalizeSlideMasterSpec(obj.master);
+        return {
+          slides: arr.map((s, i) => llmObjToSlide((s ?? {}) as Record<string, unknown>, i)),
+          masterSpec,
+        };
       }
     } catch {
       /* 잘림 가능성 → 부분 복구로 진행 */
@@ -385,7 +432,11 @@ export function slidesFromLlmJson(raw: string): Slide[] | null {
       /* 마지막 잘린 객체는 무시 */
     }
   });
-  return slides.length > 0 ? slides : null;
+  return slides.length > 0 ? { slides } : null;
+}
+
+export function slidesFromLlmJson(raw: string): Slide[] | null {
+  return slideDeckFromLlmJson(raw)?.slides ?? null;
 }
 
 /** slide-level 산정 — 내용이 바로 뒤따르는 최상위(가장 작은 번호) 헤딩 레벨. */

--- a/src/lib/pptxDesignSystem.test.ts
+++ b/src/lib/pptxDesignSystem.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { MARKMIND_PPTX_FREE_FONTS, pptxFontFaceForText } from './pptxDesignSystem';
+
+describe('pptxDesignSystem', () => {
+  it('uses Pretendard for Korean slide text', () => {
+    expect(pptxFontFaceForText('문제는 관심 부족이 아니다', 'Theme Font', 'heading')).toBe(
+      MARKMIND_PPTX_FREE_FONTS.korean,
+    );
+  });
+
+  it('uses Noto Sans JP for Japanese slide text', () => {
+    expect(pptxFontFaceForText('資料の目的', 'Theme Font')).toBe(MARKMIND_PPTX_FREE_FONTS.japanese);
+  });
+
+  it('uses Noto Sans SC/TC for Chinese slide text', () => {
+    expect(pptxFontFaceForText('市场机会', 'Theme Font')).toBe(
+      MARKMIND_PPTX_FREE_FONTS.chineseSimplified,
+    );
+    expect(pptxFontFaceForText('臺灣市場機會', 'Theme Font')).toBe(
+      MARKMIND_PPTX_FREE_FONTS.chineseTraditional,
+    );
+  });
+
+  it('keeps the theme font for Latin text and Noto Sans Mono for code', () => {
+    expect(pptxFontFaceForText('Market opportunity', 'Noto Sans Display', 'heading')).toBe(
+      'Noto Sans Display',
+    );
+    expect(pptxFontFaceForText('const x = 1', 'Theme Mono', 'mono')).toBe(
+      MARKMIND_PPTX_FREE_FONTS.mono,
+    );
+  });
+});

--- a/src/lib/pptxDesignSystem.ts
+++ b/src/lib/pptxDesignSystem.ts
@@ -1,0 +1,58 @@
+export const MARKMIND_PPTX_FREE_FONTS = {
+  latinHeading: 'Noto Sans Display',
+  latinBody: 'Noto Sans',
+  serifHeading: 'Noto Serif Display',
+  serifBody: 'Noto Serif',
+  korean: 'Pretendard',
+  japanese: 'Noto Sans JP',
+  chineseSimplified: 'Noto Sans SC',
+  chineseTraditional: 'Noto Sans TC',
+  panCjk: 'Noto Sans CJK KR',
+  mono: 'Noto Sans Mono',
+} as const;
+
+const HANGUL_RE = /[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]/;
+const KANA_RE = /[\u3040-\u30ff]/;
+const CJK_IDEOGRAPH_RE = /[\u3400-\u9fff]/;
+const TRADITIONAL_HINT_RE = /[臺灣體國學會與門開關廣東華]/;
+
+export function pptxFontFaceForText(
+  text: string,
+  themeFont: string,
+  role: 'heading' | 'body' | 'mono' = 'body',
+): string {
+  if (role === 'mono') return MARKMIND_PPTX_FREE_FONTS.mono;
+  if (HANGUL_RE.test(text)) return MARKMIND_PPTX_FREE_FONTS.korean;
+  if (KANA_RE.test(text)) return MARKMIND_PPTX_FREE_FONTS.japanese;
+  if (CJK_IDEOGRAPH_RE.test(text)) {
+    return TRADITIONAL_HINT_RE.test(text)
+      ? MARKMIND_PPTX_FREE_FONTS.chineseTraditional
+      : MARKMIND_PPTX_FREE_FONTS.chineseSimplified;
+  }
+  return themeFont;
+}
+
+export const MARKMIND_PPTX_DESIGN_RULES = [
+  'Renderer-owned design: the LLM chooses slide role, layout enum, semantic blocks, and image intent only; MarkMind code owns colors, typography, spacing, coordinates, contrast, and overflow.',
+  'Output must remain editable PowerPoint: use native text boxes, shapes, tables, charts, and image objects; never flatten a whole slide into one generated image.',
+  'Every content slide needs visible structure beyond title plus floating text: card grid, two-column cards, comparison blocks, stat callout, quote treatment, timeline/process, image-focus, or framed evidence.',
+  'Use one motif per deck and make it structural: side rail, corner block, frame, or subtle band. Avoid thick full-width footer bars and decorative title underlines.',
+  'Use the user-selected installed font family for headings and body text when provided; otherwise use high-quality free/open fonts by language: Pretendard for Korean, Noto Sans JP for Japanese, Noto Sans SC/TC or Noto Sans CJK for Chinese, Noto Sans/Noto Sans Display for Latin, and Noto Sans Mono for code.',
+  'Hide implementation artifacts: never show (root), source IDs such as S1/S2, hidden draft markers, renderer notes, raw design tokens, or JSON fields on a slide.',
+  'Fit check wins over style: if content would overflow, shorten, split, or choose a denser layout; do not rely on tiny body text.',
+  'Image policy: prefer source/user images for factual content, stock/logo providers for real-world subjects, and generated images for abstract or custom concept visuals.',
+  'QA each slide for text, layout, color, image relevance, and narrative coherence before final output.',
+] as const;
+
+export function markMindPptxDesignRulesText(extraRules?: string): string {
+  const lines = [
+    'MarkMind PPTX design system:',
+    ...MARKMIND_PPTX_DESIGN_RULES.map((rule) => `- ${rule}`),
+  ];
+  const extra = extraRules?.trim();
+  if (extra) {
+    lines.push('User-added design rules:');
+    lines.push(extra);
+  }
+  return lines.join('\n');
+}

--- a/src/lib/slideLimits.test.ts
+++ b/src/lib/slideLimits.test.ts
@@ -4,6 +4,7 @@ import {
   clampSlideCountValue,
   generatedImageLimitForPolicy,
   PPTX_MAX_SLIDES,
+  slideImageSourceMode,
   stockImageLimitForPolicy,
 } from './slideLimits';
 
@@ -19,6 +20,14 @@ describe('slideLimits', () => {
     expect(stockImageLimitForPolicy('add image intent only when it materially improves the slide')).toBe(6);
     expect(stockImageLimitForPolicy('actively add ambient and supporting visuals to spacious body slides')).toBe(18);
     expect(generatedImageLimitForPolicy('actively add ambient and supporting visuals to spacious body slides')).toBe(8);
+  });
+
+  it('이미지 소스 모드를 해석', () => {
+    expect(slideImageSourceMode('auto choose stock photos, logos, or generated images')).toBe('auto');
+    expect(slideImageSourceMode('prefer stock photos and logos, then generate only when stock fails')).toBe('stockFirst');
+    expect(slideImageSourceMode('prefer generated images for concepts')).toBe('generatedFirst');
+    expect(slideImageSourceMode('use stock photos and logos only; do not generate images')).toBe('stockOnly');
+    expect(slideImageSourceMode('use generated images only; do not search stock photos or logos')).toBe('generatedOnly');
   });
 
   it('AI가 반환한 Markdown 초안을 slide separator 기준으로 clamp', () => {

--- a/src/lib/slideLimits.test.ts
+++ b/src/lib/slideLimits.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampMarkdownSlideDraft,
+  clampSlideCountValue,
+  generatedImageLimitForPolicy,
+  PPTX_MAX_SLIDES,
+  stockImageLimitForPolicy,
+} from './slideLimits';
+
+describe('slideLimits', () => {
+  it('슬라이드 장수 힌트를 하드 리밋으로 clamp', () => {
+    expect(clampSlideCountValue('10')).toBe(10);
+    expect(clampSlideCountValue('about 100 slides')).toBe(PPTX_MAX_SLIDES);
+    expect(clampSlideCountValue('')).toBeUndefined();
+  });
+
+  it('이미지 정책별 자산 상한을 반환', () => {
+    expect(stockImageLimitForPolicy('use source images only; do not add new image intent')).toBe(0);
+    expect(stockImageLimitForPolicy('add image intent only when it materially improves the slide')).toBe(6);
+    expect(stockImageLimitForPolicy('actively add ambient and supporting visuals to spacious body slides')).toBe(18);
+    expect(generatedImageLimitForPolicy('actively add ambient and supporting visuals to spacious body slides')).toBe(8);
+  });
+
+  it('AI가 반환한 Markdown 초안을 slide separator 기준으로 clamp', () => {
+    const draft = Array.from({ length: PPTX_MAX_SLIDES + 2 }, (_, i) => `# Slide ${i + 1}`).join('\n\n---\n\n');
+    const result = clampMarkdownSlideDraft(draft);
+    expect(result.clamped).toBe(true);
+    expect(result.originalCount).toBe(PPTX_MAX_SLIDES + 2);
+    expect(result.markdown).toContain('# Slide 32');
+    expect(result.markdown).not.toContain('# Slide 33');
+  });
+});

--- a/src/lib/slideLimits.ts
+++ b/src/lib/slideLimits.ts
@@ -19,6 +19,19 @@ export function slideImagePolicyMode(policy?: string): 'sourceOnly' | 'needed' |
   return 'needed';
 }
 
+export type SlideImageSourceMode = 'auto' | 'stockFirst' | 'generatedFirst' | 'stockOnly' | 'generatedOnly';
+
+export function slideImageSourceMode(value?: string): SlideImageSourceMode {
+  const p = (value ?? '').toLowerCase();
+  if (p.includes('stock photos and logos only') || p.includes('stock only') || p.includes('stock만')) return 'stockOnly';
+  if (p.includes('generated images only') || (p.includes('use generated') && p.includes('only')) || p.includes('생성만')) {
+    return 'generatedOnly';
+  }
+  if (p.includes('prefer generated') || p.includes('generated first') || p.includes('생성 우선')) return 'generatedFirst';
+  if (p.includes('prefer stock') || p.includes('stock first') || p.includes('stock 우선')) return 'stockFirst';
+  return 'auto';
+}
+
 export function stockImageLimitForPolicy(policy?: string): number {
   return PPTX_MAX_STOCK_IMAGE_ASSETS[slideImagePolicyMode(policy)];
 }

--- a/src/lib/slideLimits.ts
+++ b/src/lib/slideLimits.ts
@@ -1,0 +1,74 @@
+export const PPTX_MAX_SLIDES = 32;
+
+export const PPTX_MAX_STOCK_IMAGE_ASSETS = {
+  sourceOnly: 0,
+  needed: 6,
+  active: 18,
+} as const;
+
+export const PPTX_MAX_GENERATED_IMAGE_ASSETS = {
+  sourceOnly: 0,
+  needed: 3,
+  active: 8,
+} as const;
+
+export function slideImagePolicyMode(policy?: string): 'sourceOnly' | 'needed' | 'active' {
+  const p = (policy ?? '').toLowerCase();
+  if (p.includes('source images only') || p.includes('do not add')) return 'sourceOnly';
+  if (p.includes('actively') || p.includes('cover, section')) return 'active';
+  return 'needed';
+}
+
+export function stockImageLimitForPolicy(policy?: string): number {
+  return PPTX_MAX_STOCK_IMAGE_ASSETS[slideImagePolicyMode(policy)];
+}
+
+export function generatedImageLimitForPolicy(policy?: string): number {
+  return PPTX_MAX_GENERATED_IMAGE_ASSETS[slideImagePolicyMode(policy)];
+}
+
+export function clampSlideCountValue(value: unknown, max = PPTX_MAX_SLIDES): number | undefined {
+  const raw = typeof value === 'number' ? String(value) : typeof value === 'string' ? value : '';
+  const match = raw.match(/\d+/);
+  if (!match) return undefined;
+  const parsed = Number.parseInt(match[0], 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.min(max, parsed);
+}
+
+const HR_RE = /^\s*([-*_])(?:\s*\1){2,}\s*$/;
+const FENCE_RE = /^\s*(```|~~~)/;
+
+export function clampMarkdownSlideDraft(
+  markdown: string,
+  max = PPTX_MAX_SLIDES,
+): { markdown: string; originalCount: number; clamped: boolean } {
+  const lines = markdown.split('\n');
+  const slides: string[][] = [[]];
+  let fence: string | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(FENCE_RE);
+    if (fenceMatch) {
+      fence = fence === fenceMatch[1] ? null : fence ?? fenceMatch[1];
+    }
+    if (!fence && HR_RE.test(line)) {
+      slides.push([]);
+      continue;
+    }
+    slides[slides.length - 1].push(line);
+  }
+
+  const meaningful = slides.filter((slide) => slide.join('\n').trim().length > 0);
+  if (meaningful.length <= max) {
+    return { markdown, originalCount: meaningful.length, clamped: false };
+  }
+  return {
+    markdown: meaningful
+      .slice(0, max)
+      .map((slide) => slide.join('\n').trim())
+      .join('\n\n---\n\n'),
+    originalCount: meaningful.length,
+    clamped: true,
+  };
+}

--- a/src/lib/slideMaster.ts
+++ b/src/lib/slideMaster.ts
@@ -1,0 +1,123 @@
+export type SlideMasterRole = 'title' | 'content' | 'section';
+export type MasterTextPosition = 'bottom-left' | 'bottom-center' | 'bottom-right';
+export type MasterElementStyle = 'minimal' | 'muted' | 'accent' | 'inverse';
+
+export interface SlideMasterTextSpec {
+  enabled?: boolean;
+  includeOn?: SlideMasterRole[];
+  position?: MasterTextPosition;
+  style?: MasterElementStyle;
+}
+
+export interface SlideMasterSpec {
+  slideNumber?: SlideMasterTextSpec;
+  footer?: SlideMasterTextSpec & {
+    text?: string;
+  };
+  date?: SlideMasterTextSpec & {
+    text?: string;
+  };
+}
+
+const MASTER_ROLES: SlideMasterRole[] = ['title', 'content', 'section'];
+const POSITIONS: MasterTextPosition[] = ['bottom-left', 'bottom-center', 'bottom-right'];
+const STYLES: MasterElementStyle[] = ['minimal', 'muted', 'accent', 'inverse'];
+
+export const DEFAULT_SLIDE_MASTER_SPEC: Required<Pick<SlideMasterSpec, 'slideNumber'>> = {
+  slideNumber: {
+    enabled: true,
+    includeOn: ['content'],
+    position: 'bottom-right',
+    style: 'muted',
+  },
+};
+
+function boolOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function enumValue<T extends string>(value: unknown, allowed: readonly T[]): T | undefined {
+  return typeof value === 'string' && allowed.includes(value as T) ? (value as T) : undefined;
+}
+
+function roleList(value: unknown): SlideMasterRole[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out = value.filter((item): item is SlideMasterRole => MASTER_ROLES.includes(item as SlideMasterRole));
+  return out.length > 0 ? Array.from(new Set(out)).slice(0, 3) : undefined;
+}
+
+function shortText(value: unknown, max = 60): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) return undefined;
+  return Array.from(trimmed).slice(0, max).join('');
+}
+
+function normalizeTextSpec(value: unknown): SlideMasterTextSpec | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  const spec: SlideMasterTextSpec = {};
+  const enabled = boolOrUndefined(obj.enabled);
+  const includeOn = roleList(obj.includeOn);
+  const position = enumValue(obj.position, POSITIONS);
+  const style = enumValue(obj.style, STYLES);
+  if (enabled !== undefined) spec.enabled = enabled;
+  if (includeOn) spec.includeOn = includeOn;
+  if (position) spec.position = position;
+  if (style) spec.style = style;
+  return Object.keys(spec).length > 0 ? spec : undefined;
+}
+
+function normalizeLabeledTextSpec(value: unknown): (SlideMasterTextSpec & { text?: string }) | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  const spec: SlideMasterTextSpec & { text?: string } = normalizeTextSpec(obj) ?? {};
+  const text = shortText(obj.text);
+  if (text) spec.text = text;
+  return Object.keys(spec).length > 0 ? spec : undefined;
+}
+
+export function normalizeSlideMasterSpec(value: unknown): SlideMasterSpec | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  const slideNumber = normalizeTextSpec(obj.slideNumber);
+  const footer = normalizeLabeledTextSpec(obj.footer);
+  const date = normalizeLabeledTextSpec(obj.date);
+  const spec: SlideMasterSpec = {};
+  if (slideNumber) spec.slideNumber = slideNumber;
+  if (footer?.text || footer?.enabled !== undefined) spec.footer = footer;
+  if (date?.text || date?.enabled !== undefined) spec.date = date;
+  return Object.keys(spec).length > 0 ? spec : undefined;
+}
+
+export function resolveSlideMasterSpec(spec?: SlideMasterSpec): SlideMasterSpec {
+  const footer = spec?.footer
+    ? {
+        position: 'bottom-left' as const,
+        style: 'muted' as const,
+        ...spec.footer,
+        enabled: spec.footer.enabled ?? Boolean(spec.footer.text),
+      }
+    : undefined;
+  const date = spec?.date
+    ? {
+        position: 'bottom-center' as const,
+        style: 'muted' as const,
+        ...spec.date,
+        enabled: spec.date.enabled ?? Boolean(spec.date.text),
+      }
+    : undefined;
+  return {
+    slideNumber: {
+      ...DEFAULT_SLIDE_MASTER_SPEC.slideNumber,
+      ...(spec?.slideNumber ?? {}),
+    },
+    footer,
+    date,
+  };
+}
+
+export function masterSpecIncludes(spec: SlideMasterTextSpec | undefined, role: SlideMasterRole): boolean {
+  if (!spec?.enabled) return false;
+  return (spec.includeOn ?? ['content']).includes(role);
+}

--- a/src/lib/slideSplit.test.ts
+++ b/src/lib/slideSplit.test.ts
@@ -45,6 +45,18 @@ describe('splitIntoSlides — 함정 처리', () => {
         expect(splitIntoSlides('---\ntitle: X\n---\n# A\nbody', opts())).toEqual(['# A\nbody']);
     });
 
+    it('MarkMind 슬라이드 초안 마커는 슬라이드 내용에서 제외', () => {
+        expect(
+            splitIntoSlides('<!-- markmind:slide-draft v1 -->\n# A\nbody\n---\n# B', opts()),
+        ).toEqual(['# A\nbody', '# B']);
+    });
+
+    it('초안 마커가 frontmatter 앞에 있어도 frontmatter 를 정상 제외', () => {
+        expect(
+            splitIntoSlides('<!-- markmind:slide-draft v1 -->\n---\ntitle: X\n---\n# A\nbody', opts()),
+        ).toEqual(['# A\nbody']);
+    });
+
     it('빈 문서 → 빈 슬라이드 1장', () => {
         expect(splitIntoSlides('', opts())).toEqual(['']);
     });

--- a/src/lib/slideSplit.ts
+++ b/src/lib/slideSplit.ts
@@ -66,6 +66,15 @@ const STRIKE_RE = /~~[^~\n]+~~/g; // 취소선
     구형 HTML 주석 `<!-- skip -->` 은 라운드트립 시 `&lt;…&gt;` 로 깨지므로 하위호환으로
     깨진 형태까지 인식한다(근본 보존은 #89 — raw HTML 라운드트립). */
 const SKIP_MARKER_RE = /%%\s*skip\s*%%|(?:<|&lt;)!--\s*skip\s*--(?:>|&gt;)/i;
+const SLIDE_DRAFT_MARKER_LINE_RE =
+    /^\s*(?:<!--\s*markmind:slide-draft\b[^>]*-->|&lt;!--\s*markmind:slide-draft\b.*?--&gt;)\s*$/i;
+
+function stripSlideDraftMarker(md: string): string {
+    return md
+        .split('\n')
+        .filter((line) => !SLIDE_DRAFT_MARKER_LINE_RE.test(line))
+        .join('\n');
+}
 
 /** YAML frontmatter(`---\n…\n---`) 제거 — 슬라이드 내용이 아님. */
 function stripFrontmatter(md: string): string {
@@ -131,7 +140,7 @@ function isEmptyAfterHide(chunk: string, opts: SlideshowSettings): boolean {
  * 빈(공백만) 슬라이드는 버린다. 결과가 없으면 빈 1장(['']).
  */
 export function splitIntoSlides(markdown: string, opts: SlideshowSettings): string[] {
-    const lines = stripFrontmatter(markdown).split('\n');
+    const lines = stripFrontmatter(stripSlideDraftMarker(markdown)).split('\n');
     const slides: string[][] = [];
     let cur: string[] = [];
     let inFence = false;

--- a/src/lib/slideTheme.test.ts
+++ b/src/lib/slideTheme.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { applySlideDesignOptions, DEFAULT_SLIDE_THEME } from './slideTheme';
+
+describe('slideTheme', () => {
+  it('uses the selected installed font family for PPTX heading and body text', () => {
+    const theme = applySlideDesignOptions(DEFAULT_SLIDE_THEME, {
+      themeId: DEFAULT_SLIDE_THEME.id,
+      fontFamily: 'Avenir Next',
+    });
+
+    expect(theme.fonts.heading).toBe('Avenir Next');
+    expect(theme.fonts.body).toBe('Avenir Next');
+    expect(theme.fonts.useLanguageFallback).toBe(false);
+  });
+});

--- a/src/lib/slideTheme.ts
+++ b/src/lib/slideTheme.ts
@@ -1,0 +1,286 @@
+import { MARKMIND_PPTX_FREE_FONTS } from './pptxDesignSystem';
+
+export type SlideThemeId = 'midnight-surge' | 'bold-sunrise' | 'mono-edge';
+
+export type SlideMotif = 'band' | 'corner-block' | 'frame';
+
+export interface SlideTheme {
+  id: SlideThemeId | string;
+  name: string;
+  description: string;
+  palette: {
+    bg: string;
+    surface: string;
+    surfaceAlt: string;
+    title: string;
+    body: string;
+    muted: string;
+    accent: string;
+    accent2: string;
+    inverseText: string;
+    codeBg: string;
+    codeFg: string;
+    border: string;
+    chart: string[];
+  };
+  fonts: {
+    heading: string;
+    body: string;
+    mono: string;
+    useLanguageFallback?: boolean;
+  };
+  typeScale: {
+    coverTitle: number;
+    title: number;
+    section: number;
+    body: number;
+    caption: number;
+    stat: number;
+  };
+  spacing: {
+    marginX: number;
+    titleY: number;
+    bodyTop: number;
+    bodyBottom: number;
+    gap: number;
+    columnGap: number;
+  };
+  shape: {
+    radius: number;
+    motif: SlideMotif;
+  };
+  rules: string[];
+}
+
+export interface SlideExportOptions {
+  themeId: string;
+  audience?: string;
+  tone?: string;
+  language?: string;
+  slideCountHint?: string;
+  draftPurpose?: string;
+  draftStructure?: string;
+  draftDepth?: string;
+  draftRevisionMode?: string;
+  draftReviewMode?: string;
+  designLayout?: string;
+  visualDensity?: string;
+  imagePolicy?: string;
+  fontPreference?: string;
+  fontFamily?: string;
+  marginPreference?: string;
+  extraInstructions?: string;
+  designRules?: string;
+}
+
+const cleanHex = (value: string, fallback = '000000') => {
+  const normalized = value.trim().replace(/^#/, '').toUpperCase();
+  return /^[0-9A-F]{6}$/.test(normalized) ? normalized : fallback;
+};
+
+function theme(input: SlideTheme): SlideTheme {
+  return {
+    ...input,
+    palette: {
+      ...input.palette,
+      bg: cleanHex(input.palette.bg, 'FFFFFF'),
+      surface: cleanHex(input.palette.surface, 'FFFFFF'),
+      surfaceAlt: cleanHex(input.palette.surfaceAlt, 'F4F5F7'),
+      title: cleanHex(input.palette.title, '1A1A2E'),
+      body: cleanHex(input.palette.body, '2D2D3A'),
+      muted: cleanHex(input.palette.muted, '7A8190'),
+      accent: cleanHex(input.palette.accent, '2F6FED'),
+      accent2: cleanHex(input.palette.accent2, '00A896'),
+      inverseText: cleanHex(input.palette.inverseText, 'FFFFFF'),
+      codeBg: cleanHex(input.palette.codeBg, 'F4F5F7'),
+      codeFg: cleanHex(input.palette.codeFg, '24292F'),
+      border: cleanHex(input.palette.border, 'D7DAE0'),
+      chart: input.palette.chart.map((c) => cleanHex(c, '2F6FED')),
+    },
+  };
+}
+
+export const BUILTIN_SLIDE_THEMES: SlideTheme[] = [
+  theme({
+    id: 'midnight-surge',
+    name: 'Midnight Surge',
+    description: '어두운 커버와 선명한 시안 포인트의 피치덱 스타일',
+    palette: {
+      bg: 'F7FAFC',
+      surface: 'FFFFFF',
+      surfaceAlt: 'EAF1F7',
+      title: '101827',
+      body: '283447',
+      muted: '6A7485',
+      accent: '007294',
+      accent2: '6EE7B7',
+      inverseText: 'F8FBFF',
+      codeBg: 'E8EEF5',
+      codeFg: '172033',
+      border: 'D3DCE8',
+      chart: ['007294', '6EE7B7', '7C8CF8', 'FBBF24'],
+    },
+    fonts: {
+      heading: MARKMIND_PPTX_FREE_FONTS.latinHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    },
+    typeScale: { coverTitle: 44, title: 28, section: 34, body: 16, caption: 11, stat: 62 },
+    spacing: { marginX: 0.72, titleY: 0.42, bodyTop: 1.52, bodyBottom: 7.0, gap: 0.16, columnGap: 0.42 },
+    shape: { radius: 0.08, motif: 'corner-block' },
+    rules: [
+      'Use dark title and divider slides with light content slides.',
+      'Use cyan as a sharp accent, not as a full-slide wash.',
+      'Avoid decorative title underlines.',
+      'Use free multilingual fonts: Pretendard for Korean and Noto Sans families for other languages.',
+    ],
+  }),
+  theme({
+    id: 'bold-sunrise',
+    name: 'Bold Sunrise',
+    description: '따뜻한 배경과 강한 코랄/네이비 대비의 발표 자료',
+    palette: {
+      bg: 'FFF8ED',
+      surface: 'FFFFFF',
+      surfaceAlt: 'FFE8CF',
+      title: '18253D',
+      body: '2E3545',
+      muted: '7C6F63',
+      accent: 'F05A43',
+      accent2: 'F7B731',
+      inverseText: 'FFFFFF',
+      codeBg: 'F8E8D7',
+      codeFg: '2B2118',
+      border: 'E8CFB3',
+      chart: ['F05A43', 'F7B731', '18253D', '65A30D'],
+    },
+    fonts: {
+      heading: MARKMIND_PPTX_FREE_FONTS.latinHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    },
+    typeScale: { coverTitle: 42, title: 27, section: 33, body: 16, caption: 11, stat: 64 },
+    spacing: { marginX: 0.74, titleY: 0.44, bodyTop: 1.54, bodyBottom: 7.0, gap: 0.17, columnGap: 0.46 },
+    shape: { radius: 0.06, motif: 'band' },
+    rules: [
+      'Use warm light slides with dark, editorial title slides.',
+      'Use coral for emphasis and calls to action.',
+      'Keep body text restrained and left-aligned.',
+      'Avoid serif display fonts for Korean titles; use Pretendard/Noto Sans unless a Latin-only serif option is explicitly selected.',
+    ],
+  }),
+  theme({
+    id: 'mono-edge',
+    name: 'Mono Edge',
+    description: '고대비 흑백 구조에 라임 포인트를 더한 기술/분석형 테마',
+    palette: {
+      bg: 'F2F4F1',
+      surface: 'FFFFFF',
+      surfaceAlt: 'E2E7DE',
+      title: '111111',
+      body: '242424',
+      muted: '6F756B',
+      accent: 'B6E600',
+      accent2: '111111',
+      inverseText: 'FFFFFF',
+      codeBg: '111111',
+      codeFg: 'EAF9B8',
+      border: 'C9D1C2',
+      chart: ['111111', 'B6E600', '6F756B', 'D8E2D0'],
+    },
+    fonts: {
+      heading: MARKMIND_PPTX_FREE_FONTS.latinHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    },
+    typeScale: { coverTitle: 40, title: 26, section: 32, body: 15, caption: 10, stat: 60 },
+    spacing: { marginX: 0.7, titleY: 0.42, bodyTop: 1.48, bodyBottom: 7.02, gap: 0.15, columnGap: 0.4 },
+    shape: { radius: 0, motif: 'frame' },
+    rules: [
+      'Use monochrome structure with lime accents only for hierarchy.',
+      'Prefer framed content blocks and strong alignment.',
+      'Avoid soft gradients and decorative title underlines.',
+      'Use Noto Sans Display and Noto Sans Mono rather than heavy system display fonts.',
+    ],
+  }),
+];
+
+export const DEFAULT_SLIDE_THEME = BUILTIN_SLIDE_THEMES[0];
+
+export function getSlideTheme(themeId?: string): SlideTheme {
+  return BUILTIN_SLIDE_THEMES.find((t) => t.id === themeId) ?? DEFAULT_SLIDE_THEME;
+}
+
+export function applySlideDesignOptions(theme: SlideTheme, options: SlideExportOptions): SlideTheme {
+  const next: SlideTheme = {
+    ...theme,
+    fonts: { ...theme.fonts },
+    spacing: { ...theme.spacing },
+    typeScale: { ...theme.typeScale },
+    rules: [...theme.rules],
+  };
+
+  if (
+    options.fontPreference === 'modern sans-serif font pairing' ||
+    options.fontPreference === 'free multilingual sans font pairing'
+  ) {
+    next.fonts = {
+      heading: MARKMIND_PPTX_FREE_FONTS.latinHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    };
+  } else if (
+    options.fontPreference === 'serif headline with clean body font' ||
+    options.fontPreference === 'free editorial serif headline with sans body'
+  ) {
+    next.fonts = {
+      heading: MARKMIND_PPTX_FREE_FONTS.serifHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    };
+  } else if (
+    options.fontPreference === 'bold editorial headline font pairing' ||
+    options.fontPreference === 'technical sans and mono font pairing'
+  ) {
+    next.fonts = {
+      heading: MARKMIND_PPTX_FREE_FONTS.latinHeading,
+      body: MARKMIND_PPTX_FREE_FONTS.latinBody,
+      mono: MARKMIND_PPTX_FREE_FONTS.mono,
+    };
+  }
+
+  if (options.fontFamily?.trim()) {
+    const fontFamily = options.fontFamily.trim();
+    next.fonts = {
+      ...next.fonts,
+      heading: fontFamily,
+      body: fontFamily,
+      useLanguageFallback: false,
+    };
+    next.rules.push(`Use installed font family "${fontFamily}" for headings and body text.`);
+  }
+
+  if (options.marginPreference === 'wide margins with generous whitespace') {
+    next.spacing.marginX = Math.min(0.98, theme.spacing.marginX + 0.16);
+    next.spacing.bodyTop = Math.min(1.72, theme.spacing.bodyTop + 0.08);
+    next.spacing.gap = Math.min(0.24, theme.spacing.gap + 0.04);
+    next.spacing.columnGap = Math.min(0.58, theme.spacing.columnGap + 0.08);
+  } else if (options.marginPreference === 'compact margins for information-heavy decks') {
+    next.spacing.marginX = Math.max(0.56, theme.spacing.marginX - 0.12);
+    next.spacing.bodyTop = Math.max(1.34, theme.spacing.bodyTop - 0.06);
+    next.spacing.gap = Math.max(0.12, theme.spacing.gap - 0.02);
+    next.spacing.columnGap = Math.max(0.34, theme.spacing.columnGap - 0.04);
+  }
+
+  if (options.visualDensity === 'minimal text with strong whitespace and visual hierarchy') {
+    next.typeScale.body = theme.typeScale.body + 1;
+    next.typeScale.caption = theme.typeScale.caption + 1;
+    next.spacing.gap = Math.min(0.25, next.spacing.gap + 0.03);
+  } else if (options.visualDensity === 'information-dense but still readable slide composition') {
+    next.typeScale.body = Math.max(13, theme.typeScale.body - 1);
+    next.typeScale.caption = Math.max(9, theme.typeScale.caption - 1);
+    next.spacing.gap = Math.max(0.11, next.spacing.gap - 0.02);
+  }
+
+  return next;
+}

--- a/src/lib/slideTheme.ts
+++ b/src/lib/slideTheme.ts
@@ -66,6 +66,7 @@ export interface SlideExportOptions {
   designLayout?: string;
   visualDensity?: string;
   imagePolicy?: string;
+  imageSourceMode?: string;
   fontPreference?: string;
   fontFamily?: string;
   marginPreference?: string;

--- a/src/lib/slideValidation.test.ts
+++ b/src/lib/slideValidation.test.ts
@@ -26,6 +26,22 @@ describe('slideValidation', () => {
     expect(normalized.flatMap((s) => s.body).filter((b) => b.kind === 'bullet')).toHaveLength(14);
   });
 
+  it('keeps image intent only on the first split slide', () => {
+    const slide: Slide = {
+      title: 'Dense visual plan',
+      layout: 'content',
+      body: bullets(14),
+      sourceIds: ['S1'],
+      image: { query: 'team workshop', sourcePreference: 'generated', role: 'support' },
+    };
+
+    const normalized = normalizeSlidesForPptx([slide]);
+
+    expect(normalized).toHaveLength(2);
+    expect(normalized[0].image?.query).toBe('team workshop');
+    expect(normalized[1].image).toBeUndefined();
+  });
+
   it('demotes invalid stat slides to content', () => {
     const slide: Slide = {
       title: 'Metric without metric',

--- a/src/lib/slideValidation.test.ts
+++ b/src/lib/slideValidation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { Slide } from './markdownToSlides';
+import { normalizeSlidesForPptx, summarizeSlideIssues, validateSlideDeck } from './slideValidation';
+
+const bullets = (count: number) =>
+  Array.from({ length: count }, (_, idx) => ({
+    kind: 'bullet' as const,
+    indent: 0,
+    spans: [{ text: `Point ${idx + 1}` }],
+  }));
+
+describe('slideValidation', () => {
+  it('splits dense text slides before PPTX rendering', () => {
+    const slide: Slide = {
+      title: 'Dense plan',
+      layout: 'content',
+      body: bullets(14),
+      sourceIds: ['S1'],
+    };
+
+    const normalized = normalizeSlidesForPptx([slide]);
+
+    expect(normalized.length).toBe(2);
+    expect(normalized[0].title).toBe('Dense plan');
+    expect(normalized[1].title).toBe('Dense plan (2/2)');
+    expect(normalized.flatMap((s) => s.body).filter((b) => b.kind === 'bullet')).toHaveLength(14);
+  });
+
+  it('demotes invalid stat slides to content', () => {
+    const slide: Slide = {
+      title: 'Metric without metric',
+      layout: 'stat',
+      body: bullets(2),
+    };
+
+    const normalized = normalizeSlidesForPptx([slide]);
+
+    expect(normalized[0].layout).toBe('content');
+  });
+
+  it('reports layout and capacity issues', () => {
+    const slide: Slide = {
+      title: 'A very long title that is intentionally beyond the normal slide title capacity for one page',
+      layout: 'content',
+      body: [
+        {
+          kind: 'table',
+          rows: [
+            ['A', 'B', 'C', 'D', 'E', 'F'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+            ['1', '2', '3', '4', '5', '6'],
+          ],
+        },
+      ],
+    };
+
+    const report = validateSlideDeck([slide]);
+    const summary = summarizeSlideIssues(report);
+
+    expect(report.warnings).toBeGreaterThanOrEqual(2);
+    expect(summary).toContain('long-title');
+    expect(summary).toContain('large-table');
+  });
+});

--- a/src/lib/slideValidation.ts
+++ b/src/lib/slideValidation.ts
@@ -113,6 +113,7 @@ function splitSlide(slide: Slide): Slide[] {
     title: chunkIndex === 0 ? slide.title : `${slide.title || 'Continued'} (${chunkIndex + 1}/${chunks.length})`,
     layout: 'content',
     body,
+    image: chunkIndex === 0 ? slide.image : undefined,
     notes: chunkIndex === 0 ? slide.notes : undefined,
   }));
 }

--- a/src/lib/slideValidation.ts
+++ b/src/lib/slideValidation.ts
@@ -1,0 +1,210 @@
+import type { Slide, SlideBlock } from './markdownToSlides';
+
+export type SlideIssueSeverity = 'info' | 'warning' | 'critical';
+
+export interface SlideIssue {
+  slideIndex: number;
+  slideNumber: number;
+  severity: SlideIssueSeverity;
+  code: string;
+  message: string;
+}
+
+export interface SlideValidationReport {
+  issues: SlideIssue[];
+  hasCritical: boolean;
+  warnings: number;
+}
+
+const LIMITS = {
+  titleChars: 86,
+  coverTitleChars: 72,
+  bodyChars: 820,
+  bulletCount: 7,
+  bulletChars: 118,
+  simpleBlockCount: 9,
+  splitChars: 760,
+  splitBlocks: 8,
+  quoteChars: 240,
+  tableRows: 7,
+  tableCols: 5,
+  codeLines: 14,
+  columnBlocks: 6,
+};
+
+function blockText(block: SlideBlock): string {
+  if (block.kind === 'text' || block.kind === 'bullet') {
+    return block.spans.map((span) => span.text).join('');
+  }
+  if (block.kind === 'subhead' || block.kind === 'code') return block.text;
+  if (block.kind === 'image') return block.alt || block.src;
+  return block.rows.map((row) => row.join(' ')).join(' ');
+}
+
+function countBullets(blocks: SlideBlock[]): number {
+  return blocks.filter((block) => block.kind === 'bullet').length;
+}
+
+function countChars(blocks: SlideBlock[]): number {
+  return blocks.reduce((sum, block) => sum + blockText(block).length, 0);
+}
+
+function isSimpleTextBlock(block: SlideBlock): boolean {
+  return block.kind === 'text' || block.kind === 'bullet' || block.kind === 'subhead';
+}
+
+function canSplitSlide(slide: Slide): boolean {
+  if (slide.layout === 'title' || slide.layout === 'section' || slide.layout === 'quote' || slide.layout === 'stat') {
+    return false;
+  }
+  if (slide.columns?.length) return false;
+  return slide.body.length > 0 && slide.body.every(isSimpleTextBlock);
+}
+
+function shouldSplitSlide(slide: Slide): boolean {
+  if (!canSplitSlide(slide)) return false;
+  return (
+    slide.body.length > LIMITS.simpleBlockCount ||
+    countBullets(slide.body) > LIMITS.bulletCount ||
+    countChars(slide.body) > LIMITS.bodyChars
+  );
+}
+
+function splitBlocks(blocks: SlideBlock[]): SlideBlock[][] {
+  const chunks: SlideBlock[][] = [];
+  let current: SlideBlock[] = [];
+  let currentChars = 0;
+
+  const flush = () => {
+    if (current.length === 0) return;
+    chunks.push(current);
+    current = [];
+    currentChars = 0;
+  };
+
+  for (const block of blocks) {
+    const blockChars = Math.max(1, blockText(block).length);
+    const tooManyBlocks = current.length >= LIMITS.splitBlocks;
+    const tooManyChars = current.length > 0 && currentChars + blockChars > LIMITS.splitChars;
+    if (tooManyBlocks || tooManyChars) flush();
+    current.push(block);
+    currentChars += blockChars;
+  }
+
+  flush();
+  return chunks.length > 0 ? chunks : [blocks];
+}
+
+function repairLayout(slide: Slide): Slide {
+  if (slide.layout === 'stat' && !slide.stat) return { ...slide, layout: 'content' };
+  if (slide.layout === 'quote' && !slide.quote && countChars(slide.body) > LIMITS.quoteChars) {
+    return { ...slide, layout: 'content' };
+  }
+  return slide;
+}
+
+function splitSlide(slide: Slide): Slide[] {
+  if (!shouldSplitSlide(slide)) return [slide];
+  const chunks = splitBlocks(slide.body);
+  if (chunks.length <= 1) return [slide];
+
+  return chunks.map((body, chunkIndex) => ({
+    ...slide,
+    title: chunkIndex === 0 ? slide.title : `${slide.title || 'Continued'} (${chunkIndex + 1}/${chunks.length})`,
+    layout: 'content',
+    body,
+    notes: chunkIndex === 0 ? slide.notes : undefined,
+  }));
+}
+
+export function normalizeSlidesForPptx(slides: Slide[]): Slide[] {
+  return slides.flatMap((slide) => splitSlide(repairLayout(slide)));
+}
+
+function addIssue(issues: SlideIssue[], slideIndex: number, severity: SlideIssueSeverity, code: string, message: string) {
+  issues.push({
+    slideIndex,
+    slideNumber: slideIndex + 1,
+    severity,
+    code,
+    message,
+  });
+}
+
+function validateBlocks(issues: SlideIssue[], slideIndex: number, blocks: SlideBlock[]) {
+  const bulletCount = countBullets(blocks);
+  const bodyChars = countChars(blocks);
+
+  if (bulletCount > LIMITS.bulletCount) {
+    addIssue(issues, slideIndex, 'warning', 'dense-bullets', `Has ${bulletCount} bullets; split or compress.`);
+  }
+  if (bodyChars > LIMITS.bodyChars) {
+    addIssue(issues, slideIndex, 'warning', 'dense-copy', `Has about ${bodyChars} text characters; may crowd the slide.`);
+  }
+
+  for (const block of blocks) {
+    if (block.kind === 'bullet' && blockText(block).length > LIMITS.bulletChars) {
+      addIssue(issues, slideIndex, 'warning', 'long-bullet', 'A bullet is too long for a presentation slot.');
+    } else if (block.kind === 'table') {
+      const cols = Math.max(0, ...block.rows.map((row) => row.length));
+      if (block.rows.length > LIMITS.tableRows || cols > LIMITS.tableCols) {
+        addIssue(issues, slideIndex, 'warning', 'large-table', 'Table is larger than the PPTX layout can comfortably render.');
+      }
+    } else if (block.kind === 'code' && block.text.split('\n').length > LIMITS.codeLines) {
+      addIssue(issues, slideIndex, 'warning', 'long-code', 'Code block is too long for one slide.');
+    }
+  }
+}
+
+export function validateSlideDeck(slides: Slide[]): SlideValidationReport {
+  const issues: SlideIssue[] = [];
+  const deckUsesSourceIds = slides.some((slide) => slide.sourceIds && slide.sourceIds.length > 0);
+
+  slides.forEach((slide, slideIndex) => {
+    const titleLimit = slide.layout === 'title' ? LIMITS.coverTitleChars : LIMITS.titleChars;
+    if (!slide.title.trim() && slide.body.length === 0 && !slide.quote && !slide.stat && !slide.image) {
+      addIssue(issues, slideIndex, 'critical', 'empty-slide', 'Slide has no visible content.');
+    }
+    if (slide.title.length > titleLimit) {
+      addIssue(issues, slideIndex, 'warning', 'long-title', 'Title is longer than the layout capacity.');
+    }
+    if (deckUsesSourceIds && slide.layout !== 'title' && slide.layout !== 'section' && !slide.sourceIds?.length) {
+      addIssue(issues, slideIndex, 'info', 'missing-source-ids', 'Slide has no sourceIds from the source map.');
+    }
+
+    if (slide.layout === 'stat' && !slide.stat) {
+      addIssue(issues, slideIndex, 'warning', 'stat-without-value', 'Stat layout needs a single headline number.');
+    }
+    if (slide.layout === 'quote') {
+      const quoteText = slide.quote?.text ?? '';
+      if (quoteText.length > LIMITS.quoteChars) {
+        addIssue(issues, slideIndex, 'warning', 'long-quote', 'Quote is too long for a quote layout.');
+      }
+    }
+    if ((slide.layout === 'two-column' || slide.layout === 'comparison') && slide.columns?.length) {
+      slide.columns.forEach((column) => {
+        if (column.length > LIMITS.columnBlocks || countChars(column) > LIMITS.splitChars) {
+          addIssue(issues, slideIndex, 'warning', 'dense-column', 'A column has more content than its visual capacity.');
+        }
+      });
+    }
+
+    validateBlocks(issues, slideIndex, slide.body);
+  });
+
+  return {
+    issues,
+    hasCritical: issues.some((issue) => issue.severity === 'critical'),
+    warnings: issues.filter((issue) => issue.severity === 'warning').length,
+  };
+}
+
+export function summarizeSlideIssues(report: SlideValidationReport, limit = 6): string {
+  if (report.issues.length === 0) return '';
+  const shown = report.issues
+    .slice(0, limit)
+    .map((issue) => `Slide ${issue.slideNumber}: ${issue.code} - ${issue.message}`);
+  const hidden = report.issues.length - shown.length;
+  if (hidden > 0) shown.push(`...and ${hidden} more issue${hidden === 1 ? '' : 's'}.`);
+  return shown.join('\n');
+}

--- a/src/services/slideAssetBundle.test.ts
+++ b/src/services/slideAssetBundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { SlideAssetRecord } from './slideAssets';
-import { slideAssetFileStem } from './slideAssetBundle';
+import { slideAssetBundleDir, slideAssetFileStem } from './slideAssetBundle';
 
 const baseRecord: SlideAssetRecord = {
   slideIndex: 2,
@@ -25,5 +25,15 @@ describe('slideAssetBundle', () => {
     expect(slideAssetFileStem({ ...baseRecord, sourceMode: 'generated', provider: 'openai' })).toContain(
       'slide-03-generated-openai-support',
     );
+  });
+
+  it('Windows PPTX 경로 옆에 asset bundle 경로를 만든다', () => {
+    expect(slideAssetBundleDir('C:\\Users\\me\\Decks\\demo.pptx')).toBe(
+      'C:\\Users\\me\\Decks\\demo.assets',
+    );
+  });
+
+  it('POSIX PPTX 경로 옆에 asset bundle 경로를 만든다', () => {
+    expect(slideAssetBundleDir('/Users/me/Decks/demo.pptx')).toBe('/Users/me/Decks/demo.assets');
   });
 });

--- a/src/services/slideAssetBundle.test.ts
+++ b/src/services/slideAssetBundle.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import type { SlideAssetRecord } from './slideAssets';
+import { slideAssetFileStem } from './slideAssetBundle';
+
+const baseRecord: SlideAssetRecord = {
+  slideIndex: 2,
+  slideTitle: '문제는 관심 부족이 아니라 조건 부족입니다',
+  slideId: 'S3',
+  role: 'support',
+  sourceMode: 'stock',
+  provider: 'openverse',
+  sourceUrl: 'https://pixabay.com/photos/workshop-team-123',
+  inserted: true,
+  importance: 84,
+  imageScore: 78,
+  dataUrl: 'data:image/png;base64,AA==',
+};
+
+describe('slideAssetBundle', () => {
+  it('검색 이미지 파일명에 슬라이드 번호, search, 출처를 포함', () => {
+    expect(slideAssetFileStem(baseRecord)).toContain('slide-03-search-pixabay-support');
+  });
+
+  it('생성 이미지 파일명에 슬라이드 번호, generated, 공급사를 포함', () => {
+    expect(slideAssetFileStem({ ...baseRecord, sourceMode: 'generated', provider: 'openai' })).toContain(
+      'slide-03-generated-openai-support',
+    );
+  });
+});

--- a/src/services/slideAssetBundle.ts
+++ b/src/services/slideAssetBundle.ts
@@ -11,9 +11,33 @@ export interface SaveSlideAssetBundleResult {
   manifestPath: string;
 }
 
+function pathSeparatorFor(path: string): '/' | '\\' {
+  return path.lastIndexOf('\\') > path.lastIndexOf('/') ? '\\' : '/';
+}
+
+function joinPath(parent: string, child: string): string {
+  if (!parent) return child;
+  const sep = pathSeparatorFor(parent);
+  const trimmed = parent.replace(/[\\/]+$/, '');
+  if (!trimmed) return `${sep}${child}`;
+  return `${trimmed}${sep}${child}`;
+}
+
+function parentDirFromPath(path: string): string {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  if (idx < 0) return '';
+  if (idx === 0) return path[0] ?? '';
+  return path.slice(0, idx);
+}
+
 function deckStemFromPath(pptxPath: string): string {
-  const file = pptxPath.split('/').pop() || 'deck.pptx';
+  const file = pptxPath.split(/[\\/]/).pop() || 'deck.pptx';
   return sanitizeFileName(file.replace(/\.pptx$/i, '') || 'deck');
+}
+
+export function slideAssetBundleDir(pptxPath: string): string {
+  const parent = parentDirFromPath(pptxPath);
+  return joinPath(parent, `${deckStemFromPath(pptxPath)}.assets`);
 }
 
 function dataUrlToBytes(dataUrl: string): { bytes: Uint8Array; mime: string } | null {
@@ -75,9 +99,9 @@ export async function saveSlideAssetBundle(
 ): Promise<SaveSlideAssetBundleResult | null> {
   if (records.length === 0) return null;
   const fs = await import('@tauri-apps/plugin-fs');
-  const dir = `${pptxPath.replace(/\/[^/]*$/, '')}/${deckStemFromPath(pptxPath)}.assets`;
-  const usedDir = `${dir}/used`;
-  const unusedDir = `${dir}/unused`;
+  const dir = slideAssetBundleDir(pptxPath);
+  const usedDir = joinPath(dir, 'used');
+  const unusedDir = joinPath(dir, 'unused');
   await fs.mkdir(usedDir, { recursive: true });
   await fs.mkdir(unusedDir, { recursive: true });
 
@@ -94,13 +118,13 @@ export async function saveSlideAssetBundle(
     const folderName = record.inserted ? 'used' : 'unused';
     const desired = `${slideAssetFileStem(record)}.${extFromMime(parsed.mime)}`;
     const name = await resolveCollision(targetDir, desired, fs.exists);
-    await fs.writeFile(`${targetDir}/${name}`, parsed.bytes);
+    await fs.writeFile(joinPath(targetDir, name), parsed.bytes);
     saved += 1;
     manifest.push({ ...withoutData, file: `${folderName}/${name}` });
   }
 
-  const manifestPath = `${dir}/manifest.json`;
+  const manifestPath = joinPath(dir, 'manifest.json');
   await fs.writeTextFile(manifestPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), assets: manifest }, null, 2)}\n`);
-  await fs.writeTextFile(`${dir}/ATTRIBUTION.md`, attributionText(manifest));
+  await fs.writeTextFile(joinPath(dir, 'ATTRIBUTION.md'), attributionText(manifest));
   return { dir, saved, manifestPath };
 }

--- a/src/services/slideAssetBundle.ts
+++ b/src/services/slideAssetBundle.ts
@@ -1,0 +1,106 @@
+import { extFromMime, resolveCollision, sanitizeFileName } from '../lib/imageAttach';
+import type { SlideAssetRecord } from './slideAssets';
+
+export interface SavedSlideAssetRecord extends Omit<SlideAssetRecord, 'dataUrl'> {
+  file?: string;
+}
+
+export interface SaveSlideAssetBundleResult {
+  dir: string;
+  saved: number;
+  manifestPath: string;
+}
+
+function deckStemFromPath(pptxPath: string): string {
+  const file = pptxPath.split('/').pop() || 'deck.pptx';
+  return sanitizeFileName(file.replace(/\.pptx$/i, '') || 'deck');
+}
+
+function dataUrlToBytes(dataUrl: string): { bytes: Uint8Array; mime: string } | null {
+  const match = dataUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s);
+  if (!match) return null;
+  const mime = match[1] || 'image/png';
+  const payload = match[3] || '';
+  const binary = match[2] ? atob(payload) : decodeURIComponent(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return { bytes, mime };
+}
+
+function shortSourceLabel(record: SlideAssetRecord): string {
+  if (record.sourceMode === 'generated') return sanitizeFileName(record.provider).toLowerCase();
+  try {
+    const host = record.sourceUrl ? new URL(record.sourceUrl).hostname.toLowerCase() : '';
+    const cleaned = host.replace(/^www\./, '').replace(/^commons\./, '');
+    const parts = cleaned.split('.').filter(Boolean);
+    if (parts.length >= 2) return sanitizeFileName(parts[parts.length - 2]).toLowerCase();
+    if (parts.length === 1) return sanitizeFileName(parts[0]).toLowerCase();
+  } catch {
+    // Fall through to provider label.
+  }
+  return sanitizeFileName(record.provider).toLowerCase();
+}
+
+export function slideAssetFileStem(record: SlideAssetRecord): string {
+  const slideNo = String(record.slideIndex + 1).padStart(2, '0');
+  const title = sanitizeFileName(record.slideTitle).slice(0, 42).trim() || 'slide';
+  const mode = record.sourceMode === 'generated' ? 'generated' : 'search';
+  const provider = shortSourceLabel(record);
+  return sanitizeFileName(`slide-${slideNo}-${mode}-${provider}-${record.role}-${title}`);
+}
+
+function attributionText(records: SavedSlideAssetRecord[]): string {
+  const lines = ['# PPTX Image Assets', ''];
+  for (const record of records) {
+    lines.push(`## Slide ${record.slideIndex + 1}: ${record.slideTitle}`);
+    lines.push(`- File: ${record.file ?? '(not saved)'}`);
+    lines.push(`- Used in PPTX: ${record.inserted ? 'yes' : 'no'}`);
+    lines.push(`- Provider: ${record.provider}`);
+    lines.push(`- Importance: ${record.importance}`);
+    lines.push(`- Image score: ${record.imageScore}`);
+    if (record.importanceReason) lines.push(`- Importance reason: ${record.importanceReason}`);
+    if (record.sourceUrl) lines.push(`- Source URL: ${record.sourceUrl}`);
+    if (record.license) lines.push(`- License: ${record.license}`);
+    if (record.attribution) lines.push(`- Attribution: ${record.attribution}`);
+    if (record.query) lines.push(`- Query: ${record.query}`);
+    if (record.generatedPrompt) lines.push(`- Generated prompt: ${record.generatedPrompt.replace(/\s+/g, ' ').slice(0, 500)}`);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export async function saveSlideAssetBundle(
+  pptxPath: string,
+  records: SlideAssetRecord[],
+): Promise<SaveSlideAssetBundleResult | null> {
+  if (records.length === 0) return null;
+  const fs = await import('@tauri-apps/plugin-fs');
+  const dir = `${pptxPath.replace(/\/[^/]*$/, '')}/${deckStemFromPath(pptxPath)}.assets`;
+  const usedDir = `${dir}/used`;
+  const unusedDir = `${dir}/unused`;
+  await fs.mkdir(usedDir, { recursive: true });
+  await fs.mkdir(unusedDir, { recursive: true });
+
+  const manifest: SavedSlideAssetRecord[] = [];
+  let saved = 0;
+  for (const record of records) {
+    const parsed = dataUrlToBytes(record.dataUrl);
+    const withoutData = (({ dataUrl: _dataUrl, ...rest }) => rest)(record);
+    if (!parsed) {
+      manifest.push(withoutData);
+      continue;
+    }
+    const targetDir = record.inserted ? usedDir : unusedDir;
+    const folderName = record.inserted ? 'used' : 'unused';
+    const desired = `${slideAssetFileStem(record)}.${extFromMime(parsed.mime)}`;
+    const name = await resolveCollision(targetDir, desired, fs.exists);
+    await fs.writeFile(`${targetDir}/${name}`, parsed.bytes);
+    saved += 1;
+    manifest.push({ ...withoutData, file: `${folderName}/${name}` });
+  }
+
+  const manifestPath = `${dir}/manifest.json`;
+  await fs.writeTextFile(manifestPath, `${JSON.stringify({ generatedAt: new Date().toISOString(), assets: manifest }, null, 2)}\n`);
+  await fs.writeTextFile(`${dir}/ATTRIBUTION.md`, attributionText(manifest));
+  return { dir, saved, manifestPath };
+}

--- a/src/services/slideAssets.test.ts
+++ b/src/services/slideAssets.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Slide } from '../lib/markdownToSlides';
 import { DEFAULT_SLIDE_THEME } from '../lib/slideTheme';
-import { buildGeneratedSlideImagePrompt, scoreSlideImageCandidate, type SlideImageIntent } from './slideAssets';
+import {
+  buildGeneratedSlideImagePrompt,
+  routeSlideImageIntent,
+  scoreSlideImageCandidate,
+  type SlideImageIntent,
+} from './slideAssets';
 
 describe('slideAssets', () => {
   it('중요도와 밀도를 합쳐 이미지 후보 점수를 계산', () => {
@@ -54,5 +59,24 @@ describe('slideAssets', () => {
     expect(prompt).toContain('negative space');
     expect(prompt).toContain('Do not include readable text');
     expect(prompt).toContain(DEFAULT_SLIDE_THEME.name);
+  });
+
+  it('Stock만 모드는 generated 선호 intent도 검색으로 라우팅', () => {
+    const intent: SlideImageIntent = {
+      slideIndex: 1,
+      slideId: 'S2',
+      title: 'AI adoption conditions',
+      role: 'support',
+      query: 'workplace collaboration training',
+      prompt: 'abstract workplace conditions',
+      aspect: '16:9',
+      sourcePreference: 'generated',
+      licenseStrictness: 'presentation',
+      importance: 72,
+      imageScore: 69,
+    };
+
+    expect(routeSlideImageIntent(intent, 'stockOnly')).toBe('stock');
+    expect(routeSlideImageIntent({ ...intent, sourcePreference: 'none' }, 'stockOnly')).toBeNull();
   });
 });

--- a/src/services/slideAssets.test.ts
+++ b/src/services/slideAssets.test.ts
@@ -82,4 +82,24 @@ describe('slideAssets', () => {
     expect(routeSlideImageIntent({ ...intent, sourcePreference: 'none' }, 'stockOnly')).toBeNull();
     expect(canResolveStockSearch({ ...intent, sourcePreference: 'none' })).toBe(false);
   });
+
+  it('생성만 모드는 stock 선호 일반 intent도 생성으로 라우팅', () => {
+    const intent: SlideImageIntent = {
+      slideIndex: 1,
+      slideId: 'S2',
+      title: 'AI adoption conditions',
+      role: 'support',
+      query: 'workplace collaboration training',
+      aspect: '16:9',
+      sourcePreference: 'stock',
+      licenseStrictness: 'presentation',
+      importance: 72,
+      imageScore: 69,
+    };
+
+    expect(routeSlideImageIntent(intent, 'generatedOnly')).toBe('generated');
+    expect(routeSlideImageIntent({ ...intent, role: 'logo' }, 'generatedOnly')).toBeNull();
+    expect(routeSlideImageIntent({ ...intent, sourcePreference: 'logo' }, 'generatedOnly')).toBeNull();
+    expect(routeSlideImageIntent({ ...intent, sourcePreference: 'none' }, 'generatedOnly')).toBeNull();
+  });
 });

--- a/src/services/slideAssets.test.ts
+++ b/src/services/slideAssets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Slide } from '../lib/markdownToSlides';
+import { DEFAULT_SLIDE_THEME } from '../lib/slideTheme';
+import { buildGeneratedSlideImagePrompt, scoreSlideImageCandidate, type SlideImageIntent } from './slideAssets';
+
+describe('slideAssets', () => {
+  it('중요도와 밀도를 합쳐 이미지 후보 점수를 계산', () => {
+    const importantSparse: Slide = {
+      title: '핵심 전략 결론',
+      layout: 'stat',
+      importance: 90,
+      body: [{ kind: 'text', spans: [{ text: '가장 중요한 의사결정 포인트' }] }],
+      stat: { value: '3x', label: '효율 개선' },
+    };
+    const denseAppendix: Slide = {
+      title: '부록 상세 로그',
+      layout: 'content',
+      importance: 25,
+      body: Array.from({ length: 10 }, (_, i) => ({
+        kind: 'bullet' as const,
+        spans: [{ text: `상세 항목 ${i + 1} `.repeat(18) }],
+        indent: 0,
+      })),
+    };
+
+    const high = scoreSlideImageCandidate(importantSparse, 0, 2, 'needed');
+    const low = scoreSlideImageCandidate(denseAppendix, 1, 2, 'needed');
+
+    expect(high.importance).toBeGreaterThanOrEqual(90);
+    expect(high.score).toBeGreaterThan(low.score);
+    expect(low.score).toBeLessThan(65);
+  });
+
+  it('생성 이미지는 검색어가 아니라 슬라이드 문맥 기반 프롬프트를 사용', () => {
+    const intent: SlideImageIntent = {
+      slideIndex: 2,
+      slideId: 'S3',
+      title: '문제는 관심 부족이 아니라 조건 부족입니다',
+      role: 'support',
+      query: 'team collaboration',
+      prompt: 'abstract workplace conditions enabling better AI adoption',
+      aspect: '4:3',
+      sourcePreference: 'generated',
+      licenseStrictness: 'presentation',
+      importance: 84,
+      imageScore: 78,
+      textSummary: '안전하게 질문할 공간과 다시 시도할 계기가 부족하다.',
+    };
+
+    const prompt = buildGeneratedSlideImagePrompt(intent, DEFAULT_SLIDE_THEME);
+
+    expect(prompt).toContain('Slide title');
+    expect(prompt).toContain('Creative brief');
+    expect(prompt).toContain('negative space');
+    expect(prompt).toContain('Do not include readable text');
+    expect(prompt).toContain(DEFAULT_SLIDE_THEME.name);
+  });
+});

--- a/src/services/slideAssets.test.ts
+++ b/src/services/slideAssets.test.ts
@@ -3,6 +3,7 @@ import type { Slide } from '../lib/markdownToSlides';
 import { DEFAULT_SLIDE_THEME } from '../lib/slideTheme';
 import {
   buildGeneratedSlideImagePrompt,
+  canResolveStockSearch,
   routeSlideImageIntent,
   scoreSlideImageCandidate,
   type SlideImageIntent,
@@ -77,6 +78,8 @@ describe('slideAssets', () => {
     };
 
     expect(routeSlideImageIntent(intent, 'stockOnly')).toBe('stock');
+    expect(canResolveStockSearch(intent)).toBe(true);
     expect(routeSlideImageIntent({ ...intent, sourcePreference: 'none' }, 'stockOnly')).toBeNull();
+    expect(canResolveStockSearch({ ...intent, sourcePreference: 'none' })).toBe(false);
   });
 });

--- a/src/services/slideAssets.ts
+++ b/src/services/slideAssets.ts
@@ -308,7 +308,6 @@ export function canResolveStockSearch(intent: SlideImageIntent): boolean {
 function canGenerate(intent: SlideImageIntent): boolean {
   return (
     intent.sourcePreference !== 'none' &&
-    intent.sourcePreference !== 'stock' &&
     intent.sourcePreference !== 'logo' &&
     intent.role !== 'logo'
   );

--- a/src/services/slideAssets.ts
+++ b/src/services/slideAssets.ts
@@ -301,7 +301,7 @@ function canSearchStock(intent: SlideImageIntent): boolean {
   return intent.sourcePreference !== 'none' && intent.sourcePreference !== 'generated' && Boolean(intent.query || intent.entity);
 }
 
-function canForceStockSearch(intent: SlideImageIntent): boolean {
+export function canResolveStockSearch(intent: SlideImageIntent): boolean {
   return intent.sourcePreference !== 'none' && Boolean(intent.query || intent.entity);
 }
 
@@ -327,7 +327,7 @@ function preferGeneratedForAuto(intent: SlideImageIntent): boolean {
 export function routeSlideImageIntent(intent: SlideImageIntent, mode: SlideImageSourceMode): AssetSourceKind | null {
   if (intent.sourcePreference === 'none') return null;
   if (mode === 'generatedOnly') return canGenerate(intent) ? 'generated' : null;
-  if (mode === 'stockOnly') return canForceStockSearch(intent) ? 'stock' : null;
+  if (mode === 'stockOnly') return canResolveStockSearch(intent) ? 'stock' : null;
   if (intent.sourcePreference === 'generated') return canGenerate(intent) ? 'generated' : null;
   if (intent.sourcePreference === 'stock' || intent.sourcePreference === 'logo' || intent.role === 'logo') {
     return canSearchStock(intent) ? 'stock' : null;
@@ -362,7 +362,7 @@ function splitQueues(
 }
 
 async function resolveStockAsset(intent: SlideImageIntent): Promise<ResolvedSlideAsset | null> {
-  if (!isTauri() || !canSearchStock(intent)) return null;
+  if (!isTauri() || !canResolveStockSearch(intent)) return null;
   const { invoke } = await import('@tauri-apps/api/core');
   return invoke<ResolvedSlideAsset | null>('resolve_stock_slide_asset', { intent });
 }

--- a/src/services/slideAssets.ts
+++ b/src/services/slideAssets.ts
@@ -3,13 +3,16 @@ import type { SlideExportOptions, SlideTheme } from '../lib/slideTheme';
 import {
   generatedImageLimitForPolicy,
   slideImagePolicyMode,
+  slideImageSourceMode,
   stockImageLimitForPolicy,
+  type SlideImageSourceMode,
 } from '../lib/slideLimits';
 import { getImageAIModelSelection } from './aiModelConfig';
 import { generateImage, humanizeImageGenError, type ImageProvider } from './imageGen';
 import { isTauri } from './platform';
 
 type AssetProvider = 'openverse' | 'wikimedia' | 'openai' | 'gemini' | 'grok';
+type AssetSourceKind = 'stock' | 'generated';
 
 export interface SlideImageIntent {
   slideIndex: number;
@@ -23,6 +26,10 @@ export interface SlideImageIntent {
   style?: string;
   sourcePreference: SlideImageSourcePreference;
   licenseStrictness: SlideImageLicenseStrictness;
+  importance: number;
+  importanceReason?: string;
+  imageScore: number;
+  textSummary?: string;
 }
 
 export interface ResolvedSlideAsset {
@@ -33,6 +40,28 @@ export interface ResolvedSlideAsset {
   license?: string;
   width?: number;
   height?: number;
+}
+
+export interface SlideAssetRecord {
+  slideIndex: number;
+  slideTitle: string;
+  slideId: string;
+  role: SlideImageRole;
+  sourceMode: AssetSourceKind;
+  provider: AssetProvider;
+  inserted: boolean;
+  importance: number;
+  importanceReason?: string;
+  imageScore: number;
+  query?: string;
+  prompt?: string;
+  generatedPrompt?: string;
+  sourceUrl?: string;
+  attribution?: string;
+  license?: string;
+  width?: number;
+  height?: number;
+  dataUrl: string;
 }
 
 export interface SlideAssetResolutionSummary {
@@ -51,28 +80,55 @@ export interface ResolveSlideAssetsOptions {
 
 const STOCK_CONCURRENCY = 4;
 const GENERATED_CONCURRENCY = 2;
+const IMPORTANT_TITLE_RE =
+  /(결론|요약|핵심|제안|추천|권고|실행|계획|다음 단계|의사결정|결정|성과|문제|전략|conclusion|summary|recommend|proposal|action|next step|decision|strategy|key)/i;
+const CONCEPTUAL_RE =
+  /(전략|성장|전환|리스크|문제|해결|협업|혁신|효율|생산성|미래|변화|갈등|균형|strategy|growth|transition|risk|problem|solution|collaboration|innovation|productivity|future|change|balance)/i;
+const FACTUAL_RE =
+  /(logo|로고|brand|브랜드|company|기업|product|제품|place|장소|city|도시|map|지도|building|건물|person|인물|founder|ceo|university|school|hospital|government|기관)/i;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function blockText(block: Slide['body'][number]): string {
+  if (block.kind === 'bullet' || block.kind === 'text') return block.spans.map((span) => span.text).join('');
+  if (block.kind === 'subhead' || block.kind === 'code') return block.text;
+  if (block.kind === 'table') return block.rows.flat().join(' ');
+  if (block.kind === 'image') return block.alt || '';
+  return '';
+}
 
 function blockTextLength(block: Slide['body'][number]): number {
-  if (block.kind === 'bullet' || block.kind === 'text') return block.spans.map((span) => span.text).join('').length;
-  if (block.kind === 'subhead' || block.kind === 'code') return block.text.length;
-  if (block.kind === 'table') return block.rows.flat().join(' ').length;
-  if (block.kind === 'image') return 0;
-  return 0;
+  return blockText(block).length;
 }
 
 function visibleElementCount(slide: Slide): number {
   const bodyCount = slide.body.filter((block) => block.kind !== 'image').length;
-  const columnCount = slide.columns?.reduce((sum, col) => sum + col.filter((block) => block.kind !== 'image').length, 0) ?? 0;
+  const columnCount =
+    slide.columns?.reduce((sum, col) => sum + col.filter((block) => block.kind !== 'image').length, 0) ?? 0;
   return Math.max(bodyCount, columnCount);
 }
 
 function textLoad(slide: Slide): number {
   const bodyText = slide.body.reduce((sum, block) => sum + blockTextLength(block), 0);
-  const columnText = slide.columns?.reduce(
-    (sum, col) => sum + col.reduce((colSum, block) => colSum + blockTextLength(block), 0),
-    0,
-  ) ?? 0;
+  const columnText =
+    slide.columns?.reduce(
+      (sum, col) => sum + col.reduce((colSum, block) => colSum + blockTextLength(block), 0),
+      0,
+    ) ?? 0;
   return Math.max(bodyText, columnText);
+}
+
+function slideTextSummary(slide: Slide): string {
+  const parts = [
+    slide.title,
+    slide.quote?.text,
+    slide.stat ? [slide.stat.value, slide.stat.label, slide.stat.context].filter(Boolean).join(' ') : '',
+    ...slide.body.map(blockText),
+    ...(slide.columns?.flat().map(blockText) ?? []),
+  ].filter(Boolean);
+  return parts.join(' ').replace(/\s+/g, ' ').trim().slice(0, 520);
 }
 
 function hasExplicitImageIntent(slide: Slide): boolean {
@@ -120,90 +176,108 @@ function fallbackQuery(slide: Slide): string {
   return [slide.image?.entity, slide.image?.query, slide.title, path, visualHint].filter(Boolean).join(' ').trim();
 }
 
-function fallbackPrompt(intent: SlideImageIntent, theme?: SlideTheme): string {
-  const tone = theme ? `Match a ${theme.name} presentation theme.` : 'Match a polished modern presentation deck.';
-  const topic = intent.entity || intent.query || intent.title;
-  const role =
-    intent.role === 'cover' || intent.role === 'background'
-      ? 'wide cinematic hero background'
-      : intent.role === 'icon'
-        ? 'simple high-quality editorial icon illustration'
-        : 'clean editorial presentation visual';
-  return [
-    `Create a ${role} for a PowerPoint slide titled "${intent.title}".`,
-    `Topic: ${topic}.`,
-    tone,
-    intent.style ? `Style: ${intent.style}.` : '',
-    'No readable text, no captions, no watermarks, no UI screenshots, no fake logos.',
-  ]
-    .filter(Boolean)
-    .join(' ');
+function slideImportance(slide: Slide, index: number, total: number): number {
+  let score = slide.importance ?? 45;
+  if (slide.layout === 'title' || index === 0) score = Math.max(score, 90);
+  if (index === total - 1) score = Math.max(score, 72);
+  if (slide.layout === 'section') score = Math.max(score, 58);
+  if (slide.layout === 'stat') score = Math.max(score, 76);
+  if (slide.layout === 'quote') score = Math.max(score, 68);
+  if (slide.layout === 'image-focus') score = Math.max(score, 80);
+  if (slide.sourceLevel && slide.sourceLevel <= 1) score = Math.max(score, 70);
+  if (IMPORTANT_TITLE_RE.test([slide.title, slide.sectionPath?.join(' ')].filter(Boolean).join(' '))) {
+    score = Math.max(score, 82);
+  }
+  return clamp(Math.round(score), 0, 100);
 }
 
-function slideVisualPriority(slide: Slide, index: number, mode: ReturnType<typeof slideImagePolicyMode>): number {
-  const explicit = hasExplicitImageIntent(slide);
+function visualOpportunity(slide: Slide): number {
   const elements = visibleElementCount(slide);
   const chars = textLoad(slide);
-  const spacious = Math.max(0, 6 - elements) * 4 + Math.max(0, 520 - chars) / 80;
-  const bodyLayout =
-    slide.layout === 'content' ||
-    slide.layout === 'two-column' ||
-    slide.layout === 'comparison' ||
-    slide.layout === 'quote' ||
-    slide.layout === 'stat';
-  const coverOrDivider = slide.layout === 'title' || slide.layout === 'section' || index === 0;
-
-  let score = explicit ? 80 : 0;
-  if (bodyLayout) score += mode === 'active' ? 34 : 18;
-  if (slide.layout === 'quote' || slide.layout === 'stat') score += mode === 'active' ? 10 : 4;
-  if (slide.layout === 'image-focus') score += 28;
-  if (coverOrDivider) score += explicit ? 18 : mode === 'active' ? 6 : 10;
-  score += spacious;
-
-  // 문서 앞쪽 편중을 약하게만 반영한다. 표지/섹션이 항상 먼저 먹는 현상을 막는다.
-  score -= index * 0.15;
-  return score;
+  const elementRoom = clamp(((7 - elements) / 7) * 100, 0, 100);
+  const textRoom = clamp(((720 - chars) / 720) * 100, 0, 100);
+  return clamp(elementRoom * 0.52 + textRoom * 0.48, 0, 100);
 }
 
-function shouldAutoAddVisual(slide: Slide, index: number, mode: ReturnType<typeof slideImagePolicyMode>): boolean {
+function visualFit(slide: Slide): number {
+  const explicit = hasExplicitImageIntent(slide);
+  if (slide.image?.sourcePreference === 'none') return 0;
+  if (slide.image?.sourcePreference === 'logo' || slide.image?.kind === 'logo') return 88;
+  if (explicit) return 86;
+  if (slide.layout === 'title' || slide.layout === 'image-focus') return 88;
+  if (slide.layout === 'section') return 76;
+  if (slide.layout === 'stat' || slide.layout === 'quote') return 72;
+  if (CONCEPTUAL_RE.test(slideTextSummary(slide))) return 70;
+  return 54;
+}
+
+function layoutBenefit(slide: Slide): number {
+  if (slide.layout === 'title' || slide.layout === 'section' || slide.layout === 'image-focus') return 86;
+  if (slide.layout === 'stat' || slide.layout === 'quote') return 74;
+  if (slide.layout === 'content' || slide.layout === 'two-column' || slide.layout === 'comparison') return 60;
+  return 38;
+}
+
+export function scoreSlideImageCandidate(
+  slide: Slide,
+  index: number,
+  total: number,
+  policyMode: ReturnType<typeof slideImagePolicyMode>,
+): { score: number; importance: number } {
+  if (hasSourceImage(slide) || policyMode === 'sourceOnly') return { score: 0, importance: 0 };
+  const importance = slideImportance(slide, index, total);
+  const chars = textLoad(slide);
+  const elements = visibleElementCount(slide);
+  const densityPenalty = (chars > 900 ? 24 : chars > 680 ? 14 : chars > 520 ? 7 : 0) + (elements > 8 ? 12 : 0);
+  let score =
+    importance * 0.45 +
+    visualOpportunity(slide) * 0.3 +
+    visualFit(slide) * 0.2 +
+    layoutBenefit(slide) * 0.05 -
+    densityPenalty;
+  if (hasExplicitImageIntent(slide)) score = Math.max(score, 75);
+  return { score: clamp(Math.round(score), 0, 100), importance };
+}
+
+function shouldAddVisual(slide: Slide, index: number, total: number, mode: ReturnType<typeof slideImagePolicyMode>): boolean {
+  if (hasSourceImage(slide) || mode === 'sourceOnly') return false;
   if (hasExplicitImageIntent(slide)) return true;
-  if (mode === 'active') return Boolean(slide.title?.trim()) && !hasSourceImage(slide);
-  if (slide.layout === 'image-focus') return true;
-  if (index === 0 || slide.layout === 'section') return true;
-  return visibleElementCount(slide) <= 3 && textLoad(slide) <= 360;
+  const threshold = mode === 'active' ? 45 : 65;
+  return scoreSlideImageCandidate(slide, index, total, mode).score >= threshold;
 }
 
 function collectImageIntents(slides: Slide[], options: SlideExportOptions): SlideImageIntent[] {
   const mode = slideImagePolicyMode(options.imagePolicy);
   if (mode === 'sourceOnly') return [];
+  const total = slides.length;
   return slides
-    .map((slide, index): { intent: SlideImageIntent; priority: number } | null => {
-      if (hasSourceImage(slide)) return null;
-      if (!shouldAutoAddVisual(slide, index, mode)) return null;
+    .map((slide, index): SlideImageIntent | null => {
+      if (!shouldAddVisual(slide, index, total, mode)) return null;
       const image = slide.image;
       const query = fallbackQuery(slide);
       const prompt = image?.prompt?.trim();
       if (!query && !prompt) return null;
+      const score = scoreSlideImageCandidate(slide, index, total, mode);
       return {
-        intent: {
-          slideIndex: index,
-          slideId: slide.sourceIds?.[0] ?? `slide-${index + 1}`,
-          title: slide.title || `Slide ${index + 1}`,
-          role: roleForSlide(slide, index),
-          query: image?.query ?? query,
-          entity: image?.entity,
-          prompt,
-          aspect: aspectForSlide(slide),
-          style: image?.style,
-          sourcePreference: sourcePreferenceForSlide(slide),
-          licenseStrictness: licenseStrictnessForSlide(slide),
-        },
-        priority: slideVisualPriority(slide, index, mode),
+        slideIndex: index,
+        slideId: slide.sourceIds?.[0] ?? `slide-${index + 1}`,
+        title: slide.title || `Slide ${index + 1}`,
+        role: roleForSlide(slide, index),
+        query: image?.query ?? query,
+        entity: image?.entity,
+        prompt,
+        aspect: aspectForSlide(slide),
+        style: image?.style,
+        sourcePreference: sourcePreferenceForSlide(slide),
+        licenseStrictness: licenseStrictnessForSlide(slide),
+        importance: score.importance,
+        importanceReason: slide.importanceReason,
+        imageScore: score.score,
+        textSummary: slideTextSummary(slide),
       };
     })
-    .filter((item): item is { intent: SlideImageIntent; priority: number } => Boolean(item))
-    .sort((a, b) => b.priority - a.priority)
-    .map((item) => item.intent);
+    .filter((item): item is SlideImageIntent => Boolean(item))
+    .sort((a, b) => b.imageScore - a.imageScore || b.importance - a.importance || a.slideIndex - b.slideIndex);
 }
 
 async function mapWithConcurrency<T, R>(
@@ -236,41 +310,121 @@ function canGenerate(intent: SlideImageIntent): boolean {
   );
 }
 
+function preferGeneratedForAuto(intent: SlideImageIntent): boolean {
+  if (intent.sourcePreference === 'generated') return true;
+  if (intent.sourcePreference === 'stock' || intent.sourcePreference === 'logo' || intent.role === 'logo') return false;
+  const text = [intent.title, intent.query, intent.entity, intent.textSummary, intent.prompt].filter(Boolean).join(' ');
+  if (FACTUAL_RE.test(text)) return false;
+  if (intent.prompt) return true;
+  if (intent.role === 'cover' || intent.role === 'background' || intent.role === 'icon') return true;
+  return CONCEPTUAL_RE.test(text);
+}
+
+function routeIntent(intent: SlideImageIntent, mode: SlideImageSourceMode): AssetSourceKind | null {
+  if (intent.sourcePreference === 'none') return null;
+  if (mode === 'generatedOnly') return canGenerate(intent) ? 'generated' : null;
+  if (mode === 'stockOnly') return canSearchStock(intent) ? 'stock' : null;
+  if (intent.sourcePreference === 'generated') return canGenerate(intent) ? 'generated' : null;
+  if (intent.sourcePreference === 'stock' || intent.sourcePreference === 'logo' || intent.role === 'logo') {
+    return canSearchStock(intent) ? 'stock' : null;
+  }
+  if (mode === 'generatedFirst') return canGenerate(intent) ? 'generated' : canSearchStock(intent) ? 'stock' : null;
+  if (mode === 'stockFirst') return canSearchStock(intent) ? 'stock' : canGenerate(intent) ? 'generated' : null;
+  return preferGeneratedForAuto(intent) && canGenerate(intent)
+    ? 'generated'
+    : canSearchStock(intent)
+      ? 'stock'
+      : canGenerate(intent)
+        ? 'generated'
+        : null;
+}
+
+function splitQueues(
+  intents: SlideImageIntent[],
+  sourceMode: SlideImageSourceMode,
+  stockLimit: number,
+  generatedLimit: number,
+): { stock: SlideImageIntent[]; generated: SlideImageIntent[]; skipped: number } {
+  const stock: SlideImageIntent[] = [];
+  const generated: SlideImageIntent[] = [];
+  let skipped = 0;
+  for (const intent of intents) {
+    const route = routeIntent(intent, sourceMode);
+    if (route === 'stock' && stock.length < stockLimit) stock.push(intent);
+    else if (route === 'generated' && generated.length < generatedLimit) generated.push(intent);
+    else skipped += 1;
+  }
+  return { stock, generated, skipped };
+}
+
 async function resolveStockAsset(intent: SlideImageIntent): Promise<ResolvedSlideAsset | null> {
   if (!isTauri() || !canSearchStock(intent)) return null;
   const { invoke } = await import('@tauri-apps/api/core');
   return invoke<ResolvedSlideAsset | null>('resolve_stock_slide_asset', { intent });
 }
 
-async function resolveGeneratedAsset(intent: SlideImageIntent, theme?: SlideTheme): Promise<ResolvedSlideAsset | null> {
-  if (!canGenerate(intent)) return null;
+export function buildGeneratedSlideImagePrompt(intent: SlideImageIntent, theme?: SlideTheme): string {
+  const role =
+    intent.role === 'cover' || intent.role === 'background'
+      ? 'wide cinematic presentation background'
+      : intent.role === 'hero'
+        ? 'hero image for a presentation slide'
+        : intent.role === 'icon'
+          ? 'simple editorial icon-style illustration'
+          : 'supporting editorial presentation visual';
+  const topic = [intent.entity, intent.title, intent.textSummary || intent.query].filter(Boolean).join(' - ');
+  return [
+    `Create a ${role}.`,
+    `Slide title: "${intent.title}".`,
+    topic ? `Slide context: ${topic}.` : '',
+    intent.prompt ? `Creative brief: ${intent.prompt}.` : '',
+    `Composition: clean, professional, presentation-ready, strong focal point, useful negative space for surrounding slide content.`,
+    theme ? `Visual tone: match the "${theme.name}" deck theme. ${theme.description}.` : 'Visual tone: polished modern presentation deck.',
+    intent.style ? `Style guidance: ${intent.style}.` : '',
+    intent.importance >= 80 ? 'This is a high-importance slide, so make the image memorable and visually strong.' : '',
+    `Aspect ratio: ${intent.aspect}.`,
+    'Do not include readable text, captions, watermarks, UI screenshots, charts, fake logos, or brand marks.',
+    'Do not invent a real person, company logo, product screenshot, document, or data visualization.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function resolveGeneratedAsset(
+  intent: SlideImageIntent,
+  theme?: SlideTheme,
+): Promise<{ asset: ResolvedSlideAsset | null; generatedPrompt: string }> {
+  if (!canGenerate(intent)) return { asset: null, generatedPrompt: '' };
   const selection = getImageAIModelSelection();
-  const prompt = intent.prompt || fallbackPrompt(intent, theme);
+  const generatedPrompt = buildGeneratedSlideImagePrompt(intent, theme);
   try {
     const urls = await generateImage({
       provider: selection.company as ImageProvider,
       auth: selection.auth,
       model: selection.model,
-      prompt,
+      prompt: generatedPrompt,
       aspectRatio: intent.aspect,
       resolution: '2K',
       quality: 'high',
     });
     const dataUrl = urls.find(Boolean);
-    if (!dataUrl) return null;
+    if (!dataUrl) return { asset: null, generatedPrompt };
     return {
-      dataUrl,
-      provider: selection.company,
-      attribution: `${selection.company} ${selection.model} generated image`,
+      generatedPrompt,
+      asset: {
+        dataUrl,
+        provider: selection.company,
+        attribution: `${selection.company} ${selection.model} generated image`,
+      },
     };
   } catch (err) {
     throw new Error(humanizeImageGenError(err, selection.company as ImageProvider));
   }
 }
 
-function applyAsset(slides: Slide[], intent: SlideImageIntent, asset: ResolvedSlideAsset): void {
+function applyAsset(slides: Slide[], intent: SlideImageIntent, asset: ResolvedSlideAsset): boolean {
   const slide = slides[intent.slideIndex];
-  if (!slide) return;
+  if (!slide) return false;
   const image = {
     ...slide.image,
     src: asset.dataUrl,
@@ -284,13 +438,103 @@ function applyAsset(slides: Slide[], intent: SlideImageIntent, asset: ResolvedSl
       ? [slide.notes, `이미지 출처: ${attribution}`].filter(Boolean).join('\n\n')
       : slide.notes;
   slides[intent.slideIndex] = { ...slide, image, notes };
+  return true;
+}
+
+function makeAssetRecord(
+  intent: SlideImageIntent,
+  asset: ResolvedSlideAsset,
+  sourceMode: AssetSourceKind,
+  inserted: boolean,
+  generatedPrompt?: string,
+): SlideAssetRecord {
+  return {
+    slideIndex: intent.slideIndex,
+    slideTitle: intent.title,
+    slideId: intent.slideId,
+    role: intent.role,
+    sourceMode,
+    provider: asset.provider,
+    inserted,
+    importance: intent.importance,
+    importanceReason: intent.importanceReason,
+    imageScore: intent.imageScore,
+    query: intent.query,
+    prompt: intent.prompt,
+    generatedPrompt,
+    sourceUrl: asset.sourceUrl,
+    attribution: asset.attribution,
+    license: asset.license,
+    width: asset.width,
+    height: asset.height,
+    dataUrl: asset.dataUrl,
+  };
+}
+
+async function resolveStockQueue(
+  items: SlideImageIntent[],
+  resolveOptions: ResolveSlideAssetsOptions,
+): Promise<Array<{ intent: SlideImageIntent; asset: ResolvedSlideAsset | null; error: string | null }>> {
+  if (items.length === 0) return [];
+  let done = 0;
+  let ok = 0;
+  resolveOptions.onProgress?.('🖼️ Stock 이미지 검색 중...', `후보 처리 0/${items.length}`, 'pptx-assets-stock');
+  return mapWithConcurrency(items, STOCK_CONCURRENCY, async (intent) => {
+    let asset: ResolvedSlideAsset | null = null;
+    try {
+      asset = await resolveStockAsset(intent);
+      return { intent, asset, error: null };
+    } catch (err) {
+      return { intent, asset: null, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      done += 1;
+      if (asset) ok += 1;
+      resolveOptions.onProgress?.(
+        '🖼️ Stock 이미지 검색 중...',
+        `${ok}개 확보 · 후보 처리 ${done}/${items.length}`,
+        'pptx-assets-stock',
+      );
+    }
+  });
+}
+
+async function resolveGeneratedQueue(
+  items: SlideImageIntent[],
+  resolveOptions: ResolveSlideAssetsOptions,
+): Promise<
+  Array<{ intent: SlideImageIntent; asset: ResolvedSlideAsset | null; generatedPrompt?: string; error: string | null }>
+> {
+  if (items.length === 0) return [];
+  let done = 0;
+  let ok = 0;
+  resolveOptions.onProgress?.('🖼️ AI 이미지 생성 중...', `후보 처리 0/${items.length}`, 'pptx-assets-generated');
+  return mapWithConcurrency(items, GENERATED_CONCURRENCY, async (intent) => {
+    let asset: ResolvedSlideAsset | null = null;
+    let generatedPrompt = '';
+    try {
+      const result = await resolveGeneratedAsset(intent, resolveOptions.theme);
+      asset = result.asset;
+      generatedPrompt = result.generatedPrompt;
+      return { intent, asset, generatedPrompt, error: null };
+    } catch (err) {
+      return { intent, asset: null, generatedPrompt, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      done += 1;
+      if (asset) ok += 1;
+      resolveOptions.onProgress?.(
+        '🖼️ AI 이미지 생성 중...',
+        `${ok}개 확보 · 후보 처리 ${done}/${items.length}`,
+        'pptx-assets-generated',
+      );
+    }
+  });
 }
 
 export async function resolveSlideAssets(
   slides: Slide[],
   options: SlideExportOptions,
   resolveOptions: ResolveSlideAssetsOptions = {},
-): Promise<{ slides: Slide[]; summary: SlideAssetResolutionSummary }> {
+): Promise<{ slides: Slide[]; summary: SlideAssetResolutionSummary; assets: SlideAssetRecord[] }> {
   const stockLimit = stockImageLimitForPolicy(options.imagePolicy);
   const generatedLimit = generatedImageLimitForPolicy(options.imagePolicy);
   const summary: SlideAssetResolutionSummary = {
@@ -302,86 +546,92 @@ export async function resolveSlideAssets(
     skipped: 0,
   };
   if (stockLimit <= 0 && generatedLimit <= 0) {
-    return { slides, summary };
+    return { slides, summary, assets: [] };
   }
 
   const next = slides.map((slide) => ({ ...slide, body: [...slide.body], columns: slide.columns?.map((c) => [...c]) }));
-  const intents = collectImageIntents(next, options).slice(0, stockLimit);
-  summary.requested = intents.length;
-  if (intents.length === 0) return { slides: next, summary };
+  const intents = collectImageIntents(next, options);
+  const sourceMode = slideImageSourceMode(options.imageSourceMode);
+  const queues = splitQueues(intents, sourceMode, stockLimit, generatedLimit);
+  const assets: SlideAssetRecord[] = [];
+  summary.requested = queues.stock.length + queues.generated.length;
+  summary.skipped += queues.skipped;
+  if (summary.requested === 0) return { slides: next, summary, assets };
 
-  let done = 0;
-  let stockOk = 0;
-  resolveOptions.onProgress?.('🖼️ 이미지 에셋 준비 중...', `후보 처리 0/${intents.length}`, 'pptx-assets');
-
-  const stockResults = await mapWithConcurrency(intents, STOCK_CONCURRENCY, async (intent) => {
-    let asset: ResolvedSlideAsset | null = null;
-    try {
-      asset = await resolveStockAsset(intent);
-      return { intent, asset, error: null as string | null };
-    } catch (err) {
-      return { intent, asset: null, error: err instanceof Error ? err.message : String(err) };
-    } finally {
-      done += 1;
-      if (asset) stockOk += 1;
-      resolveOptions.onProgress?.(
-        '🖼️ 이미지 에셋 준비 중...',
-        `${stockOk}개 확보 · 후보 처리 ${done}/${intents.length}`,
-        'pptx-assets',
-      );
-    }
-  });
-
-  const unresolved: SlideImageIntent[] = [];
+  const stockResults = await resolveStockQueue(queues.stock, resolveOptions);
+  const stockUnresolved: SlideImageIntent[] = [];
   for (const result of stockResults) {
     if (result.asset) {
-      applyAsset(next, result.intent, result.asset);
-      summary.resolved += 1;
+      const inserted = applyAsset(next, result.intent, result.asset);
+      assets.push(makeAssetRecord(result.intent, result.asset, 'stock', inserted));
+      summary.resolved += inserted ? 1 : 0;
       summary.stockResolved += 1;
     } else {
-      unresolved.push(result.intent);
+      stockUnresolved.push(result.intent);
+      if (result.error) console.warn('[slideAssets] Stock 이미지 검색 실패:', result.intent.title, result.error);
     }
   }
 
-  const generationQueue = unresolved.filter(canGenerate).slice(0, Math.max(0, generatedLimit - summary.generatedResolved));
-  summary.skipped += unresolved.length - generationQueue.length;
-  if (generationQueue.length > 0) {
-    done = 0;
-    let generatedOk = 0;
-    resolveOptions.onProgress?.('🖼️ 이미지 에셋 추가 중...', `후보 처리 0/${generationQueue.length}`, 'pptx-assets');
-    const generatedResults = await mapWithConcurrency(generationQueue, GENERATED_CONCURRENCY, async (intent) => {
-      let asset: ResolvedSlideAsset | null = null;
-      try {
-        asset = await resolveGeneratedAsset(intent, resolveOptions.theme);
-        return { intent, asset, error: null as string | null };
-      } catch (err) {
-        return { intent, asset: null, error: err instanceof Error ? err.message : String(err) };
-      } finally {
-        done += 1;
-        if (asset) generatedOk += 1;
-        resolveOptions.onProgress?.(
-          '🖼️ 이미지 에셋 추가 중...',
-          `${generatedOk}개 확보 · 후보 처리 ${done}/${generationQueue.length}`,
-          'pptx-assets',
-        );
-      }
-    });
-    for (const result of generatedResults) {
+  const generatedResults = await resolveGeneratedQueue(queues.generated, resolveOptions);
+  const generatedUnresolved: SlideImageIntent[] = [];
+  for (const result of generatedResults) {
+    if (result.asset) {
+      const inserted = applyAsset(next, result.intent, result.asset);
+      assets.push(makeAssetRecord(result.intent, result.asset, 'generated', inserted, result.generatedPrompt));
+      summary.resolved += inserted ? 1 : 0;
+      summary.generatedResolved += 1;
+    } else {
+      generatedUnresolved.push(result.intent);
+      summary.failed += result.error ? 1 : 0;
+      if (result.error) console.warn('[slideAssets] AI 이미지 생성 실패:', result.intent.title, result.error);
+    }
+  }
+
+  const remainingGenerated = Math.max(0, generatedLimit - queues.generated.length);
+  const shouldGeneratedFallback = sourceMode !== 'generatedOnly' && sourceMode !== 'stockOnly' && remainingGenerated > 0;
+  if (shouldGeneratedFallback) {
+    const fallbackQueue = stockUnresolved.filter(canGenerate).slice(0, remainingGenerated);
+    summary.skipped += stockUnresolved.length - fallbackQueue.length;
+    const fallbackResults = await resolveGeneratedQueue(fallbackQueue, resolveOptions);
+    for (const result of fallbackResults) {
       if (result.asset) {
-        applyAsset(next, result.intent, result.asset);
-        summary.resolved += 1;
+        const inserted = applyAsset(next, result.intent, result.asset);
+        assets.push(makeAssetRecord(result.intent, result.asset, 'generated', inserted, result.generatedPrompt));
+        summary.resolved += inserted ? 1 : 0;
         summary.generatedResolved += 1;
       } else {
-        summary.failed += 1;
-        console.warn('[slideAssets] 이미지 자산 생성 실패:', result.intent.title, result.error);
+        summary.failed += result.error ? 1 : 0;
+        if (result.error) console.warn('[slideAssets] AI 이미지 fallback 실패:', result.intent.title, result.error);
       }
     }
+  } else {
+    summary.skipped += stockUnresolved.length;
+  }
+
+  const remainingStock = Math.max(0, stockLimit - queues.stock.length);
+  const shouldStockFallback = sourceMode === 'generatedFirst' && remainingStock > 0;
+  if (shouldStockFallback) {
+    const fallbackQueue = generatedUnresolved.filter(canSearchStock).slice(0, remainingStock);
+    summary.skipped += generatedUnresolved.length - fallbackQueue.length;
+    const fallbackResults = await resolveStockQueue(fallbackQueue, resolveOptions);
+    for (const result of fallbackResults) {
+      if (result.asset) {
+        const inserted = applyAsset(next, result.intent, result.asset);
+        assets.push(makeAssetRecord(result.intent, result.asset, 'stock', inserted));
+        summary.resolved += inserted ? 1 : 0;
+        summary.stockResolved += 1;
+      } else if (result.error) {
+        console.warn('[slideAssets] Stock 이미지 fallback 실패:', result.intent.title, result.error);
+      }
+    }
+  } else {
+    summary.skipped += generatedUnresolved.length;
   }
 
   resolveOptions.onProgress?.(
     '✅ 이미지 에셋 준비 완료',
-    `${summary.resolved}/${summary.requested}개 확보 · stock ${summary.stockResolved} · 생성 ${summary.generatedResolved}`,
+    `${summary.resolved}/${summary.requested}개 삽입 · stock ${summary.stockResolved} · 생성 ${summary.generatedResolved}`,
     'pptx-assets',
   );
-  return { slides: next, summary };
+  return { slides: next, summary, assets };
 }

--- a/src/services/slideAssets.ts
+++ b/src/services/slideAssets.ts
@@ -1,0 +1,387 @@
+import type { Slide, SlideImageLicenseStrictness, SlideImageRole, SlideImageSourcePreference } from '../lib/markdownToSlides';
+import type { SlideExportOptions, SlideTheme } from '../lib/slideTheme';
+import {
+  generatedImageLimitForPolicy,
+  slideImagePolicyMode,
+  stockImageLimitForPolicy,
+} from '../lib/slideLimits';
+import { getImageAIModelSelection } from './aiModelConfig';
+import { generateImage, humanizeImageGenError, type ImageProvider } from './imageGen';
+import { isTauri } from './platform';
+
+type AssetProvider = 'openverse' | 'wikimedia' | 'openai' | 'gemini' | 'grok';
+
+export interface SlideImageIntent {
+  slideIndex: number;
+  slideId: string;
+  title: string;
+  role: SlideImageRole;
+  query?: string;
+  entity?: string;
+  prompt?: string;
+  aspect: string;
+  style?: string;
+  sourcePreference: SlideImageSourcePreference;
+  licenseStrictness: SlideImageLicenseStrictness;
+}
+
+export interface ResolvedSlideAsset {
+  dataUrl: string;
+  provider: AssetProvider;
+  sourceUrl?: string;
+  attribution?: string;
+  license?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SlideAssetResolutionSummary {
+  requested: number;
+  resolved: number;
+  stockResolved: number;
+  generatedResolved: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface ResolveSlideAssetsOptions {
+  theme?: SlideTheme;
+  onProgress?: (step: string, detail?: string, stepId?: string) => void;
+}
+
+const STOCK_CONCURRENCY = 4;
+const GENERATED_CONCURRENCY = 2;
+
+function blockTextLength(block: Slide['body'][number]): number {
+  if (block.kind === 'bullet' || block.kind === 'text') return block.spans.map((span) => span.text).join('').length;
+  if (block.kind === 'subhead' || block.kind === 'code') return block.text.length;
+  if (block.kind === 'table') return block.rows.flat().join(' ').length;
+  if (block.kind === 'image') return 0;
+  return 0;
+}
+
+function visibleElementCount(slide: Slide): number {
+  const bodyCount = slide.body.filter((block) => block.kind !== 'image').length;
+  const columnCount = slide.columns?.reduce((sum, col) => sum + col.filter((block) => block.kind !== 'image').length, 0) ?? 0;
+  return Math.max(bodyCount, columnCount);
+}
+
+function textLoad(slide: Slide): number {
+  const bodyText = slide.body.reduce((sum, block) => sum + blockTextLength(block), 0);
+  const columnText = slide.columns?.reduce(
+    (sum, col) => sum + col.reduce((colSum, block) => colSum + blockTextLength(block), 0),
+    0,
+  ) ?? 0;
+  return Math.max(bodyText, columnText);
+}
+
+function hasExplicitImageIntent(slide: Slide): boolean {
+  return Boolean(slide.image?.prompt || slide.image?.query || slide.image?.entity || slide.image?.role || slide.image?.sourcePreference);
+}
+
+function hasSourceImage(slide: Slide): boolean {
+  return Boolean(slide.image?.src || slide.body.some((b) => b.kind === 'image' && b.src));
+}
+
+function roleForSlide(slide: Slide, index: number): SlideImageRole {
+  if (slide.image?.role) return slide.image.role;
+  if (slide.image?.kind === 'logo') return 'logo';
+  if (slide.image?.kind === 'background') return 'background';
+  if (slide.layout === 'title' || index === 0) return 'cover';
+  if (slide.layout === 'section') return 'background';
+  if (slide.layout === 'image-focus') return 'hero';
+  return 'support';
+}
+
+function aspectForSlide(slide: Slide): string {
+  if (slide.image?.aspect) return slide.image.aspect;
+  if (slide.layout === 'image-focus' || slide.layout === 'title' || slide.layout === 'section') return '16:9';
+  return '4:3';
+}
+
+function sourcePreferenceForSlide(slide: Slide): SlideImageSourcePreference {
+  if (slide.image?.sourcePreference) return slide.image.sourcePreference;
+  if (slide.image?.kind === 'logo') return 'logo';
+  return 'auto';
+}
+
+function licenseStrictnessForSlide(slide: Slide): SlideImageLicenseStrictness {
+  return slide.image?.licenseStrictness ?? 'presentation';
+}
+
+function fallbackQuery(slide: Slide): string {
+  const path = slide.sectionPath?.filter(Boolean).join(' ');
+  const visualHint =
+    slide.layout === 'title' || slide.layout === 'section'
+      ? 'presentation background'
+      : slide.layout === 'stat' || slide.layout === 'quote'
+        ? 'editorial concept image'
+        : 'presentation supporting visual';
+  return [slide.image?.entity, slide.image?.query, slide.title, path, visualHint].filter(Boolean).join(' ').trim();
+}
+
+function fallbackPrompt(intent: SlideImageIntent, theme?: SlideTheme): string {
+  const tone = theme ? `Match a ${theme.name} presentation theme.` : 'Match a polished modern presentation deck.';
+  const topic = intent.entity || intent.query || intent.title;
+  const role =
+    intent.role === 'cover' || intent.role === 'background'
+      ? 'wide cinematic hero background'
+      : intent.role === 'icon'
+        ? 'simple high-quality editorial icon illustration'
+        : 'clean editorial presentation visual';
+  return [
+    `Create a ${role} for a PowerPoint slide titled "${intent.title}".`,
+    `Topic: ${topic}.`,
+    tone,
+    intent.style ? `Style: ${intent.style}.` : '',
+    'No readable text, no captions, no watermarks, no UI screenshots, no fake logos.',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function slideVisualPriority(slide: Slide, index: number, mode: ReturnType<typeof slideImagePolicyMode>): number {
+  const explicit = hasExplicitImageIntent(slide);
+  const elements = visibleElementCount(slide);
+  const chars = textLoad(slide);
+  const spacious = Math.max(0, 6 - elements) * 4 + Math.max(0, 520 - chars) / 80;
+  const bodyLayout =
+    slide.layout === 'content' ||
+    slide.layout === 'two-column' ||
+    slide.layout === 'comparison' ||
+    slide.layout === 'quote' ||
+    slide.layout === 'stat';
+  const coverOrDivider = slide.layout === 'title' || slide.layout === 'section' || index === 0;
+
+  let score = explicit ? 80 : 0;
+  if (bodyLayout) score += mode === 'active' ? 34 : 18;
+  if (slide.layout === 'quote' || slide.layout === 'stat') score += mode === 'active' ? 10 : 4;
+  if (slide.layout === 'image-focus') score += 28;
+  if (coverOrDivider) score += explicit ? 18 : mode === 'active' ? 6 : 10;
+  score += spacious;
+
+  // 문서 앞쪽 편중을 약하게만 반영한다. 표지/섹션이 항상 먼저 먹는 현상을 막는다.
+  score -= index * 0.15;
+  return score;
+}
+
+function shouldAutoAddVisual(slide: Slide, index: number, mode: ReturnType<typeof slideImagePolicyMode>): boolean {
+  if (hasExplicitImageIntent(slide)) return true;
+  if (mode === 'active') return Boolean(slide.title?.trim()) && !hasSourceImage(slide);
+  if (slide.layout === 'image-focus') return true;
+  if (index === 0 || slide.layout === 'section') return true;
+  return visibleElementCount(slide) <= 3 && textLoad(slide) <= 360;
+}
+
+function collectImageIntents(slides: Slide[], options: SlideExportOptions): SlideImageIntent[] {
+  const mode = slideImagePolicyMode(options.imagePolicy);
+  if (mode === 'sourceOnly') return [];
+  return slides
+    .map((slide, index): { intent: SlideImageIntent; priority: number } | null => {
+      if (hasSourceImage(slide)) return null;
+      if (!shouldAutoAddVisual(slide, index, mode)) return null;
+      const image = slide.image;
+      const query = fallbackQuery(slide);
+      const prompt = image?.prompt?.trim();
+      if (!query && !prompt) return null;
+      return {
+        intent: {
+          slideIndex: index,
+          slideId: slide.sourceIds?.[0] ?? `slide-${index + 1}`,
+          title: slide.title || `Slide ${index + 1}`,
+          role: roleForSlide(slide, index),
+          query: image?.query ?? query,
+          entity: image?.entity,
+          prompt,
+          aspect: aspectForSlide(slide),
+          style: image?.style,
+          sourcePreference: sourcePreferenceForSlide(slide),
+          licenseStrictness: licenseStrictnessForSlide(slide),
+        },
+        priority: slideVisualPriority(slide, index, mode),
+      };
+    })
+    .filter((item): item is { intent: SlideImageIntent; priority: number } => Boolean(item))
+    .sort((a, b) => b.priority - a.priority)
+    .map((item) => item.intent);
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const out = new Array<R>(items.length);
+  let cursor = 0;
+  const run = async () => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      out[index] = await worker(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, run));
+  return out;
+}
+
+function canSearchStock(intent: SlideImageIntent): boolean {
+  return intent.sourcePreference !== 'none' && intent.sourcePreference !== 'generated' && Boolean(intent.query || intent.entity);
+}
+
+function canGenerate(intent: SlideImageIntent): boolean {
+  return (
+    intent.sourcePreference !== 'none' &&
+    intent.sourcePreference !== 'stock' &&
+    intent.sourcePreference !== 'logo' &&
+    intent.role !== 'logo'
+  );
+}
+
+async function resolveStockAsset(intent: SlideImageIntent): Promise<ResolvedSlideAsset | null> {
+  if (!isTauri() || !canSearchStock(intent)) return null;
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<ResolvedSlideAsset | null>('resolve_stock_slide_asset', { intent });
+}
+
+async function resolveGeneratedAsset(intent: SlideImageIntent, theme?: SlideTheme): Promise<ResolvedSlideAsset | null> {
+  if (!canGenerate(intent)) return null;
+  const selection = getImageAIModelSelection();
+  const prompt = intent.prompt || fallbackPrompt(intent, theme);
+  try {
+    const urls = await generateImage({
+      provider: selection.company as ImageProvider,
+      auth: selection.auth,
+      model: selection.model,
+      prompt,
+      aspectRatio: intent.aspect,
+      resolution: '2K',
+      quality: 'high',
+    });
+    const dataUrl = urls.find(Boolean);
+    if (!dataUrl) return null;
+    return {
+      dataUrl,
+      provider: selection.company,
+      attribution: `${selection.company} ${selection.model} generated image`,
+    };
+  } catch (err) {
+    throw new Error(humanizeImageGenError(err, selection.company as ImageProvider));
+  }
+}
+
+function applyAsset(slides: Slide[], intent: SlideImageIntent, asset: ResolvedSlideAsset): void {
+  const slide = slides[intent.slideIndex];
+  if (!slide) return;
+  const image = {
+    ...slide.image,
+    src: asset.dataUrl,
+    alt: slide.image?.alt || intent.query || intent.title,
+    role: slide.image?.role ?? intent.role,
+    aspect: slide.image?.aspect ?? intent.aspect,
+  };
+  const attribution = asset.attribution || asset.sourceUrl;
+  const notes =
+    attribution && !slide.notes?.includes(attribution)
+      ? [slide.notes, `이미지 출처: ${attribution}`].filter(Boolean).join('\n\n')
+      : slide.notes;
+  slides[intent.slideIndex] = { ...slide, image, notes };
+}
+
+export async function resolveSlideAssets(
+  slides: Slide[],
+  options: SlideExportOptions,
+  resolveOptions: ResolveSlideAssetsOptions = {},
+): Promise<{ slides: Slide[]; summary: SlideAssetResolutionSummary }> {
+  const stockLimit = stockImageLimitForPolicy(options.imagePolicy);
+  const generatedLimit = generatedImageLimitForPolicy(options.imagePolicy);
+  const summary: SlideAssetResolutionSummary = {
+    requested: 0,
+    resolved: 0,
+    stockResolved: 0,
+    generatedResolved: 0,
+    failed: 0,
+    skipped: 0,
+  };
+  if (stockLimit <= 0 && generatedLimit <= 0) {
+    return { slides, summary };
+  }
+
+  const next = slides.map((slide) => ({ ...slide, body: [...slide.body], columns: slide.columns?.map((c) => [...c]) }));
+  const intents = collectImageIntents(next, options).slice(0, stockLimit);
+  summary.requested = intents.length;
+  if (intents.length === 0) return { slides: next, summary };
+
+  let done = 0;
+  let stockOk = 0;
+  resolveOptions.onProgress?.('🖼️ 이미지 에셋 준비 중...', `후보 처리 0/${intents.length}`, 'pptx-assets');
+
+  const stockResults = await mapWithConcurrency(intents, STOCK_CONCURRENCY, async (intent) => {
+    let asset: ResolvedSlideAsset | null = null;
+    try {
+      asset = await resolveStockAsset(intent);
+      return { intent, asset, error: null as string | null };
+    } catch (err) {
+      return { intent, asset: null, error: err instanceof Error ? err.message : String(err) };
+    } finally {
+      done += 1;
+      if (asset) stockOk += 1;
+      resolveOptions.onProgress?.(
+        '🖼️ 이미지 에셋 준비 중...',
+        `${stockOk}개 확보 · 후보 처리 ${done}/${intents.length}`,
+        'pptx-assets',
+      );
+    }
+  });
+
+  const unresolved: SlideImageIntent[] = [];
+  for (const result of stockResults) {
+    if (result.asset) {
+      applyAsset(next, result.intent, result.asset);
+      summary.resolved += 1;
+      summary.stockResolved += 1;
+    } else {
+      unresolved.push(result.intent);
+    }
+  }
+
+  const generationQueue = unresolved.filter(canGenerate).slice(0, Math.max(0, generatedLimit - summary.generatedResolved));
+  summary.skipped += unresolved.length - generationQueue.length;
+  if (generationQueue.length > 0) {
+    done = 0;
+    let generatedOk = 0;
+    resolveOptions.onProgress?.('🖼️ 이미지 에셋 추가 중...', `후보 처리 0/${generationQueue.length}`, 'pptx-assets');
+    const generatedResults = await mapWithConcurrency(generationQueue, GENERATED_CONCURRENCY, async (intent) => {
+      let asset: ResolvedSlideAsset | null = null;
+      try {
+        asset = await resolveGeneratedAsset(intent, resolveOptions.theme);
+        return { intent, asset, error: null as string | null };
+      } catch (err) {
+        return { intent, asset: null, error: err instanceof Error ? err.message : String(err) };
+      } finally {
+        done += 1;
+        if (asset) generatedOk += 1;
+        resolveOptions.onProgress?.(
+          '🖼️ 이미지 에셋 추가 중...',
+          `${generatedOk}개 확보 · 후보 처리 ${done}/${generationQueue.length}`,
+          'pptx-assets',
+        );
+      }
+    });
+    for (const result of generatedResults) {
+      if (result.asset) {
+        applyAsset(next, result.intent, result.asset);
+        summary.resolved += 1;
+        summary.generatedResolved += 1;
+      } else {
+        summary.failed += 1;
+        console.warn('[slideAssets] 이미지 자산 생성 실패:', result.intent.title, result.error);
+      }
+    }
+  }
+
+  resolveOptions.onProgress?.(
+    '✅ 이미지 에셋 준비 완료',
+    `${summary.resolved}/${summary.requested}개 확보 · stock ${summary.stockResolved} · 생성 ${summary.generatedResolved}`,
+    'pptx-assets',
+  );
+  return { slides: next, summary };
+}

--- a/src/services/slideAssets.ts
+++ b/src/services/slideAssets.ts
@@ -301,6 +301,10 @@ function canSearchStock(intent: SlideImageIntent): boolean {
   return intent.sourcePreference !== 'none' && intent.sourcePreference !== 'generated' && Boolean(intent.query || intent.entity);
 }
 
+function canForceStockSearch(intent: SlideImageIntent): boolean {
+  return intent.sourcePreference !== 'none' && Boolean(intent.query || intent.entity);
+}
+
 function canGenerate(intent: SlideImageIntent): boolean {
   return (
     intent.sourcePreference !== 'none' &&
@@ -320,10 +324,10 @@ function preferGeneratedForAuto(intent: SlideImageIntent): boolean {
   return CONCEPTUAL_RE.test(text);
 }
 
-function routeIntent(intent: SlideImageIntent, mode: SlideImageSourceMode): AssetSourceKind | null {
+export function routeSlideImageIntent(intent: SlideImageIntent, mode: SlideImageSourceMode): AssetSourceKind | null {
   if (intent.sourcePreference === 'none') return null;
   if (mode === 'generatedOnly') return canGenerate(intent) ? 'generated' : null;
-  if (mode === 'stockOnly') return canSearchStock(intent) ? 'stock' : null;
+  if (mode === 'stockOnly') return canForceStockSearch(intent) ? 'stock' : null;
   if (intent.sourcePreference === 'generated') return canGenerate(intent) ? 'generated' : null;
   if (intent.sourcePreference === 'stock' || intent.sourcePreference === 'logo' || intent.role === 'logo') {
     return canSearchStock(intent) ? 'stock' : null;
@@ -349,7 +353,7 @@ function splitQueues(
   const generated: SlideImageIntent[] = [];
   let skipped = 0;
   for (const intent of intents) {
-    const route = routeIntent(intent, sourceMode);
+    const route = routeSlideImageIntent(intent, sourceMode);
     if (route === 'stock' && stock.length < stockLimit) stock.push(intent);
     else if (route === 'generated' && generated.length < generatedLimit) generated.push(intent);
     else skipped += 1;

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -3,7 +3,7 @@
  *  - structurize(라벨 "마인드맵 정리"): 산문을 #/##/### + 불릿 계층 아웃라인으로 재구성(마인드맵용)
  *  - meeting-notes: 현재 문서를 transcript 로 보고 회의록 .md 새 파일 생성 → ResultCard
  *  - stt/ocr: 입력(음성/이미지)을 텍스트로 변환 — converter 가 자체 키로 처리(AI 에이전트 키 무관)
- *  - pptx(라벨 "슬라이드 만들기"): 현재 문서를 AI 레이아웃으로 .pptx 내보내기
+ *  - pptx(라벨 "슬라이드 생성"): 슬라이드 초안 생성 또는 AI 기반 .pptx 생성
  *  - image-gen(라벨 "이미지 생성"): 프롬프트(+참조 이미지)로 이미지 생성 → 미리보기 → 문서 삽입/파일 저장.
  *    Gemini/OpenAI 자체 키 사용(diff 흐름 아님, ImageGenPanel 로컬 상태).
  */

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -104,6 +104,11 @@ export interface ProgressStep {
     step: string;
     detail?: string;
     progress?: number;
+    model?: {
+        company: string;
+        auth: AIAuthMode;
+        model: string;
+    };
     /** stable id — 같은 stepId 면 in-place 갱신 (heartbeat / progress). undefined 면 append. */
     stepId?: string;
 }


### PR DESCRIPTION
## Summary

- Adds slide image source controls so PPTX generation can choose automatic, stock-first, generated-first, stock-only, or generated-only behavior.
- Scores slide image candidates using slide importance, layout fit, and text density, then routes work through stock search or generated image prompts.
- Saves fetched/generated image assets beside the exported PPTX with used/unused folders, manifest metadata, and attribution notes.
- Preserves source image aspect ratio when inserting images into PPTX layouts instead of stretching them into fixed slots.

## Validation

- `git diff --check`
- `npm test -- src/services/slideAssetBundle.test.ts src/lib/buildPptx.test.ts src/lib/slideLimits.test.ts src/lib/markdownToSlides.test.ts src/services/slideAssets.test.ts`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`