### PR TITLE
feat(view/slideshow): AI 사이드바 레이아웃·⌘L·슬라이드쇼 여백/다크/컨트롤

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1436,6 +1436,9 @@ body {
   width: 100%;
   height: 100%;
   flex: 1;
+  /* 넓은 콘텐츠(Gantt SVG·Kanban grid)가 split-pane 을 못 줄이면 형제 .ai-panel 이
+     밀려 main-content overflow:hidden 으로 잘린다 → min-width:0 으로 shrink 허용 */
+  min-width: 0;
   min-height: 0;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2104,6 +2104,13 @@ function App() {
               toggleSearch();
             }
             break;
+          case 'l':
+            // AI 에이전트 사이드바 토글 (⌘L — Cursor 등 AI 채팅 사이드바 관습. ⌘⇧L 은 제외)
+            if (!e.shiftKey) {
+              e.preventDefault();
+              handleToggleAI();
+            }
+            break;
           case '1':
             e.preventDefault();
             setViewMode('editor');

--- a/src/components/AIPanel.css
+++ b/src/components/AIPanel.css
@@ -3,6 +3,7 @@
 .ai-panel {
     width: 340px;
     min-width: 340px;
+    flex-shrink: 0; /* main-content flex 에서 340px 절대 보장 — 안 줄고 안 밀림 */
     height: 100%;
     border-left: 1px solid var(--border-primary);
     background: var(--bg-secondary);

--- a/src/components/KanbanView.css
+++ b/src/components/KanbanView.css
@@ -14,7 +14,10 @@
     flex: 1;
     min-height: 0;
     display: grid;
-    grid-template-columns: repeat(5, minmax(220px, 1fr));
+    /* 고정폭 — AI 사이드바 토글로 영역이 바뀌어도 카드(컬럼) 폭은 일정.
+       넓으면 왼쪽 정렬(오른쪽 여백), 좁으면 가로 스크롤(overflow auto). */
+    grid-template-columns: repeat(5, 260px);
+    justify-content: start;
     gap: 14px;
     align-items: start;
     padding: 16px;

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -40,6 +40,8 @@
 .slideshow-content.markdown-body {
     width: 100%;
     max-width: 1080px;
+    /* 본문 색 = 테마 변수(라이트/다크 자동) — Rich Text(Preview) 와 동일 */
+    color: var(--text-primary);
     /* 발표용 기본 크기(뷰포트 기반) × 사용자 배율. 내부 요소는 상대 단위로 따라옴. */
     font-size: calc(clamp(0.95rem, 0.62rem + 0.7vw, 1.25rem) * var(--slideshow-scale, 1));
     line-height: var(--md-line-height, 1.7);
@@ -82,9 +84,11 @@
     opacity: 0.5;
     transition: opacity 0.18s ease, background 0.18s ease;
 }
-.slideshow-close:hover,
 .slideshow-nav:hover {
     opacity: 1;
+    background: var(--bg-active, rgba(0, 0, 0, 0.12));
+}
+.slideshow-close:hover {
     background: var(--bg-active, rgba(0, 0, 0, 0.12));
 }
 .slideshow-nav:disabled {
@@ -122,7 +126,6 @@
     transition: opacity 0.18s ease, background 0.18s ease;
 }
 .slideshow-fontctl button:hover {
-    opacity: 1;
     background: var(--bg-active, rgba(0, 0, 0, 0.12));
 }
 
@@ -142,9 +145,6 @@
 /* 좌우 네비 — 평소 숨김, 화면에 마우스를 올리면 나타남(롤오버) */
 .slideshow-nav {
     opacity: 0;
-}
-.slideshow-root:hover .slideshow-nav:not(:disabled) {
-    opacity: 0.45;
 }
 .slideshow-nav:not(:disabled):hover {
     opacity: 1;
@@ -170,4 +170,49 @@
 /* 본문 명조 — App 의 data-font-family 규칙과 동일 패밀리 적용(portal 이라 직접 지정). */
 .slideshow-root[data-font-family='serif'] .slideshow-content {
     font-family: var(--font-serif, 'Noto Serif KR', Georgia, serif);
+}
+
+/* ── 여백 3단계 (상하=padding-block, 좌우=콘텐츠 max-width) — data-pad ── */
+.slideshow-root[data-pad='small'] .slideshow-slide {
+    padding-block: clamp(0.6rem, 1.5vh, 1.2rem);
+}
+.slideshow-root[data-pad='small'] .slideshow-content.markdown-body {
+    max-width: 1200px;
+}
+.slideshow-root[data-pad='large'] .slideshow-slide {
+    padding-block: clamp(3rem, 8vh, 6rem);
+}
+.slideshow-root[data-pad='large'] .slideshow-content.markdown-body {
+    max-width: 960px;
+}
+
+/* 다크 모드는 별도 규칙 없이 root 의 data-theme="dark" + data-custom-bg 가
+   App.css 의 검증된 [data-theme=dark]·[data-custom-bg] 규칙(변수·표·코드·인용·marker)을
+   그대로 적용한다. 컨트롤(close/nav/fontctl)·indicator 도 var(--text-primary)·var(--bg-active)
+   를 써서 테마 변수로 자동 다크. */
+
+/* ── 컨트롤 hover zone — 상단/좌/우 가장자리 근처에서만 노출(평소 숨김) ── */
+.slideshow-hover {
+    position: absolute;
+}
+.slideshow-hover.top { top: 0; left: 0; right: 0; height: 76px; }
+.slideshow-hover.left { top: 0; bottom: 0; left: 0; width: 110px; }
+.slideshow-hover.right { top: 0; bottom: 0; right: 0; width: 110px; }
+
+/* 상단(닫기·폰트/여백/다크): 평소 숨김 → 상단 zone(또는 버튼 자체) hover 시 노출 */
+.slideshow-close,
+.slideshow-fontctl button {
+    opacity: 0;
+}
+/* 상단 zone 또는 상단 버튼 어느 것에든 마우스가 있으면 세트 전체 노출 유지.
+   (zone 만 보면 버튼 위로 올라간 순간 zone hover 가 풀려 세트가 사라짐) */
+.slideshow-root:has(.slideshow-hover.top:hover, .slideshow-fontctl:hover, .slideshow-close:hover) .slideshow-close,
+.slideshow-root:has(.slideshow-hover.top:hover, .slideshow-fontctl:hover, .slideshow-close:hover) .slideshow-fontctl button {
+    opacity: 0.85;
+}
+
+/* 좌우 네비: 좌/우 zone(또는 버튼 자체) hover 시 노출 */
+.slideshow-root:has(.slideshow-hover.left:hover) .slideshow-nav.prev:not(:disabled):not(:hover),
+.slideshow-root:has(.slideshow-hover.right:hover) .slideshow-nav.next:not(:disabled):not(:hover) {
+    opacity: 0.5;
 }

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -142,9 +142,10 @@
     right: 0.75rem;
 }
 
-/* 좌우 네비 — 평소 숨김, 화면에 마우스를 올리면 나타남(롤오버) */
+/* 좌우 네비 — 평소 숨김(hit-test 제외). data-near-* 일 때만 위 블록에서 pointer-events 켜짐 */
 .slideshow-nav {
     opacity: 0;
+    pointer-events: none;
 }
 .slideshow-nav:not(:disabled):hover {
     opacity: 1;
@@ -165,6 +166,7 @@
     font-variant-numeric: tabular-nums;
     opacity: 0.4;
     user-select: none;
+    pointer-events: none;
 }
 
 /* 본문 명조 — App 의 data-font-family 규칙과 동일 패밀리 적용(portal 이라 직접 지정). */
@@ -196,15 +198,19 @@
 .slideshow-close,
 .slideshow-fontctl button {
     opacity: 0;
+    /* 숨김 시 hit-test 제외 — 보이지 않는 버튼이 탭/클릭/휠 가로채는 것 방지(Codex P2) */
+    pointer-events: none;
 }
-/* 마우스가 상단 근처면 상단 버튼 세트 전체가 함께 노출(개별 hover 로 opacity 안 튐) */
+/* 마우스가 상단 근처면 상단 버튼 세트 전체가 함께 노출 + 클릭 가능 */
 .slideshow-root[data-near-top] .slideshow-close,
 .slideshow-root[data-near-top] .slideshow-fontctl button {
     opacity: 0.85;
+    pointer-events: auto;
 }
 
-/* 좌/우 근처면 해당 네비 노출(버튼 자체 hover 는 위 .slideshow-nav:hover 가 1 로) */
+/* 좌/우 근처면 해당 네비 노출 + 클릭 가능(버튼 자체 hover 는 위 .slideshow-nav:hover 가 1 로) */
 .slideshow-root[data-near-left] .slideshow-nav.prev:not(:disabled),
 .slideshow-root[data-near-right] .slideshow-nav.next:not(:disabled) {
     opacity: 0.5;
+    pointer-events: auto;
 }

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -191,28 +191,20 @@
    custom-bg 는 안 씀(반투명 규칙이 Preview 와 달라짐). 컨트롤·indicator 도
    var(--text-primary)·var(--bg-active) 로 테마 변수 자동 다크. */
 
-/* ── 컨트롤 hover zone — 상단/좌/우 가장자리 근처에서만 노출(평소 숨김) ── */
-.slideshow-hover {
-    position: absolute;
-}
-.slideshow-hover.top { top: 0; left: 0; right: 0; height: 76px; }
-.slideshow-hover.left { top: 0; bottom: 0; left: 0; width: 110px; }
-.slideshow-hover.right { top: 0; bottom: 0; right: 0; width: 110px; }
-
-/* 상단(닫기·폰트/여백/다크): 평소 숨김 → 상단 zone(또는 버튼 자체) hover 시 노출 */
+/* ── 컨트롤 노출 — root 의 data-near-*(마우스 좌표 기반). 투명 hover zone 을 두지 않아
+   슬라이드 스크롤·스크롤바·링크 이벤트를 가로채지 않는다(Codex P2). ── */
 .slideshow-close,
 .slideshow-fontctl button {
     opacity: 0;
 }
-/* 상단 zone 또는 상단 버튼 어느 것에든 마우스가 있으면 세트 전체 노출 유지.
-   (zone 만 보면 버튼 위로 올라간 순간 zone hover 가 풀려 세트가 사라짐) */
-.slideshow-root:has(.slideshow-hover.top:hover, .slideshow-fontctl:hover, .slideshow-close:hover) .slideshow-close,
-.slideshow-root:has(.slideshow-hover.top:hover, .slideshow-fontctl:hover, .slideshow-close:hover) .slideshow-fontctl button {
+/* 마우스가 상단 근처면 상단 버튼 세트 전체가 함께 노출(개별 hover 로 opacity 안 튐) */
+.slideshow-root[data-near-top] .slideshow-close,
+.slideshow-root[data-near-top] .slideshow-fontctl button {
     opacity: 0.85;
 }
 
-/* 좌우 네비: 좌/우 zone(또는 버튼 자체) hover 시 노출 */
-.slideshow-root:has(.slideshow-hover.left:hover) .slideshow-nav.prev:not(:disabled):not(:hover),
-.slideshow-root:has(.slideshow-hover.right:hover) .slideshow-nav.next:not(:disabled):not(:hover) {
+/* 좌/우 근처면 해당 네비 노출(버튼 자체 hover 는 위 .slideshow-nav:hover 가 1 로) */
+.slideshow-root[data-near-left] .slideshow-nav.prev:not(:disabled),
+.slideshow-root[data-near-right] .slideshow-nav.next:not(:disabled) {
     opacity: 0.5;
 }

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -144,10 +144,11 @@
     right: 0.75rem;
 }
 
-/* 좌우 네비 — 평소 숨김(hit-test 제외). data-near-* 일 때만 위 블록에서 pointer-events 켜짐 */
+/* 좌우 네비 — 평소 숨김(hit-test·탭 순서 제외). data-near-* 일 때만 위 블록에서 켜짐 */
 .slideshow-nav {
     opacity: 0;
     pointer-events: none;
+    visibility: hidden;
 }
 .slideshow-nav:not(:disabled):hover {
     opacity: 1;
@@ -200,19 +201,23 @@
 .slideshow-close,
 .slideshow-fontctl button {
     opacity: 0;
-    /* 숨김 시 hit-test 제외 — 보이지 않는 버튼이 탭/클릭/휠 가로채는 것 방지(Codex P2) */
+    /* 숨김 시 hit-test + 탭 순서 + 포커스 모두 제외(Codex P2). visibility 가 한 번에 처리하고
+       pointer-events 는 즉시 hit-test 차단을 명시적으로 보장. */
     pointer-events: none;
+    visibility: hidden;
 }
-/* 마우스가 상단 근처면 상단 버튼 세트 전체가 함께 노출 + 클릭 가능 */
+/* 마우스가 상단 근처면 상단 버튼 세트 전체가 함께 노출 + 클릭/포커스 가능 */
 .slideshow-root[data-near-top] .slideshow-close,
 .slideshow-root[data-near-top] .slideshow-fontctl button {
     opacity: 0.85;
     pointer-events: auto;
+    visibility: visible;
 }
 
-/* 좌/우 근처면 해당 네비 노출 + 클릭 가능(버튼 자체 hover 는 위 .slideshow-nav:hover 가 1 로) */
+/* 좌/우 근처면 해당 네비 노출 + 클릭/포커스 가능(버튼 자체 hover 는 위 .slideshow-nav:hover 가 1 로) */
 .slideshow-root[data-near-left] .slideshow-nav.prev:not(:disabled),
 .slideshow-root[data-near-right] .slideshow-nav.next:not(:disabled) {
     opacity: 0.5;
     pointer-events: auto;
+    visibility: visible;
 }

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -186,10 +186,10 @@
     max-width: 960px;
 }
 
-/* 다크 모드는 별도 규칙 없이 root 의 data-theme="dark" + data-custom-bg 가
-   App.css 의 검증된 [data-theme=dark]·[data-custom-bg] 규칙(변수·표·코드·인용·marker)을
-   그대로 적용한다. 컨트롤(close/nav/fontctl)·indicator 도 var(--text-primary)·var(--bg-active)
-   를 써서 테마 변수로 자동 다크. */
+/* 다크 모드는 별도 규칙 없이 root 의 data-theme="dark"(다크 토글 ON) 가 App.css 의
+   검증된 [data-theme=dark] 변수(텍스트·배경·표·코드·인용·marker)를 그대로 적용한다.
+   custom-bg 는 안 씀(반투명 규칙이 Preview 와 달라짐). 컨트롤·indicator 도
+   var(--text-primary)·var(--bg-active) 로 테마 변수 자동 다크. */
 
 /* ── 컨트롤 hover zone — 상단/좌/우 가장자리 근처에서만 노출(평소 숨김) ── */
 .slideshow-hover {

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -110,6 +110,8 @@
     right: 4rem;
     display: flex;
     gap: 0.4rem;
+    /* wrapper 투명 박스도 hit-test 제외 — 버튼만 노출 시 auto 로 켜진다(Codex P2) */
+    pointer-events: none;
 }
 .slideshow-fontctl button {
     width: 36px;

--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -160,9 +160,10 @@ export function SlideshowView({
             className="slideshow-root"
             data-font-family={fontFamily}
             data-pad={['small', 'normal', 'large'][padLevel]}
-            // 다크는 App 의 [data-theme=dark] 변수만 재사용(Preview read-only 와 동일 컨텍스트).
-            // custom-bg 는 부여하지 않음 — 부여하면 반투명 규칙이 들어가 Preview 와 달라짐.
-            data-theme={dark ? 'dark' : 'light'}
+            // 다크 토글 ON 일 때만 dark 강제. OFF 는 속성 생략 → App 의 테마(html data-theme,
+            // bgColor luminance 반영)를 상속. light 를 강제하면 다크 bg 에 다크 텍스트로 안 보임(Codex P2).
+            // custom-bg 는 부여 안 함(반투명 규칙이 Preview 와 달라짐).
+            data-theme={dark ? 'dark' : undefined}
             role="dialog"
             aria-modal="true"
             aria-label="슬라이드쇼"

--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -86,6 +86,16 @@ export function SlideshowView({
     const [dark, setDark] = useState(() => localStorage.getItem('markmind-slideshow-dark') === '1');
     useEffect(() => { localStorage.setItem('markmind-slideshow-dark', dark ? '1' : '0'); }, [dark]);
 
+    // 컨트롤 노출 — 마우스가 상단/좌우 가장자리 근처일 때만. 투명 hover zone 을 stage 위에 두면
+    // 슬라이드 스크롤·스크롤바·링크 클릭을 가로채므로(Codex P2), 좌표로 감지해 이벤트를 안 막는다.
+    const [edge, setEdge] = useState({ top: false, left: false, right: false });
+    const onEdgeMove = useCallback((e: React.MouseEvent) => {
+        const top = e.clientY < 84;
+        const left = e.clientX < 120;
+        const right = e.clientX > window.innerWidth - 120;
+        setEdge((p) => (p.top === top && p.left === left && p.right === right ? p : { top, left, right }));
+    }, []);
+
     // 설정/내용 변경으로 슬라이드 수가 줄면 current 가 범위를 벗어날 수 있어 보정.
     useEffect(() => {
         setCurrent((c) => Math.min(c, Math.max(0, slides.length - 1)));
@@ -164,6 +174,11 @@ export function SlideshowView({
             // bgColor luminance 반영)를 상속. light 를 강제하면 다크 bg 에 다크 텍스트로 안 보임(Codex P2).
             // custom-bg 는 부여 안 함(반투명 규칙이 Preview 와 달라짐).
             data-theme={dark ? 'dark' : undefined}
+            data-near-top={edge.top ? '' : undefined}
+            data-near-left={edge.left ? '' : undefined}
+            data-near-right={edge.right ? '' : undefined}
+            onMouseMove={onEdgeMove}
+            onMouseLeave={() => setEdge({ top: false, left: false, right: false })}
             role="dialog"
             aria-modal="true"
             aria-label="슬라이드쇼"
@@ -186,11 +201,6 @@ export function SlideshowView({
                     </div>
                 ))}
             </div>
-
-            {/* 컨트롤 hover zone — 상단/좌/우 가장자리에 마우스 올릴 때만 컨트롤 노출(평소 숨김) */}
-            <div className="slideshow-hover top" aria-hidden="true" />
-            <div className="slideshow-hover left" aria-hidden="true" />
-            <div className="slideshow-hover right" aria-hidden="true" />
 
             <div className="slideshow-fontctl">
                 <button onClick={() => setDark((d) => !d)} title={dark ? '라이트 모드' : '다크 모드'} aria-label="다크 모드 토글">

--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { X, ChevronLeft, ChevronRight, AArrowDown, AArrowUp } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, AArrowDown, AArrowUp, Moon, Sun, Frame } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkFrontmatter from 'remark-frontmatter';
@@ -73,6 +73,18 @@ export function SlideshowView({
     const adjustScale = useCallback((d: number) => {
         setScale((s) => Math.round(Math.max(0.6, Math.min(2, s + d)) * 10) / 10);
     }, []);
+
+    // 여백 3단계: 0 작게 / 1 표준 / 2 크게 (상하·좌우 함께) — 클릭 시 순환. localStorage 영속.
+    const [padLevel, setPadLevel] = useState(() => {
+        const v = parseInt(localStorage.getItem('markmind-slideshow-pad') || '', 10);
+        return v >= 0 && v <= 2 ? v : 1;
+    });
+    useEffect(() => { localStorage.setItem('markmind-slideshow-pad', String(padLevel)); }, [padLevel]);
+    const cyclePad = useCallback(() => setPadLevel((p) => (p + 1) % 3), []);
+
+    // 다크 모드(발표 배경 반전) — localStorage 영속.
+    const [dark, setDark] = useState(() => localStorage.getItem('markmind-slideshow-dark') === '1');
+    useEffect(() => { localStorage.setItem('markmind-slideshow-dark', dark ? '1' : '0'); }, [dark]);
 
     // 설정/내용 변경으로 슬라이드 수가 줄면 current 가 범위를 벗어날 수 있어 보정.
     useEffect(() => {
@@ -147,12 +159,17 @@ export function SlideshowView({
         <div
             className="slideshow-root"
             data-font-family={fontFamily}
+            data-pad={['small', 'normal', 'large'][padLevel]}
+            // 다크는 App 의 [data-theme=dark] 변수만 재사용(Preview read-only 와 동일 컨텍스트).
+            // custom-bg 는 부여하지 않음 — 부여하면 반투명 규칙이 들어가 Preview 와 달라짐.
+            data-theme={dark ? 'dark' : 'light'}
             role="dialog"
             aria-modal="true"
             aria-label="슬라이드쇼"
             style={{
                 '--slideshow-scale': String(scale),
-                ...(bgColor ? { '--slideshow-bg': bgColor } : {}),
+                // 라이트만 사용자 bg. 다크는 --preview-bg(#222) 가 배경 처리.
+                ...(bgColor && !dark ? { '--slideshow-bg': bgColor } : {}),
             } as React.CSSProperties}
         >
             <div className="slideshow-stage">
@@ -169,7 +186,18 @@ export function SlideshowView({
                 ))}
             </div>
 
+            {/* 컨트롤 hover zone — 상단/좌/우 가장자리에 마우스 올릴 때만 컨트롤 노출(평소 숨김) */}
+            <div className="slideshow-hover top" aria-hidden="true" />
+            <div className="slideshow-hover left" aria-hidden="true" />
+            <div className="slideshow-hover right" aria-hidden="true" />
+
             <div className="slideshow-fontctl">
+                <button onClick={() => setDark((d) => !d)} title={dark ? '라이트 모드' : '다크 모드'} aria-label="다크 모드 토글">
+                    {dark ? <Sun size={18} strokeWidth={1.75} /> : <Moon size={18} strokeWidth={1.75} />}
+                </button>
+                <button onClick={cyclePad} title={`여백: ${['작게', '표준', '크게'][padLevel]} (클릭하여 변경)`} aria-label="여백 조절">
+                    <Frame size={18} strokeWidth={1.75} />
+                </button>
                 <button onClick={() => adjustScale(-0.1)} title="글자 작게 (−)" aria-label="글자 작게">
                     <AArrowDown size={18} strokeWidth={1.75} />
                 </button>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -558,7 +558,7 @@ export function Toolbar({
                         <span>자동 생성</span>
                     </button>
                 )}
-                <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘⇧I)">
+                <button className={`toolbar-text-btn ai-agent${aiPanelVisible ? ' active' : ''}`} onClick={onToggleAI} title="AI 에이전트 (⌘L)">
                     <Bot size={14} strokeWidth={1.5} />
                     <span>AI 에이전트</span>
                 </button>


### PR DESCRIPTION
## Summary
뷰·슬라이드쇼 UX 개선 3건: (1) Gantt/Kanban 에서 AI 사이드바가 안 보이거나 잘리던 레이아웃 버그 수정, (2) AI 에이전트 사이드바 토글 단축키 `⌘L` 추가, (3) Slideshow 여백 3단계·다크모드·컨트롤 자동숨김.

## Changes
- **fix(layout)** — `.split-pane` 에 `min-width:0` 이 없어 넓은 콘텐츠(Gantt SVG·Kanban grid)가 형제 `.ai-panel` 을 밀어내 `main-content overflow:hidden` 으로 잘리던 문제. split-pane `min-width:0` + ai-panel `flex-shrink:0`(340px 보장). Kanban 컬럼은 고정폭 260px 로 바꿔 사이드바 토글 시 카드 폭이 흔들리지 않게.
- **feat(⌘L)** — 툴팁에 표기만 있고 키 핸들러가 없던 AI 사이드바 토글을 `⌘L` 로 구현(Cursor 등 AI 채팅 사이드바 관습), 툴팁 갱신.
- **feat(slideshow)** — 여백 작게/표준/크게 3단계(상하 `padding-block` + 좌우 콘텐츠 `max-width`, 1버튼 순환) · 다크모드는 App 의 `[data-theme=dark]` 변수를 재사용(Rich Text/Preview 와 동일, 표·코드·인용·marker 검증된 규칙) · 컨트롤은 상단/좌우 가장자리 hover zone(`:has`)으로 평소 숨김·근처에서만 노출(상단 버튼 함께).

## Test plan
- [x] tsc 0, dev(HMR) 동작 확인
- [ ] Gantt/Kanban 뷰 + AI 사이드바 온전 표시, Kanban 카드 폭 고정(260px)
- [ ] `⌘L` 로 AI 사이드바 열기/닫기
- [ ] Slideshow: 여백 3단계, 다크모드 표/bullet 색이 Preview 와 동일, 컨트롤 가장자리 hover 시 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)