### PR TITLE
feat(gantt): 막대 드래그·인라인 편집 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2443,7 +2443,7 @@ function App() {
       case 'flowchart':
         return <>{mcpBanner}<FlowchartView content={content} fileName={fileName} onChange={updateContent} flowchartPanelOpen={flowchartPanelOpen} onCloseFlowchartPanel={() => setFlowchartPanelOpen(false)} /></>;
       case 'gantt':
-        return <>{mcpBanner}<GanttView content={content} fileName={fileName} onJumpToSource={handleJumpToSource} onChange={updateContent} ganttPanelOpen={ganttPanelOpen} onCloseGanttPanel={() => setGanttPanelOpen(false)} /></>;
+        return <>{mcpBanner}<GanttView content={content} fileName={fileName} onChange={editable ? updateContent : undefined} ganttPanelOpen={ganttPanelOpen} onCloseGanttPanel={() => setGanttPanelOpen(false)} /></>;
       case 'kanban':
         return <>{mcpBanner}<KanbanView content={content} fileName={fileName} onChange={editable ? updateContent : undefined} readOnly={!editable} kanbanPanelOpen={kanbanPanelOpen} onCloseKanbanPanel={() => setKanbanPanelOpen(false)} /></>;
     }

--- a/src/components/GanttView.css
+++ b/src/components/GanttView.css
@@ -55,7 +55,16 @@
 }
 .gantt-task-label {
     fill: var(--text-primary, #333333);
-    font-size: 12px;
+    font-size: 13.5px;
+}
+.gantt-task-pct {
+    fill: var(--text-secondary, #888888);
+    font-size: 10px;
+    font-weight: 400;
+}
+.gantt-task-meta {
+    fill: var(--text-secondary, #888888);
+    font-size: 10px;
 }
 
 /* 막대 + 진행률 */
@@ -143,4 +152,89 @@
     max-width: 460px;
     font-size: 12px;
     line-height: 1.7;
+}
+
+/* ── 드래그 편집 (#54 follow-up) ──────────────────────────────────────────── */
+/* 편집 가능 시 막대/마일스톤은 잡아끌 수 있음. resize 영역은 동적이라 공통 grab. */
+.gantt-svg.is-editable .gantt-bar,
+.gantt-svg.is-editable .gantt-bar-progress,
+.gantt-svg.is-editable .gantt-milestone {
+    cursor: grab;
+}
+.gantt-svg.is-dragging,
+.gantt-svg.is-dragging .gantt-row {
+    cursor: grabbing;
+}
+
+/* 드래그 중 막대/마일스톤 강조 (미리보기 위치) */
+.gantt-row.is-dragging .gantt-bar {
+    fill-opacity: 0.55;
+    stroke: var(--text-primary, #333333);
+    stroke-width: 1;
+    stroke-opacity: 0.35;
+}
+.gantt-row.is-dragging .gantt-milestone {
+    stroke: var(--text-primary, #333333);
+    stroke-opacity: 0.5;
+}
+
+/* 드래그 중 날짜 미리보기 — 그리드/막대 위에서도 읽히게 외곽선 페인트 */
+.gantt-drag-tip {
+    fill: var(--text-primary, #222222);
+    font-size: 11px;
+    font-weight: 700;
+    paint-order: stroke;
+    stroke: var(--bg-primary, #ffffff);
+    stroke-width: 3px;
+    stroke-linejoin: round;
+    pointer-events: none;
+}
+
+/* 드래그 중 전역 텍스트 선택/커서 잠금 (KanbanView 와 동일 패턴) */
+body.gantt-drag-select-block,
+body.gantt-drag-select-block * {
+    cursor: grabbing !important;
+    user-select: none !important;
+    -webkit-user-select: none !important;
+}
+
+/* ── 인라인 편집 (라벨 클릭=이름 / 막대 클릭=진행률) — foreignObject 안 HTML ── */
+.gantt-edit-input {
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0 6px;
+    border: 1.5px solid var(--accent-primary, #3b82f6);
+    border-radius: 4px;
+    background: var(--bg-primary, #ffffff);
+    color: var(--text-primary, #222222);
+    font-size: 12px;
+    font-family: inherit;
+    outline: none;
+}
+.gantt-edit-progress {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    padding: 0 8px;
+    border: 1.5px solid var(--accent-primary, #3b82f6);
+    border-radius: 4px;
+    background: var(--bg-primary, #ffffff);
+}
+.gantt-edit-progress input[type="range"] {
+    flex: 1;
+    min-width: 0;
+    accent-color: var(--accent-primary, #3b82f6);
+}
+.gantt-edit-progress-val {
+    flex: none;
+    min-width: 30px;
+    text-align: right;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--text-primary, #222222);
 }

--- a/src/components/GanttView.tsx
+++ b/src/components/GanttView.tsx
@@ -195,7 +195,9 @@ export function GanttView({ content, fileName, onChange, ganttPanelOpen, onClose
         const localX = clientX - svgRect.left; // SVG user-space x (rect.left already accounts for scroll)
         if (eff.isMilestone) {
             const cx = bx + DAY_W / 2;
-            return { draggable: Math.abs(localX - cx) <= MS_R + 2, mode: 'move' };
+            if (Math.abs(localX - cx) > MS_R + 2) return { draggable: false, mode: 'move' };
+            // 다이아 오른쪽 절반을 끌면 resize-end(막대로 복원), 왼쪽/중앙은 move
+            return { draggable: true, mode: localX > cx + 1 ? 'resize-end' : 'move' };
         }
         if (localX < bx - 2 || localX > bx + bw + 2) return { draggable: false, mode: 'move' };
         const edge = Math.min(EDGE_HIT, bw / 3); // shrink edge zones on short bars so a move stays possible

--- a/src/components/GanttView.tsx
+++ b/src/components/GanttView.tsx
@@ -1,23 +1,29 @@
 /**
- * Gantt view mode (#54) — read-only, self-rendered SVG.
+ * Gantt view mode (#54) — self-rendered SVG, drag-editable.
  *
  * Markdown is the SSOT: parseGantt() pulls deterministic inline markers
  * (@start/@due/@progress) off the document tree. We render a classic gantt —
  * a left label column (sections + task names) and a right time axis with bars,
- * progress fill, milestone diamonds, and a "today" line. Clicking a bar jumps to
- * its source line in the editor. No external gantt library (the other views are
- * all self-built too); editing happens in the markdown, drag-edit is a follow-up.
+ * progress fill, milestone diamonds, and a "today" line.
+ *
+ * Editing: bars/milestones are draggable when `onChange` is supplied. Dragging a
+ * bar's body moves it (start+due together); the left/right edges resize one end;
+ * a milestone moves as a point, and a bar pulled shorter than a day collapses to
+ * a milestone (and back). Every commit flows through ganttEdit→updateKanbanCardLine
+ * (the SHARED line engine), so a Gantt edit never disturbs the Kanban markers on
+ * the same line (@status/@priority/@order). A short press (no drag) does nothing.
  */
 
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { ChartBarStacked } from 'lucide-react';
 import { parseGantt } from '../lib/gantt-parser';
+import { applyGanttDrag, applyGanttLabel, applyGanttProgress, previewGanttDrag, type GanttDragMode, type GanttDragResult } from '../lib/ganttEdit';
 import type { GanttTask } from '../types/gantt';
 import { GanttPanel } from './GanttPanel';
 import './GanttView.css';
 
 // ── layout constants ─────────────────────────────────────────────────────────
-const LABEL_W = 220;   // left label column width
+const LABEL_W = 300;   // left label column width (task name + date/progress meta)
 const HEADER_H = 40;   // time-axis header height
 const ROW_H = 32;      // task row height
 const SECTION_H = 30;  // section header row height
@@ -25,6 +31,9 @@ const DAY_W = 30;      // px per day
 const BAR_PAD = 6;     // vertical padding inside a row for the bar
 
 const MS_PER_DAY = 86_400_000;
+const EDGE_HIT = 7;       // px from a bar edge that starts a resize instead of a move
+const DRAG_THRESHOLD = 4; // px of travel before a press becomes a drag (else: jump)
+const MS_R = 8;           // milestone diamond half-size
 
 function midnight(d: Date): Date {
     const c = new Date(d);
@@ -38,23 +47,51 @@ function addDays(base: Date, n: number): Date {
     return new Date(base.getFullYear(), base.getMonth(), base.getDate() + n);
 }
 
+/** Toggle a global no-select cursor lock while dragging (mirrors the Kanban view). */
+function setGanttDragSelectBlock(on: boolean): void {
+    document.body.classList.toggle('gantt-drag-select-block', on);
+}
+
 type Row =
     | { kind: 'section'; label: string; y: number }
     | { kind: 'task'; task: GanttTask; y: number };
 
+/** A press in progress: a candidate until it travels past the threshold. */
+interface DragCandidate {
+    task: GanttTask;
+    mode: GanttDragMode;
+    startX: number;
+    /** false ⇒ press is outside any bar: it can only become a drag-less click. */
+    draggable: boolean;
+    /** Which inline editor a click (no drag) opens: 'label' (name column) or 'progress' (bar). */
+    clickField: 'label' | 'progress' | null;
+    active: boolean;
+}
+
+/** Live preview state surfaced to the render (drives the ghost bar + date tip). */
+interface DragPreview {
+    taskId: string;
+    mode: GanttDragMode;
+    dayDelta: number;
+}
+
 interface GanttViewProps {
     content: string;
     fileName: string;
-    onJumpToSource: (line: number) => void;
-    /** 마크다운 SSOT 쓰기 — AI 자동 생성 결과 반영(없으면 read-only). */
+    /** 마크다운 SSOT 쓰기 — 없으면 read-only(드래그 편집·자동 생성 비활성, split 미러). */
     onChange?: (md: string) => void;
     /** 모달(GanttPanel) 열림 — 메인 툴바 "자동 생성" 클릭을 App 이 토글. */
     ganttPanelOpen?: boolean;
     onCloseGanttPanel?: () => void;
 }
 
-export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPanelOpen, onCloseGanttPanel }: GanttViewProps) {
+export function GanttView({ content, fileName, onChange, ganttPanelOpen, onCloseGanttPanel }: GanttViewProps) {
     const data = useMemo(() => parseGantt(content, fileName), [content, fileName]);
+    const editable = !!onChange;
+    const svgRef = useRef<SVGSVGElement | null>(null);
+    const dragRef = useRef<DragCandidate | null>(null);
+    const [drag, setDrag] = useState<DragPreview | null>(null);
+    const [edit, setEdit] = useState<{ taskId: string; field: 'label' | 'progress' } | null>(null);
 
     // 자동 생성 모달 — 빈 상태/렌더 상태 양쪽에서 동일하게 떠야 하므로 변수로 만들어 둔다.
     const panel = ganttPanelOpen && onChange ? (
@@ -105,6 +142,94 @@ export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPa
         return { start, totalDays, rows, chartW, chartH, todayX, bodyH: y };
     }, [data]);
 
+    // Global drag listeners (press → threshold → drag, else jump). Mirrors KanbanView.
+    useEffect(() => {
+        if (!editable) return;
+
+        const reset = () => {
+            dragRef.current = null;
+            setDrag(null);
+            setGanttDragSelectBlock(false);
+        };
+
+        const onMove = (e: MouseEvent) => {
+            const cand = dragRef.current;
+            if (!cand || !cand.draggable) return; // non-draggable press → jump only
+            const dx = e.clientX - cand.startX;
+            if (!cand.active && Math.abs(dx) < DRAG_THRESHOLD) return;
+            cand.active = true;
+            e.preventDefault();
+            setDrag({ taskId: cand.task.id, mode: cand.mode, dayDelta: Math.round(dx / DAY_W) });
+        };
+
+        const onUp = (e: MouseEvent) => {
+            const cand = dragRef.current;
+            reset();
+            if (!cand) return;
+            if (!cand.active) {
+                // A drag-less click opens the inline editor matching where it landed.
+                if (cand.clickField) setEdit({ taskId: cand.task.id, field: cand.clickField });
+                return;
+            }
+            e.preventDefault();
+            const dayDelta = Math.round((e.clientX - cand.startX) / DAY_W);
+            const next = applyGanttDrag(content, cand.task, cand.mode, dayDelta);
+            if (next !== content) onChange?.(next);
+        };
+
+        window.addEventListener('mousemove', onMove, { capture: true });
+        window.addEventListener('mouseup', onUp, { capture: true });
+        window.addEventListener('blur', reset);
+        return () => {
+            window.removeEventListener('mousemove', onMove, { capture: true });
+            window.removeEventListener('mouseup', onUp, { capture: true });
+            window.removeEventListener('blur', reset);
+            setGanttDragSelectBlock(false);
+        };
+    }, [content, editable, onChange]);
+
+    /** Classify a press: which (if any) drag mode, based on where it lands on the bar. */
+    const hitTest = useCallback((eff: GanttDragResult, bx: number, bw: number, clientX: number): { draggable: boolean; mode: GanttDragMode } => {
+        const svgRect = svgRef.current?.getBoundingClientRect();
+        if (!svgRect) return { draggable: false, mode: 'move' };
+        const localX = clientX - svgRect.left; // SVG user-space x (rect.left already accounts for scroll)
+        if (eff.isMilestone) {
+            const cx = bx + DAY_W / 2;
+            return { draggable: Math.abs(localX - cx) <= MS_R + 2, mode: 'move' };
+        }
+        if (localX < bx - 2 || localX > bx + bw + 2) return { draggable: false, mode: 'move' };
+        const edge = Math.min(EDGE_HIT, bw / 3); // shrink edge zones on short bars so a move stays possible
+        if (localX <= bx + edge) return { draggable: true, mode: 'resize-start' };
+        if (localX >= bx + bw - edge) return { draggable: true, mode: 'resize-end' };
+        return { draggable: true, mode: 'move' };
+    }, []);
+
+    const onRowMouseDown = useCallback((task: GanttTask, eff: GanttDragResult, bx: number, bw: number) => (e: ReactMouseEvent<SVGGElement>) => {
+        if (!editable || typeof task.mdLine !== 'number' || e.button !== 0) return;
+        if (edit) return; // an editor is open — let it handle focus/commit, don't start a new press
+        const { draggable, mode } = hitTest(eff, bx, bw, e.clientX);
+        const svgRect = svgRef.current?.getBoundingClientRect();
+        const localX = svgRect ? e.clientX - svgRect.left : 0;
+        // Where a drag-less click lands decides which editor opens.
+        const clickField: 'label' | 'progress' | null =
+            localX < LABEL_W ? 'label' : (draggable && !eff.isMilestone ? 'progress' : null);
+        e.preventDefault();
+        if (draggable) setGanttDragSelectBlock(true);
+        dragRef.current = { task, mode, startX: e.clientX, draggable, clickField, active: false };
+    }, [editable, edit, hitTest]);
+
+    const commitLabel = useCallback((task: GanttTask, label: string) => {
+        const next = applyGanttLabel(content, task, label);
+        if (next !== content) onChange?.(next);
+        setEdit(null);
+    }, [content, onChange]);
+
+    const commitProgress = useCallback((task: GanttTask, progress: number) => {
+        const next = applyGanttProgress(content, task, progress);
+        if (next !== content) onChange?.(next);
+        setEdit(null);
+    }, [content, onChange]);
+
     if (!model) {
         return (
             <div className="gantt-view">
@@ -139,7 +264,8 @@ export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPa
         <div className="gantt-view">
             <div className="gantt-scroll">
                 <svg
-                    className="gantt-svg"
+                    ref={svgRef}
+                    className={`gantt-svg${editable ? ' is-editable' : ''}${drag ? ' is-dragging' : ''}`}
                     width={chartW}
                     height={chartH}
                     role="img"
@@ -183,21 +309,30 @@ export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPa
                             );
                         }
                         const t = row.task;
-                        const bx = LABEL_W + diffDays(start, t.start) * DAY_W;
+                        const isDragging = drag?.taskId === t.id;
+                        // While dragging, render the bar at its previewed position.
+                        const eff: GanttDragResult = isDragging
+                            ? previewGanttDrag(t, drag.mode, drag.dayDelta)
+                            : { start: t.start, end: t.end, isMilestone: t.isMilestone };
+
+                        const bx = LABEL_W + diffDays(start, eff.start) * DAY_W;
+                        const days = diffDays(eff.start, eff.end) + 1;
+                        const bw = Math.max(DAY_W * days, 6);
                         const cy = ry + ROW_H / 2;
-                        const labelText =
-                            t.label.length > 26 ? `${t.label.slice(0, 25)}…` : t.label;
+                        const hasPct = !eff.isMilestone && t.progress > 0;
+                        const maxTitle = hasPct ? 10 : 14;
+                        const labelText = t.label.length > maxTitle ? `${t.label.slice(0, maxTitle - 1)}…` : t.label;
 
                         return (
                             <g
                                 key={i}
-                                className="gantt-row"
-                                onClick={() => t.mdLine && onJumpToSource(t.mdLine)}
-                                style={{ cursor: t.mdLine ? 'pointer' : 'default' }}
+                                className={`gantt-row${editable ? ' is-editable' : ''}${isDragging ? ' is-dragging' : ''}`}
+                                onMouseDown={editable ? onRowMouseDown(t, eff, bx, bw) : undefined}
+                                style={{ cursor: editable && t.mdLine ? 'grab' : (t.mdLine ? 'pointer' : 'default') }}
                             >
                                 <title>
-                                    {`${t.label}\n${ymd(t.start)}${t.isMilestone ? ' (마일스톤)' : ` → ${ymd(t.end)}`}` +
-                                        `${t.isMilestone ? '' : `\n진행률 ${t.progress}%`}`}
+                                    {`${t.label}\n${ymd(eff.start)}${eff.isMilestone ? ' (마일스톤)' : ` → ${ymd(eff.end)}`}` +
+                                        `${eff.isMilestone ? '' : `\n진행률 ${t.progress}%`}`}
                                 </title>
                                 {/* row hover background spanning the chart */}
                                 <rect
@@ -207,60 +342,61 @@ export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPa
                                     width={chartW}
                                     height={ROW_H}
                                 />
-                                <text className="gantt-task-label" x={20} y={cy + 4}>
+                                <text className="gantt-task-label" x={18} y={cy + 4}>
                                     {labelText}
+                                    {hasPct && <tspan className="gantt-task-pct"> ({t.progress}%)</tspan>}
+                                </text>
+                                <text className="gantt-task-meta" x={LABEL_W - 10} y={cy + 4} textAnchor="end">
+                                    {ganttMeta(eff.start, eff.end, eff.isMilestone)}
                                 </text>
 
-                                {t.isMilestone ? (
+                                {eff.isMilestone ? (
                                     // diamond centred on the start day
                                     <path
                                         className="gantt-milestone"
-                                        d={diamond(bx + DAY_W / 2, cy, 8)}
+                                        d={diamond(bx + DAY_W / 2, cy, MS_R)}
                                         fill={t.color}
                                     />
-                                ) : (
-                                    <>
-                                        {(() => {
-                                            const days = diffDays(t.start, t.end) + 1;
-                                            const bw = Math.max(DAY_W * days, 6);
-                                            const by = ry + BAR_PAD;
-                                            const bh = ROW_H - BAR_PAD * 2;
-                                            const fillW = Math.round((bw * t.progress) / 100);
-                                            return (
-                                                <>
-                                                    <rect
-                                                        className="gantt-bar"
-                                                        x={bx}
-                                                        y={by}
-                                                        width={bw}
-                                                        height={bh}
-                                                        rx={4}
-                                                        fill={t.color}
-                                                    />
-                                                    {fillW > 0 && (
-                                                        <rect
-                                                            className="gantt-bar-progress"
-                                                            x={bx}
-                                                            y={by}
-                                                            width={fillW}
-                                                            height={bh}
-                                                            rx={4}
-                                                            fill={t.color}
-                                                        />
-                                                    )}
-                                                    {t.progress > 0 && (
-                                                        <text
-                                                            className="gantt-bar-pct"
-                                                            x={bx + bw + 6}
-                                                            y={cy + 4}
-                                                        >
-                                                            {t.progress}%
-                                                        </text>
-                                                    )}
-                                                </>
-                                            );
-                                        })()}
-                                    </>
+                                ) : (() => {
+                                    const by = ry + BAR_PAD;
+                                    const bh = ROW_H - BAR_PAD * 2;
+                                    const fillW = Math.round((bw * t.progress) / 100);
+                                    return (
+                                        <>
+                                            <rect
+                                                className="gantt-bar"
+                                                x={bx}
+                                                y={by}
+                                                width={bw}
+                                                height={bh}
+                                                rx={4}
+                                                fill={t.color}
+                                            />
+                                            {fillW > 0 && !isDragging && (
+                                                <rect
+                                                    className="gantt-bar-progress"
+                                                    x={bx}
+                                                    y={by}
+                                                    width={fillW}
+                                                    height={bh}
+                                                    rx={4}
+                                                    fill={t.color}
+                                                />
+                                            )}
+                                        </>
+                                    );
+                                })()}
+
+                                {/* live date tip while dragging */}
+                                {isDragging && (
+                                    <text
+                                        className="gantt-drag-tip"
+                                        x={eff.isMilestone ? bx + DAY_W / 2 : bx + bw / 2}
+                                        y={ry + BAR_PAD - 3}
+                                        textAnchor="middle"
+                                    >
+                                        {eff.isMilestone ? ymd(eff.start) : `${ymd(eff.start)} → ${ymd(eff.end)}`}
+                                    </text>
                                 )}
                             </g>
                         );
@@ -281,9 +417,102 @@ export function GanttView({ content, fileName, onJumpToSource, onChange, ganttPa
                             </text>
                         </g>
                     )}
+
+                    {/* inline editor (label / progress) — drawn last so it sits on top */}
+                    {edit && (() => {
+                        const row = rows.find((r) => r.kind === 'task' && r.task.id === edit.taskId);
+                        if (!row || row.kind !== 'task') return null;
+                        const t = row.task;
+                        const ry = HEADER_H + row.y;
+                        if (edit.field === 'label') {
+                            return (
+                                <foreignObject x={14} y={ry + 4} width={LABEL_W - 24} height={ROW_H - 8}>
+                                    <GanttLabelInput
+                                        initial={t.label}
+                                        onCommit={(v) => commitLabel(t, v)}
+                                        onCancel={() => setEdit(null)}
+                                    />
+                                </foreignObject>
+                            );
+                        }
+                        // progress slider over the bar (clamped within the chart)
+                        const bx = LABEL_W + diffDays(start, t.start) * DAY_W;
+                        const px = Math.min(Math.max(bx, LABEL_W + 4), chartW - 174);
+                        return (
+                            <foreignObject x={px} y={ry + 3} width={170} height={ROW_H - 6}>
+                                <GanttProgressInput
+                                    initial={t.progress}
+                                    onCommit={(v) => commitProgress(t, v)}
+                                    onCancel={() => setEdit(null)}
+                                />
+                            </foreignObject>
+                        );
+                    })()}
                 </svg>
             </div>
             {panel}
+        </div>
+    );
+}
+
+/** Inline name editor rendered inside a foreignObject over the label column. */
+function GanttLabelInput({ initial, onCommit, onCancel }: {
+    initial: string;
+    onCommit: (value: string) => void;
+    onCancel: () => void;
+}) {
+    const [value, setValue] = useState(initial);
+    const ref = useRef<HTMLInputElement>(null);
+    useEffect(() => { const el = ref.current; if (el) { el.focus(); el.select(); } }, []);
+    return (
+        <input
+            ref={ref}
+            className="gantt-edit-input"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={() => onCommit(value)}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); onCommit(value); }
+                else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+            }}
+        />
+    );
+}
+
+/** Inline progress slider (0–100) rendered inside a foreignObject over the bar. */
+function GanttProgressInput({ initial, onCommit, onCancel }: {
+    initial: number;
+    onCommit: (value: number) => void;
+    onCancel: () => void;
+}) {
+    const [value, setValue] = useState(initial);
+    const ref = useRef<HTMLDivElement>(null);
+    const latest = useRef(value);
+    latest.current = value;
+    useEffect(() => {
+        // Commit when the user clicks outside the slider popover.
+        const onDown = (e: PointerEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) onCommit(latest.current);
+        };
+        document.addEventListener('pointerdown', onDown, true);
+        return () => document.removeEventListener('pointerdown', onDown, true);
+    }, [onCommit]);
+    return (
+        <div ref={ref} className="gantt-edit-progress">
+            <input
+                type="range"
+                min={0}
+                max={100}
+                step={5}
+                value={value}
+                autoFocus
+                onChange={(e) => setValue(Number(e.target.value))}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') { e.preventDefault(); onCommit(value); }
+                    else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+                }}
+            />
+            <span className="gantt-edit-progress-val">{value}%</span>
         </div>
     );
 }
@@ -296,4 +525,18 @@ function diamond(cx: number, cy: number, r: number): string {
 function ymd(d: Date): string {
     const p = (n: number) => String(n).padStart(2, '0');
     return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/** Slash-separated date, no zero-padding: 2026/5/11. */
+function slashDate(d: Date): string {
+    return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+/** Label-column date meta: "2026/5/11 ~ 5/13" — end-year dropped when it matches the start. */
+function ganttMeta(start: Date, end: Date, isMilestone: boolean): string {
+    if (isMilestone) return slashDate(start);
+    const endStr = start.getFullYear() === end.getFullYear()
+        ? `${end.getMonth() + 1}/${end.getDate()}`
+        : slashDate(end);
+    return `${slashDate(start)} ~ ${endStr}`;
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -19,8 +19,8 @@ export type PaneView = Exclude<ViewMode, 'split' | 'slideshow'>;
 /** 패인 뷰 전체 목록 — localStorage 복원 검증 등에 사용. */
 export const PANE_VIEWS: PaneView[] = ['editor', 'preview', 'mindmap', 'flowchart', 'gantt', 'kanban'];
 
-/** 편집(양방향) 가능한 뷰. flowchart/gantt(read-only)는 미포함 → 항상 미러. */
-export const EDITABLE_VIEWS = new Set<PaneView>(['editor', 'preview', 'mindmap', 'kanban']);
+/** 편집(양방향) 가능한 뷰. flowchart(read-only)는 미포함 → 항상 미러. */
+export const EDITABLE_VIEWS = new Set<PaneView>(['editor', 'preview', 'mindmap', 'kanban', 'gantt']);
 
 /** localStorage 등 외부 문자열을 PaneView 로 안전 검증. */
 export function isPaneView(v: string | null | undefined): v is PaneView {

--- a/src/lib/ganttEdit.test.ts
+++ b/src/lib/ganttEdit.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { applyGanttDrag, applyGanttLabel, applyGanttProgress, previewGanttDrag } from './ganttEdit';
+import { parseGantt } from './gantt-parser';
+import { parseKanban } from './kanban-parser';
+import type { GanttTask } from '../types/gantt';
+
+/** Build a single GanttTask from one marker line via the real parser. */
+function firstTask(md: string): GanttTask {
+    const t = parseGantt(md).tasks[0];
+    if (!t) throw new Error('no task parsed');
+    return t;
+}
+function line(md: string, n: number): string {
+    return md.split('\n')[n - 1];
+}
+function ymd(d: Date): string {
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+describe('previewGanttDrag (pure date math)', () => {
+    const md = `# P\n- [ ] A @start(2026-07-01) @due(2026-07-10) @progress(40)\n`;
+
+    it('move shifts start and end together (duration preserved)', () => {
+        const r = previewGanttDrag(firstTask(md), 'move', 3);
+        expect(ymd(r.start)).toBe('2026-07-04');
+        expect(ymd(r.end)).toBe('2026-07-13');
+        expect(r.isMilestone).toBe(false);
+    });
+
+    it('resize-end extends only the end', () => {
+        const r = previewGanttDrag(firstTask(md), 'resize-end', 5);
+        expect(ymd(r.start)).toBe('2026-07-01');
+        expect(ymd(r.end)).toBe('2026-07-15');
+    });
+
+    it('resize-start moves only the start, clamped to the end', () => {
+        const r = previewGanttDrag(firstTask(md), 'resize-start', 100);
+        expect(ymd(r.start)).toBe('2026-07-10'); // clamped, never past end
+        expect(ymd(r.end)).toBe('2026-07-10');
+    });
+
+    it('resize-end dragged before the start collapses to a milestone', () => {
+        const r = previewGanttDrag(firstTask(md), 'resize-end', -100);
+        expect(r.isMilestone).toBe(true);
+        expect(ymd(r.end)).toBe(ymd(r.start));
+    });
+
+    it('a milestone grows into a bar when its end is dragged out', () => {
+        const ms = firstTask(`# P\n- [ ] 출시 @start(2026-07-15)\n`);
+        expect(ms.isMilestone).toBe(true);
+        const r = previewGanttDrag(ms, 'resize-end', 4);
+        expect(r.isMilestone).toBe(false);
+        expect(ymd(r.end)).toBe('2026-07-19');
+    });
+});
+
+describe('applyGanttDrag — Kanban marker compatibility (shared line engine)', () => {
+    it('moving a bar keeps @status/@priority/@order/@progress and unknown markers intact', () => {
+        const md = `# Board
+- [ ] 구현 @status(doing) @priority(high) @start(2026-07-01) @due(2026-07-10) @progress(40) @order(2000) @owner(kim)
+`;
+        const next = applyGanttDrag(md, firstTask(md), 'move', 7);
+
+        // Gantt side: both dates shifted by 7 days.
+        const gt = parseGantt(next).tasks[0];
+        expect(ymd(gt.start)).toBe('2026-07-08');
+        expect(ymd(gt.end)).toBe('2026-07-17');
+
+        // Kanban side: every non-date marker survived the edit.
+        const card = parseKanban(next).cards[0];
+        expect(card.status).toBe('doing');
+        expect(card.priority).toBe('high');
+        expect(card.order).toBe(2000);
+        expect(card.progress).toBe(40);
+
+        // An unknown marker is preserved verbatim.
+        expect(line(next, 2)).toContain('@owner(kim)');
+    });
+
+    it('resize-end only rewrites @due, leaving the rest of the line stable', () => {
+        const md = `# Board
+- [ ] B @status(review) @start(2026-07-01) @due(2026-07-05)
+`;
+        const next = applyGanttDrag(md, firstTask(md), 'resize-end', 3);
+        expect(line(next, 2)).toContain('@start(2026-07-01)');
+        expect(line(next, 2)).toContain('@due(2026-07-08)');
+        expect(parseKanban(next).cards[0].status).toBe('review');
+    });
+
+    it('collapsing a bar to a milestone drops @due but keeps the Kanban card', () => {
+        const md = `# Board\n- [ ] C @status(todo) @start(2026-07-10) @due(2026-07-15)\n`;
+        const next = applyGanttDrag(md, firstTask(md), 'resize-end', -100);
+        expect(line(next, 2)).not.toContain('@due');
+        expect(parseGantt(next).tasks[0].isMilestone).toBe(true);
+        expect(parseKanban(next).cards[0].status).toBe('todo');
+    });
+
+    it('a zero-day drag is a no-op', () => {
+        const md = `# Board\n- [ ] D @start(2026-07-01) @due(2026-07-10)\n`;
+        expect(applyGanttDrag(md, firstTask(md), 'move', 0)).toBe(md);
+    });
+
+    it('never touches sibling lines', () => {
+        const md = `# Board
+- [ ] A @start(2026-07-01) @due(2026-07-05)
+- [ ] B @start(2026-07-10) @due(2026-07-12)
+`;
+        const next = applyGanttDrag(md, parseGantt(md).tasks[0], 'move', 2);
+        expect(line(next, 3)).toBe('- [ ] B @start(2026-07-10) @due(2026-07-12)');
+    });
+});
+
+describe('applyGanttLabel / applyGanttProgress — inline edits via shared engine', () => {
+    it('renames the label (collapsed whitespace), preserving markers', () => {
+        const md = `# Board\n- [ ] 구현 @status(doing) @start(2026-07-01) @due(2026-07-10) @progress(40)\n`;
+        const next = applyGanttLabel(md, firstTask(md), '  설계  검토 ');
+        const card = parseKanban(next).cards[0];
+        expect(card.label).toBe('설계 검토');
+        expect(card.status).toBe('doing');
+        expect(card.progress).toBe(40);
+        expect(ymd(parseGantt(next).tasks[0].start)).toBe('2026-07-01');
+    });
+
+    it('ignores an empty rename', () => {
+        const md = `# Board\n- [ ] A @start(2026-07-01) @due(2026-07-05)\n`;
+        expect(applyGanttLabel(md, firstTask(md), '   ')).toBe(md);
+    });
+
+    it('sets progress and keeps other markers (status/dates)', () => {
+        const md = `# Board\n- [ ] B @status(doing) @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 65);
+        expect(line(next, 2)).toContain('@progress(65)');
+        expect(parseGantt(next).tasks[0].progress).toBe(65);
+        expect(parseKanban(next).cards[0].status).toBe('doing');
+    });
+
+    it('clamps progress to 0–100', () => {
+        const md = `# Board\n- [ ] C @start(2026-07-01) @due(2026-07-10) @progress(50)\n`;
+        expect(parseGantt(applyGanttProgress(md, firstTask(md), 150)).tasks[0].progress).toBe(100);
+        // progress 0 ⇒ marker dropped, parser falls back to checkbox [ ] = 0
+        expect(parseGantt(applyGanttProgress(md, firstTask(md), -20)).tasks[0].progress).toBe(0);
+    });
+});

--- a/src/lib/ganttEdit.test.ts
+++ b/src/lib/ganttEdit.test.ts
@@ -173,4 +173,13 @@ describe('applyGanttLabel / applyGanttProgress — inline edits via shared engin
         expect(parseKanban(next).cards[0].status).not.toBe('done');   // Kanban 도 done 아님
         expect(parseGantt(next).tasks[0].progress).toBe(60);
     });
+
+    it('checked card with a non-done alias keeps the alias on release (Codex P2 — only done alias removed)', () => {
+        const md = `# Board\n- [x] 작업 @status(qa) @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 60);
+        expect(line(next, 2)).toContain('@status(qa)');               // 비-done 별칭(qa=review) 보존
+        expect(line(next, 2)).toContain('[ ]');                       // checkbox 만 해제
+        expect(parseKanban(next).cards[0].status).toBe('review');     // review 유지
+        expect(parseGantt(next).tasks[0].progress).toBe(60);
+    });
 });

--- a/src/lib/ganttEdit.test.ts
+++ b/src/lib/ganttEdit.test.ts
@@ -182,4 +182,12 @@ describe('applyGanttLabel / applyGanttProgress — inline edits via shared engin
         expect(parseKanban(next).cards[0].status).toBe('review');     // review 유지
         expect(parseGantt(next).tasks[0].progress).toBe(60);
     });
+
+    it('explicit done task with no checkbox/@progress saves a 100% edit (Codex P2)', () => {
+        const md = `# Board\n- 배포 @status(done) @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 100);
+        expect(next).not.toBe(md);                                    // 유실되지 않음
+        expect(parseGantt(next).tasks[0].progress).toBe(100);         // 100% 저장
+        expect(parseKanban(next).cards[0].status).toBe('done');       // done 유지
+    });
 });

--- a/src/lib/ganttEdit.test.ts
+++ b/src/lib/ganttEdit.test.ts
@@ -141,4 +141,28 @@ describe('applyGanttLabel / applyGanttProgress — inline edits via shared engin
         // progress 0 ⇒ marker dropped, parser falls back to checkbox [ ] = 0
         expect(parseGantt(applyGanttProgress(md, firstTask(md), -20)).tasks[0].progress).toBe(0);
     });
+
+    it('lowering a done task below 100 releases done — status + checkbox (Codex P2, 저장 유실 방지)', () => {
+        const md = `# Board\n- [x] 완료작업 @status(done) @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 60);
+        expect(parseGantt(next).tasks[0].progress).toBe(60);          // 진행률 반영(유실 X)
+        expect(line(next, 2)).not.toContain('@status(done)');         // done 마커 해제
+        expect(line(next, 2)).not.toContain('[x]');                   // checkbox 해제
+        expect(parseKanban(next).cards[0].status).not.toBe('done');   // Kanban 도 done 아님
+        expect(parseKanban(next).cards[0].progress).toBe(60);
+    });
+
+    it('checkbox-only done also releases when progress lowered', () => {
+        const md = `# Board\n- [x] 작업 @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 40);
+        expect(parseGantt(next).tasks[0].progress).toBe(40);
+        expect(line(next, 2)).not.toContain('[x]');
+    });
+
+    it('progress 100 keeps done (release only below 100)', () => {
+        const md = `# Board\n- [x] 작업 @status(done) @start(2026-07-01) @due(2026-07-10)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 100);
+        expect(parseGantt(next).tasks[0].progress).toBe(100);
+        expect(parseKanban(next).cards[0].status).toBe('done');
+    });
 });

--- a/src/lib/ganttEdit.test.ts
+++ b/src/lib/ganttEdit.test.ts
@@ -165,4 +165,12 @@ describe('applyGanttLabel / applyGanttProgress — inline edits via shared engin
         expect(parseGantt(next).tasks[0].progress).toBe(100);
         expect(parseKanban(next).cards[0].status).toBe('done');
     });
+
+    it('done alias without checkbox (@status(완료)) also releases on progress lower (Codex P2)', () => {
+        const md = `# Board\n- 작업 @status(완료) @start(2026-07-01) @due(2026-07-10) @progress(100)\n`;
+        const next = applyGanttProgress(md, firstTask(md), 60);
+        expect(line(next, 2)).not.toContain('@status(완료)');         // done 별칭 해제
+        expect(parseKanban(next).cards[0].status).not.toBe('done');   // Kanban 도 done 아님
+        expect(parseGantt(next).tasks[0].progress).toBe(60);
+    });
 });

--- a/src/lib/ganttEdit.ts
+++ b/src/lib/ganttEdit.ts
@@ -1,0 +1,111 @@
+/**
+ * Safe Gantt drag edits against the Markdown SSOT (#54 — drag-edit follow-up).
+ *
+ * Gantt bars/milestones derive from the SAME inline markers as Kanban
+ * (@start/@due/@progress) on a single source line (`mdLine`). To guarantee a
+ * Gantt edit can never corrupt the Kanban markers on that line — and vice
+ * versa — every edit goes through the SHARED line engine `updateKanbanCardLine`,
+ * which re-parses the whole line and re-emits all known + preserved markers.
+ * A drag only ever sends `{ start, due }`; `@status`/`@priority`/`@order` and
+ * any unknown markers are read back from the line and kept verbatim.
+ *
+ * The day math here is PURE so the view can render a live preview and tests can
+ * assert the round-trip (Gantt edit → parseKanban still intact, and back).
+ */
+
+import { updateKanbanCardLine, type KanbanCardPatch } from './kanbanEdit';
+import type { GanttTask } from '../types/gantt';
+
+/** What a pointer drag on a bar is doing. */
+export type GanttDragMode = 'move' | 'resize-start' | 'resize-end';
+
+/** Result of a drag in date space (local midnight), before serialization. */
+export interface GanttDragResult {
+    start: Date;
+    end: Date;
+    /** A drag can flip a bar↔milestone (drop the due, or grow one out of a point). */
+    isMilestone: boolean;
+}
+
+function addDays(base: Date, n: number): Date {
+    return new Date(base.getFullYear(), base.getMonth(), base.getDate() + n);
+}
+
+function ymd(d: Date): string {
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+/**
+ * Compute the new start/end for dragging `task` by `dayDelta` whole days.
+ * Pure + deterministic — the same call drives the live preview and the commit.
+ *
+ *  - move          → start and end shift together (duration preserved).
+ *  - resize-start  → start moves; clamped to ≤ end (a milestone just moves).
+ *  - resize-end    → end moves; if pulled before start the bar collapses to a
+ *                    milestone (due dropped); growing a milestone's end makes a bar.
+ */
+export function previewGanttDrag(task: GanttTask, mode: GanttDragMode, dayDelta: number): GanttDragResult {
+    if (mode === 'move') {
+        return {
+            start: addDays(task.start, dayDelta),
+            end: addDays(task.end, dayDelta),
+            isMilestone: task.isMilestone,
+        };
+    }
+
+    if (mode === 'resize-start') {
+        let start = addDays(task.start, dayDelta);
+        // A milestone is a point: resizing its start is the same as moving it.
+        if (task.isMilestone) return { start, end: start, isMilestone: true };
+        // Never let the start cross past the end.
+        if (start.getTime() > task.end.getTime()) start = task.end;
+        return { start, end: task.end, isMilestone: false };
+    }
+
+    // resize-end
+    const end = addDays(task.end, dayDelta);
+    // Pulled before the start → collapse to a milestone (no due marker).
+    if (end.getTime() < task.start.getTime()) {
+        return { start: task.start, end: task.start, isMilestone: true };
+    }
+    // Otherwise it's a real bar (this is also how a milestone grows into one).
+    return { start: task.start, end, isMilestone: false };
+}
+
+/**
+ * Apply a Gantt drag to the markdown via the shared line engine.
+ * Returns the markdown unchanged when there's nothing to do (no source line,
+ * or a zero-day delta).
+ */
+export function applyGanttDrag(
+    markdown: string,
+    task: GanttTask,
+    mode: GanttDragMode,
+    dayDelta: number,
+): string {
+    if (typeof task.mdLine !== 'number' || dayDelta === 0) return markdown;
+
+    const { start, end, isMilestone } = previewGanttDrag(task, mode, dayDelta);
+    const patch: KanbanCardPatch = {
+        start: ymd(start),
+        // Milestone ⇒ drop the due marker; bar ⇒ set it. `null` removes it safely.
+        due: isMilestone ? null : ymd(end),
+    };
+    return updateKanbanCardLine(markdown, task.mdLine, patch);
+}
+
+/** Rename a task via the shared line engine (Kanban markers preserved). Empty ⇒ no-op. */
+export function applyGanttLabel(markdown: string, task: GanttTask, label: string): string {
+    if (typeof task.mdLine !== 'number') return markdown;
+    const next = label.replace(/\s+/g, ' ').trim();
+    if (!next) return markdown;
+    return updateKanbanCardLine(markdown, task.mdLine, { label: next });
+}
+
+/** Set a task's progress (clamped 0–100) via the shared line engine. */
+export function applyGanttProgress(markdown: string, task: GanttTask, progress: number): string {
+    if (typeof task.mdLine !== 'number' || !Number.isFinite(progress)) return markdown;
+    const p = Math.min(100, Math.max(0, Math.round(progress)));
+    return updateKanbanCardLine(markdown, task.mdLine, { progress: p });
+}

--- a/src/lib/ganttEdit.ts
+++ b/src/lib/ganttEdit.ts
@@ -107,5 +107,10 @@ export function applyGanttLabel(markdown: string, task: GanttTask, label: string
 export function applyGanttProgress(markdown: string, task: GanttTask, progress: number): string {
     if (typeof task.mdLine !== 'number' || !Number.isFinite(progress)) return markdown;
     const p = Math.min(100, Math.max(0, Math.round(progress)));
-    return updateKanbanCardLine(markdown, task.mdLine, { progress: p });
+    // 100% 는 done 으로 명시한다 — 이미 done 인 작업(@status(done) 만 있고 [x]/@progress 없는 경우)은
+    // buildLine 이 done 일 때 @progress(100) 을 안 쓰고 progress-only patch 는 [x] 도 안 만들어, 결과가
+    // 원문과 같아져 100% 변경이 유실된다(Codex P2). status='done' 을 함께 보내 [x] 로 저장되게 한다.
+    // 100 미만은 progress 만 보내 buildLine 이 done 해제까지 처리(p<100 + done → 해제).
+    const patch: KanbanCardPatch = p >= 100 ? { progress: 100, status: 'done' } : { progress: p };
+    return updateKanbanCardLine(markdown, task.mdLine, patch);
 }

--- a/src/lib/kanban-parser.ts
+++ b/src/lib/kanban-parser.ts
@@ -21,7 +21,7 @@ const ORDER_RE = /@order\(\s*(\d+)\s*\)/i;
 const CHECKBOX_RE = /^\[([ xX])\]\s*/;
 const MARKER_RE = /@\w+\([^)]*\)/g;
 
-const STATUS_ALIASES: Record<string, KanbanStatus> = {
+export const STATUS_ALIASES: Record<string, KanbanStatus> = {
     backlog: 'todo',
     open: 'todo',
     ready: 'todo',
@@ -108,7 +108,7 @@ function parseLocalDate(y: number, m: number, d: number): Date | null {
     return date;
 }
 
-function cleanToken(value: string): string {
+export function cleanToken(value: string): string {
     return value.trim().toLowerCase().replace(/\s+/g, '-');
 }
 

--- a/src/lib/kanbanEdit.ts
+++ b/src/lib/kanbanEdit.ts
@@ -142,15 +142,25 @@ function isKanbanPriority(value: string): value is KanbanPriority {
 
 function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     const label = patch.label !== undefined ? patch.label.replace(/\s+/g, ' ').trim() : parsed.label;
-    const status = patch.status !== undefined ? patch.status : parsed.status;
+    let status = patch.status !== undefined ? patch.status : parsed.status;
     const priority = patch.priority !== undefined ? patch.priority : parsed.priority;
     const start = patch.start !== undefined ? normalizeDate(patch.start) : parsed.start;
     let due = patch.due !== undefined ? normalizeDate(patch.due) : parsed.due;
     let progress = patch.progress !== undefined ? normalizeProgress(patch.progress) : parsed.progress;
     const order = patch.order !== undefined ? normalizeOrder(patch.order) : parsed.order;
+    const wasChecked = parsed.checkbox?.trim().toLowerCase() === '[x]';
     if (start && due && due < start) due = null;
     if (patch.status !== undefined && patch.status !== 'done' && patch.progress === undefined && progress === 100) {
         progress = null;
+    }
+    // 진행률을 명시적으로 100 미만으로 바꿨는데 라인이 done(@status(done) 또는 [x]) 이면 done 을 해제한다.
+    // 공유 엔진은 status==='done' 일 때 @progress 를 쓰지 않고 [x] 도 유지하므로, 안 풀면 진행률 변경이
+    // 유실되고 Kanban 에서 계속 done 으로 파싱된다(Codex P2). status 를 직접 바꾼 patch 에는 미적용(기존 동작 보존).
+    let releaseDone = false;
+    if (patch.progress !== undefined && patch.status === undefined &&
+        progress !== null && progress < 100 && (status === 'done' || wasChecked)) {
+        releaseDone = true;
+        if (status === 'done') status = null; // @status(done) 제거 → progress 로 재추론
     }
 
     const markers: string[] = [];
@@ -161,7 +171,7 @@ function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     if (progress !== null && progress > 0 && status !== 'done') markers.push(`@progress(${progress})`);
     if (order !== null) markers.push(`@order(${order})`);
     const replaced = new Set<string>();
-    if (patch.status !== undefined) replaced.add('status');
+    if (patch.status !== undefined || releaseDone) replaced.add('status');
     if (patch.priority !== undefined) replaced.add('priority');
     if (patch.start !== undefined) replaced.add('start');
     if (patch.due !== undefined) {
@@ -172,8 +182,9 @@ function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     if (patch.order !== undefined) replaced.add('order');
     markers.push(...parsed.preservedMarkers.filter((m) => !replaced.has(m.name)).map((m) => m.marker));
 
-    const wasChecked = parsed.checkbox?.trim().toLowerCase() === '[x]';
-    const shouldCheck = patch.status !== undefined ? status === 'done' : status === 'done' || wasChecked;
+    const shouldCheck = releaseDone
+        ? false
+        : (patch.status !== undefined ? status === 'done' : status === 'done' || wasChecked);
     const checkbox = parsed.checkbox !== null || patch.status !== undefined
         ? `${shouldCheck ? '[x]' : '[ ]'} `
         : '';

--- a/src/lib/kanbanEdit.ts
+++ b/src/lib/kanbanEdit.ts
@@ -184,7 +184,7 @@ function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     if (progress !== null && progress > 0 && status !== 'done') markers.push(`@progress(${progress})`);
     if (order !== null) markers.push(`@order(${order})`);
     const replaced = new Set<string>();
-    if (patch.status !== undefined || releaseDone) replaced.add('status');
+    if (patch.status !== undefined) replaced.add('status');
     if (patch.priority !== undefined) replaced.add('priority');
     if (patch.start !== undefined) replaced.add('start');
     if (patch.due !== undefined) {

--- a/src/lib/kanbanEdit.ts
+++ b/src/lib/kanbanEdit.ts
@@ -7,6 +7,7 @@
  */
 
 import type { KanbanPriority, KanbanStatus } from '../types/kanban';
+import { STATUS_ALIASES, cleanToken } from './kanban-parser';
 
 export interface KanbanCardPatch {
     label?: string;
@@ -74,6 +75,12 @@ function normalizeProgress(value: number | null | undefined): number | null {
 function normalizeOrder(value: number | null | undefined): number | null {
     if (value === null || value === undefined || !Number.isFinite(value)) return null;
     return Math.max(0, Math.round(value));
+}
+
+/** Extract the inner value of a `@name(value)` marker (for normalizing preserved status aliases). */
+function markerValue(marker: string): string {
+    const m = /\(([^)]*)\)/.exec(marker);
+    return m ? m[1].trim() : '';
 }
 
 function parseLine(line: string): ParsedLine {
@@ -149,16 +156,22 @@ function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     let progress = patch.progress !== undefined ? normalizeProgress(patch.progress) : parsed.progress;
     const order = patch.order !== undefined ? normalizeOrder(patch.order) : parsed.order;
     const wasChecked = parsed.checkbox?.trim().toLowerCase() === '[x]';
+    // preserved status marker 중 done 별칭(완료/closed/complete 등) 위치 — done 판정·제거용.
+    // parseLine 은 정확한 KanbanStatus 만 status 로 흡수하고 별칭은 preserved 로 남기므로(표기 보존),
+    // done 해제 판정엔 별칭을 normalize 해서 함께 본다.
+    const preservedDoneStatusIdx = parsed.preservedMarkers.findIndex(
+        (m) => m.name === 'status' && STATUS_ALIASES[cleanToken(markerValue(m.marker))] === 'done',
+    );
     if (start && due && due < start) due = null;
     if (patch.status !== undefined && patch.status !== 'done' && patch.progress === undefined && progress === 100) {
         progress = null;
     }
-    // 진행률을 명시적으로 100 미만으로 바꿨는데 라인이 done(@status(done) 또는 [x]) 이면 done 을 해제한다.
+    // 진행률을 명시적으로 100 미만으로 바꿨는데 라인이 done(@status(done)/done 별칭 또는 [x]) 이면 done 을 해제한다.
     // 공유 엔진은 status==='done' 일 때 @progress 를 쓰지 않고 [x] 도 유지하므로, 안 풀면 진행률 변경이
     // 유실되고 Kanban 에서 계속 done 으로 파싱된다(Codex P2). status 를 직접 바꾼 patch 에는 미적용(기존 동작 보존).
     let releaseDone = false;
     if (patch.progress !== undefined && patch.status === undefined &&
-        progress !== null && progress < 100 && (status === 'done' || wasChecked)) {
+        progress !== null && progress < 100 && (status === 'done' || wasChecked || preservedDoneStatusIdx >= 0)) {
         releaseDone = true;
         if (status === 'done') status = null; // @status(done) 제거 → progress 로 재추론
     }
@@ -180,7 +193,12 @@ function buildLine(parsed: ParsedLine, patch: KanbanCardPatch): string {
     }
     if (patch.progress !== undefined) replaced.add('progress');
     if (patch.order !== undefined) replaced.add('order');
-    markers.push(...parsed.preservedMarkers.filter((m) => !replaced.has(m.name)).map((m) => m.marker));
+    // done 해제 시 done 별칭 status marker 도 함께 제거(그 외 preserved 는 보존)
+    markers.push(
+        ...parsed.preservedMarkers
+            .filter((m, i) => !replaced.has(m.name) && !(releaseDone && i === preservedDoneStatusIdx))
+            .map((m) => m.marker),
+    );
 
     const shouldCheck = releaseDone
         ? false

--- a/src/types/gantt.ts
+++ b/src/types/gantt.ts
@@ -28,7 +28,7 @@ export interface GanttTask {
     isMilestone: boolean;
     /** Completion 0–100. From `@progress(n)`, else checkbox ([x]=100 / [ ]=0), else 0. */
     progress: number;
-    /** 1-based source line in the FULL document (for onJumpToSource). */
+    /** 1-based source line in the FULL document (drag edits patch this line). */
     mdLine?: number;
     /** Palette colour for this task's section (consistent per section). */
     color: string;


### PR DESCRIPTION
## Summary
간트 차트 뷰를 read-only 에서 직접 편집 가능하게 만든다. 막대 드래그(이동/리사이즈/마일스톤)와 인라인 편집(이름/진행률)을 추가하고, 라벨 컬럼에 진행률·날짜 메타를 표시한다. 모든 편집은 Kanban 과 같은 마커 라인 엔진을 공유해 두 뷰의 문법이 서로 충돌하지 않는다.

## Changes
- **막대 드래그**: 본체=이동(start+due 동시), 좌/우 엣지=한쪽 리사이즈, 마일스톤=점 이동, 막대를 하루 미만으로 줄이면 마일스톤↔막대 전환. 드래그 중 날짜 미리보기.
- **인라인 편집**: 왼쪽 이름 라벨 클릭=이름 변경, 막대 클릭=진행률 슬라이더(0~100). SVG `foreignObject` 사용.
- **라벨 컬럼 메타**: 진행률 `(n%)`(제목 옆) + 날짜 `2026/5/11 ~ 5/13`(슬래시·0제거·동일연도 종료연도 생략). 컬럼 폭 220→300.
- **호환성**: 편집을 모두 `updateKanbanCardLine`(공유 라인 엔진) 경유 → 같은 줄의 Kanban 마커(`@status/@priority/@order`)·미지 마커 보존.
- `gantt` 를 `EDITABLE_VIEWS` 에 추가 → 솔로/활성 패인에서 편집, split 미러는 read-only. 클릭 시 소스 점프는 제거(편집으로 대체).

## Test plan
- [x] `ganttEdit.test.ts` 14개 — 드래그/인라인 편집 + 양방향 Kanban 호환성 라운드트립
- [x] 전체 테스트 304개 통과, `tsc --noEmit` 0
- [x] `tauri build` (release) 성공
- [ ] 간트 뷰: 막대 드래그(이동/리사이즈/마일스톤)·클릭 편집(이름/진행률) 동작
- [ ] 칸반 뷰 전환 시 변경된 이름/날짜/진행률 반영 + 상태/우선순위 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)