### PR TITLE
[codex] fix(editor): preserve rich text focus and menu dialogs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/App.css
+++ b/src/App.css
@@ -1806,7 +1806,7 @@ body.is-resizing .split-pane {
   height: 100%;
   overflow-y: auto;
   background: var(--preview-bg);
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
   position: relative;
   padding: 32px 40px;
 }
@@ -1992,6 +1992,43 @@ body.is-resizing .split-pane {
 .tiptap-rich ol li::marker {
   font-size: 1.25em;
   color: var(--text-secondary);
+}
+
+/* Rich Text 리스트는 문단 rhythm 보다 촘촘하게. TipTap 이 li 안에 p 를 만들기 때문에
+   .markdown-body p margin 이 겹치지 않도록 편집 영역에서만 좁힌다. */
+.tiptap-rich ul:not([data-type="taskList"]),
+.tiptap-rich ol {
+  margin-top: 0.4em;
+  margin-bottom: 0.7em;
+}
+
+.tiptap-rich ul:not([data-type="taskList"]) li,
+.tiptap-rich ol li {
+  line-height: min(var(--md-line-height, 1.8), 1.55);
+  margin: 0.12em 0;
+}
+
+.tiptap-rich ul:not([data-type="taskList"]) li > p,
+.tiptap-rich ol li > p {
+  margin: 0.1em 0;
+}
+
+.tiptap-rich ul:not([data-type="taskList"]) li > p:first-child,
+.tiptap-rich ol li > p:first-child {
+  margin-top: 0;
+}
+
+.tiptap-rich ul:not([data-type="taskList"]) li > p:last-child,
+.tiptap-rich ol li > p:last-child {
+  margin-bottom: 0;
+}
+
+.tiptap-rich ul:not([data-type="taskList"]) li > ul,
+.tiptap-rich ul:not([data-type="taskList"]) li > ol,
+.tiptap-rich ol li > ul,
+.tiptap-rich ol li > ol {
+  margin-top: 0.15em;
+  margin-bottom: 0.15em;
 }
 
 /* === Background color picker === */
@@ -2317,7 +2354,8 @@ body.is-resizing .split-pane {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  margin: 4px 0;
+  line-height: min(var(--md-line-height, 1.8), 1.55);
+  margin: 2px 0;
 }
 .tiptap-rich ul[data-type="taskList"] li > label {
   flex-shrink: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,15 +345,58 @@ function App() {
   // viewMode 전환 시 scroll 위치 보존 — Markdown(CodeMirror) ↔ Rich Text(.preview-wrapper) ↔ Split
   const scrollRatioRef = useRef<number>(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const editorRef = useRef<EditorHandle>(null);
-  const previewRef = useRef<PreviewHandle>(null); // Rich Text 이미지 삽입 라우팅(#56)
+  const editorSoloRef = useRef<EditorHandle>(null);
+  const editorLeftRef = useRef<EditorHandle>(null);
+  const editorRightRef = useRef<EditorHandle>(null);
+  const previewSoloRef = useRef<PreviewHandle>(null);
+  const previewLeftRef = useRef<PreviewHandle>(null);
+  const previewRightRef = useRef<PreviewHandle>(null); // Rich Text 이미지 삽입 라우팅(#56)
   const pendingFocusOffsetRef = useRef<number | null>(null);
 
+  const editorRefForSide = useCallback((side: 'left' | 'right' | 'solo') => {
+    if (side === 'left') return editorLeftRef;
+    if (side === 'right') return editorRightRef;
+    return editorSoloRef;
+  }, []);
+
+  const previewRefForSide = useCallback((side: 'left' | 'right' | 'solo') => {
+    if (side === 'left') return previewLeftRef;
+    if (side === 'right') return previewRightRef;
+    return previewSoloRef;
+  }, []);
+
+  const activeEditorHandle = useCallback((): EditorHandle | null => {
+    if (viewMode === 'split') {
+      return (activePane === 'left' ? editorLeftRef : editorRightRef).current;
+    }
+    return editorSoloRef.current;
+  }, [activePane, viewMode]);
+
+  const activePreviewHandle = useCallback((): PreviewHandle | null => {
+    if (viewMode === 'split') {
+      return (activePane === 'left' ? previewLeftRef : previewRightRef).current;
+    }
+    return previewSoloRef.current;
+  }, [activePane, viewMode]);
+
+  const visibleEditorHandle = useCallback((): EditorHandle | null => (
+    activeEditorHandle()
+    ?? editorLeftRef.current
+    ?? editorRightRef.current
+    ?? editorSoloRef.current
+  ), [activeEditorHandle]);
+
+  const clearAllEditorSearch = useCallback(() => {
+    editorSoloRef.current?.searchClear();
+    editorLeftRef.current?.searchClear();
+    editorRightRef.current?.searchClear();
+  }, []);
+
   const captureTextFocusOffset = useCallback((): number | null => {
-    if (activeView === 'editor') return editorRef.current?.getCursorOffset() ?? null;
-    if (activeView === 'preview') return previewRef.current?.getMarkdownOffset() ?? null;
+    if (activeView === 'editor') return activeEditorHandle()?.getCursorOffset() ?? null;
+    if (activeView === 'preview') return activePreviewHandle()?.getMarkdownOffset() ?? null;
     return null;
-  }, [activeView]);
+  }, [activeEditorHandle, activePreviewHandle, activeView]);
 
   const setViewModePreservingFocus = useCallback((next: ViewMode) => {
     if (next !== viewMode) {
@@ -376,8 +419,8 @@ function App() {
       if (cancelled) return;
       const shouldScroll = settledFrames === 0;
       const ok = activeView === 'editor'
-        ? editorRef.current?.focusAtOffset(offset, shouldScroll)
-        : previewRef.current?.focusAtMarkdownOffset(offset, shouldScroll);
+        ? activeEditorHandle()?.focusAtOffset(offset, shouldScroll)
+        : activePreviewHandle()?.focusAtMarkdownOffset(offset, shouldScroll);
       if (ok) {
         settledFrames += 1;
         if (settledFrames >= 3) {
@@ -1295,6 +1338,12 @@ function App() {
   useEffect(() => {
     activeViewRef.current = activeView;
   }, [activeView]);
+  const viewModeRef = useRef(viewMode);
+  const activePaneRef = useRef(activePane);
+  useEffect(() => {
+    viewModeRef.current = viewMode;
+    activePaneRef.current = activePane;
+  }, [activePane, viewMode]);
 
   // 화자 정리(rename_speakers) 후 리로드 판정에 최신 열린 파일 경로를 stale 없이 참조.
   const filePathRef = useRef(filePath);
@@ -1377,11 +1426,17 @@ function App() {
           // 표시는 #55(asset://), 실제 assets/ 복사·상대경로 치환은 저장 시 flush 가 처리.
           const insertImageAbs = (absPath: string) => {
             if (activeViewRef.current === 'preview') {
-              if (cx != null && cy != null) previewRef.current?.insertImageAtCoords(absPath, cx, cy);
-              else previewRef.current?.insertImageMarkdown(absPath);
+              const preview = viewModeRef.current === 'split'
+                ? (activePaneRef.current === 'left' ? previewLeftRef.current : previewRightRef.current)
+                : previewSoloRef.current;
+              if (cx != null && cy != null) preview?.insertImageAtCoords(absPath, cx, cy);
+              else preview?.insertImageMarkdown(absPath);
             } else {
-              if (cx != null && cy != null) editorRef.current?.insertAtCoords(`\n![](${absPath})\n`, cx, cy);
-              else editorRef.current?.insertAtCursor(`\n![](${absPath})\n`);
+              const editor = viewModeRef.current === 'split'
+                ? (activePaneRef.current === 'left' ? editorLeftRef.current : editorRightRef.current)
+                : editorSoloRef.current;
+              if (cx != null && cy != null) editor?.insertAtCoords(`\n![](${absPath})\n`, cx, cy);
+              else editor?.insertAtCursor(`\n![](${absPath})\n`);
             }
           };
 
@@ -1505,21 +1560,21 @@ function App() {
   const hasEditorPane = viewMode === 'editor' || (viewMode === 'split' && (splitLeft === 'editor' || splitRight === 'editor'));
   const handleJumpToSource = useCallback((line: number) => {
     if (hasEditorPane) {
-      editorRef.current?.scrollToLine(line);
+      visibleEditorHandle()?.scrollToLine(line);
     } else {
       pendingScrollLineRef.current = line;
       setViewMode('editor');
     }
-  }, [hasEditorPane]);
+  }, [hasEditorPane, visibleEditorHandle]);
 
   useEffect(() => {
     if (hasEditorPane && pendingScrollLineRef.current != null) {
       const line = pendingScrollLineRef.current;
       pendingScrollLineRef.current = null;
-      const t = setTimeout(() => editorRef.current?.scrollToLine(line), 120);
+      const t = setTimeout(() => visibleEditorHandle()?.scrollToLine(line), 120);
       return () => clearTimeout(t);
     }
-  }, [hasEditorPane]);
+  }, [hasEditorPane, visibleEditorHandle]);
 
   // AIPanel "실행" 클릭 → 모드에 따라 분기
   // - meeting-notes: converter.runNotes (새 .md 생성)
@@ -1602,11 +1657,11 @@ function App() {
       const { writeTempImage, extFromMime } = await import('./lib/imageAttach');
       const bytes = new Uint8Array(await file.arrayBuffer());
       const path = await writeTempImage(bytes, extFromMime(file.type));
-      editorRef.current?.insertAtCursor(`\n![](${path})\n`);
+      activeEditorHandle()?.insertAtCursor(`\n![](${path})\n`);
     } catch (err) {
       console.error('[App] 클립보드 이미지 첨부 실패:', err);
     }
-  }, []);
+  }, [activeEditorHandle]);
 
   // AI 이미지 생성 결과를 현재 문서에 삽입(ImageGenPanel "문서에 삽입" 버튼).
   // base64 data URL → temp 파일 → 활성 에디터(viewMode 분기)에 `![](temp경로)`.
@@ -1620,12 +1675,12 @@ function App() {
       const bytes = new Uint8Array(raw.length);
       for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
       const path = await writeTempImage(bytes, extFromMime(mime));
-      if (activeViewRef.current === 'preview') previewRef.current?.insertImageMarkdown(path);
-      else editorRef.current?.insertAtCursor(`\n![](${path})\n`);
+      if (activeViewRef.current === 'preview') activePreviewHandle()?.insertImageMarkdown(path);
+      else activeEditorHandle()?.insertAtCursor(`\n![](${path})\n`);
     } catch (err) {
       console.error('[App] 생성 이미지 삽입 실패:', err);
     }
-  }, []);
+  }, [activeEditorHandle, activePreviewHandle]);
 
   // MCP propose_edit 수락/거절 결과를 백엔드 tool 에 ack.
   const ackMcpProposal = useCallback((requestId: string, accepted: boolean, charCount: number | null) => {
@@ -1686,7 +1741,7 @@ function App() {
   const handleOutlineClick = useCallback((id: string, line: number) => {
     if (activeView !== 'preview') {
       // editor 패인이 active(또는 solo): heading 라인으로 CodeMirror 스크롤
-      editorRef.current?.scrollToLine(line);
+      visibleEditorHandle()?.scrollToLine(line);
     } else {
       // Preview mode: scroll the rendered heading into view
       const previewEl = document.querySelector('.preview-wrapper');
@@ -1707,7 +1762,7 @@ function App() {
         }
       }
     }
-  }, [activeView]);
+  }, [activeView, visibleEditorHandle]);
 
   const handleFloatingAction = useCallback((mode: AIMode, text: string) => {
     // Open AI panel, set mode, and run with selected text
@@ -1863,9 +1918,9 @@ function App() {
     setSearchShowReplace(false);
     setSearchMatchCount(0);
     setSearchCurrentIndex(-1);
-    editorRef.current?.searchClear();
+    clearAllEditorSearch();
     window.dispatchEvent(new Event('markmind:rich-search-clear'));
-  }, [viewMode, splitLeft, splitRight]);
+  }, [viewMode, splitLeft, splitRight, clearAllEditorSearch]);
 
   // viewMode 전환 시 scroll 위치 보존 (Markdown ↔ Rich Text).
   // 이전 모드의 scroll 비율을 기억해 새 모드의 같은 비율 위치로 자동 이동.
@@ -1938,7 +1993,7 @@ function App() {
 
   // Search toggle
   // ─── 통일 검색 (Markdown/CodeMirror + Rich Text/Tiptap 공용 SearchBar) ───
-  // 엔진 라우팅: 편집/split → editorRef 프로그램 검색(동기 {count,index}), 프리뷰 →
+  // 엔진 라우팅: 편집/split → active CodeMirror 프로그램 검색(동기 {count,index}), 프리뷰 →
   // Tiptap window 이벤트(카운트는 markmind:rich-search-count 로 비동기 회신).
   const applySearchInfo = useCallback((info?: { count: number; index: number } | null) => {
     if (!info) return;
@@ -1983,18 +2038,19 @@ function App() {
     if (activeView === 'preview') {
       window.dispatchEvent(new CustomEvent('markmind:rich-search', { detail: { query } }));
     } else {
-      applySearchInfo(editorRef.current?.searchSetQuery(query, replace));
+      applySearchInfo(activeEditorHandle()?.searchSetQuery(query, replace));
       // split 의 미러(정적 프리뷰) 하이라이트는 아래 effect 가 CSS Highlight API 로 처리.
     }
-  }, [activeView, applySearchInfo]);
+  }, [activeEditorHandle, activeView, applySearchInfo]);
 
   const navigateMatch = useCallback((delta: number) => {
     if (activeView === 'preview') {
       window.dispatchEvent(new Event(delta > 0 ? 'markmind:rich-search-next' : 'markmind:rich-search-prev'));
     } else {
-      applySearchInfo(delta > 0 ? editorRef.current?.searchNext() : editorRef.current?.searchPrev());
+      const editor = activeEditorHandle();
+      applySearchInfo(delta > 0 ? editor?.searchNext() : editor?.searchPrev());
     }
-  }, [activeView, applySearchInfo]);
+  }, [activeEditorHandle, activeView, applySearchInfo]);
 
   const replaceMatch = useCallback((all: boolean) => {
     if (activeView === 'preview') {
@@ -2002,15 +2058,15 @@ function App() {
       window.dispatchEvent(new CustomEvent(ev, { detail: { replace: searchReplace } }));
     } else {
       applySearchInfo(all
-        ? editorRef.current?.searchReplaceAll(searchReplace)
-        : editorRef.current?.searchReplaceCurrent(searchReplace));
+        ? activeEditorHandle()?.searchReplaceAll(searchReplace)
+        : activeEditorHandle()?.searchReplaceCurrent(searchReplace));
       // split: 소스 변경 → content 갱신 → 아래 effect 가 프리뷰 하이라이트 재계산.
     }
-  }, [activeView, applySearchInfo, searchReplace]);
+  }, [activeEditorHandle, activeView, applySearchInfo, searchReplace]);
 
   const closeSearch = useCallback(() => {
     // 양 엔진 모두 해제(미마운트 쪽은 no-op) — split 의 오른쪽 하이라이트까지 확실히 정리.
-    editorRef.current?.searchClear();
+    clearAllEditorSearch();
     window.dispatchEvent(new Event('markmind:rich-search-clear'));
     clearPreviewHighlight();
     setSearchVisible(false);
@@ -2019,7 +2075,7 @@ function App() {
     setSearchShowReplace(false);
     setSearchMatchCount(0);
     setSearchCurrentIndex(-1);
-  }, [clearPreviewHighlight]);
+  }, [clearAllEditorSearch, clearPreviewHighlight]);
 
   const toggleSearch = useCallback(() => {
     if (searchVisible) {
@@ -2229,7 +2285,7 @@ function App() {
             if (activeView === 'editor') {
               // CodeMirror: undo content 를 doc 에 직접 적용(+변경 지점 커서). react-codemirror
               // 의 value sync 가 커서를 0 으로 리셋하기 전에 doc 를 맞춰 그 sync 를 skip 시킨다.
-              editorRef.current?.applyContentWithCursor(r.content, r.cursorOffset);
+              activeEditorHandle()?.applyContentWithCursor(r.content, r.cursorOffset);
             } else if (ae && typeof ae.focus === 'function') {
               // preview(Tiptap 내부에서 커서를 클램프 보존)·비주얼 뷰: 포커스만 복원.
               requestAnimationFrame(() => {
@@ -2250,7 +2306,7 @@ function App() {
     saveFile, saveFileAs, handleOpenFile, newFile, toggleSearch,
     handleFontSizeChange, resetFontSize, recentPanelVisible,
     searchVisible, activeView, handleToggleAI, settingsVisible,
-    undo, redo, setViewModePreservingFocus,
+    undo, redo, setViewModePreservingFocus, activeEditorHandle,
   ]);
 
   // Split pane drag
@@ -2391,7 +2447,7 @@ function App() {
   };
 
   // editor 패인 콘텐츠 — 편집 가능 + AI diff 중이면 InlineDiffView, 아니면 Editor(미러는 read-only).
-  const renderEditorPane = (editable: boolean) => {
+  const renderEditorPane = (editable: boolean, side: 'left' | 'right' | 'solo') => {
     if (editable && ai.response && !ai.isLoading) {
       return (
         <InlineDiffView
@@ -2445,11 +2501,9 @@ function App() {
         />
       );
     }
-    // ref 는 editable 무관하게 editor 뷰 패인에 연결 — jump/검색/삽입이 active 여부와 상관없이 동작.
-    // (같은 뷰가 양쪽이면 마지막 mount 가 ref 를 차지하나 content 가 동일해 무해.)
     return (
       <Editor
-        ref={editorRef}
+        ref={editorRefForSide(side)}
         content={content}
         onChange={editable ? updateContent : () => {}}
         theme={theme}
@@ -2468,11 +2522,11 @@ function App() {
     const editable = paneEditable(view, side);
     switch (view) {
       case 'editor':
-        return <>{mcpBanner}{renderEditorPane(editable)}</>;
+        return <>{mcpBanner}{renderEditorPane(editable, side)}</>;
       case 'preview':
         return (
           <Preview
-            ref={previewRef}
+            ref={previewRefForSide(side)}
             content={content}
             fontSize={fontSize}
             onChange={editable ? updateContent : undefined}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -347,6 +347,55 @@ function App() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const editorRef = useRef<EditorHandle>(null);
   const previewRef = useRef<PreviewHandle>(null); // Rich Text 이미지 삽입 라우팅(#56)
+  const pendingFocusOffsetRef = useRef<number | null>(null);
+
+  const captureTextFocusOffset = useCallback((): number | null => {
+    if (activeView === 'editor') return editorRef.current?.getCursorOffset() ?? null;
+    if (activeView === 'preview') return previewRef.current?.getMarkdownOffset() ?? null;
+    return null;
+  }, [activeView]);
+
+  const setViewModePreservingFocus = useCallback((next: ViewMode) => {
+    if (next !== viewMode) {
+      const offset = captureTextFocusOffset();
+      if (offset != null) pendingFocusOffsetRef.current = offset;
+    }
+    setViewMode(next);
+  }, [captureTextFocusOffset, viewMode]);
+
+  useEffect(() => {
+    const offset = pendingFocusOffsetRef.current;
+    if (offset == null) return;
+    if (activeView !== 'editor' && activeView !== 'preview') return;
+
+    let cancelled = false;
+    let raf = 0;
+    let attempts = 0;
+    let settledFrames = 0;
+    const restore = () => {
+      if (cancelled) return;
+      const shouldScroll = settledFrames === 0;
+      const ok = activeView === 'editor'
+        ? editorRef.current?.focusAtOffset(offset, shouldScroll)
+        : previewRef.current?.focusAtMarkdownOffset(offset, shouldScroll);
+      if (ok) {
+        settledFrames += 1;
+        if (settledFrames >= 3) {
+          pendingFocusOffsetRef.current = null;
+          return;
+        }
+      } else {
+        settledFrames = 0;
+      }
+      attempts += 1;
+      if (attempts < 12) raf = requestAnimationFrame(restore);
+    };
+    raf = requestAnimationFrame(restore);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+    };
+  }, [activeView, viewMode, splitLeft, splitRight, activePane]);
 
   // PDF export — 옵션 B1: WKWebView.createPDFWithConfiguration 으로 dialog 없이
   // PDF 생성 + tauri-plugin-dialog 의 save() 로 사용자 저장 위치 지정.
@@ -1833,18 +1882,19 @@ function App() {
 
     // mount 직후 — 이전에 저장된 ratio 로 새 element 의 scrollTop 복원.
     // ResizeObserver 로 scrollHeight 변화 감지 → 안정될 때까지 자동 재시도 (매직 timeout 제거).
+    const shouldRestoreScrollRatio = pendingFocusOffsetRef.current == null;
     const restore = () => {
       const el = scrollEl();
       if (!el) return;
       const max = el.scrollHeight - el.clientHeight;
       if (max > 0) el.scrollTop = Math.round(max * scrollRatioRef.current);
     };
-    restore();
+    if (shouldRestoreScrollRatio) restore();
 
     const el = scrollEl();
     let restored = false;
     let ro: ResizeObserver | null = null;
-    if (el && typeof ResizeObserver !== 'undefined') {
+    if (shouldRestoreScrollRatio && el && typeof ResizeObserver !== 'undefined') {
       ro = new ResizeObserver(() => {
         if (restored) return;
         const max = el.scrollHeight - el.clientHeight;
@@ -2113,27 +2163,27 @@ function App() {
             break;
           case '1':
             e.preventDefault();
-            setViewMode('editor');
+            setViewModePreservingFocus('editor');
             break;
           case '2':
             e.preventDefault();
-            setViewMode('preview');
+            setViewModePreservingFocus('preview');
             break;
           case '3':
             e.preventDefault();
-            setViewMode('mindmap');
+            setViewModePreservingFocus('mindmap');
             break;
           case '4':
             e.preventDefault();
-            setViewMode('flowchart');
+            setViewModePreservingFocus('flowchart');
             break;
           case '5':
             e.preventDefault();
-            setViewMode('gantt');
+            setViewModePreservingFocus('gantt');
             break;
           case '6':
             e.preventDefault();
-            setViewMode('kanban');
+            setViewModePreservingFocus('kanban');
             break;
           case '7':
             e.preventDefault();
@@ -2141,11 +2191,11 @@ function App() {
             break;
           case '8':
             e.preventDefault();
-            setViewMode('split');
+            setViewModePreservingFocus('split');
             break;
           case '9':
             e.preventDefault();
-            setViewMode('slideshow');
+            setViewModePreservingFocus('slideshow');
             break;
           case '=':
           case '+':
@@ -2200,7 +2250,7 @@ function App() {
     saveFile, saveFileAs, handleOpenFile, newFile, toggleSearch,
     handleFontSizeChange, resetFontSize, recentPanelVisible,
     searchVisible, activeView, handleToggleAI, settingsVisible,
-    undo, redo,
+    undo, redo, setViewModePreservingFocus,
   ]);
 
   // Split pane drag
@@ -2289,7 +2339,7 @@ function App() {
     onOpenFromDrive: () => setDriveBrowserMode('open'),
     onSaveToDrive: () => setDriveBrowserMode('save'),
     onOpenRecent: handleOpenRecentByPath,
-    onViewModeChange: setViewMode,
+    onViewModeChange: setViewModePreservingFocus,
     onUndo: undo,
     onRedo: redo,
   });
@@ -2499,7 +2549,7 @@ function App() {
       <Toolbar
         viewMode={viewMode}
         outlineVisible={outlineVisible}
-        onViewModeChange={setViewMode}
+        onViewModeChange={setViewModePreservingFocus}
         onNewFile={newFile}
         onOpenFile={handleOpenFile}
         onSaveFile={saveFile}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -65,6 +65,10 @@ export interface EditorHandle {
      *  우리가 먼저 doc 를 새 content 로 바꾸면 value prop==doc 이라 그 sync 가 skip 된다.
      *  (uiwjs/react-codemirror #199 / #694 알려진 이슈) */
     applyContentWithCursor: (content: string, offset: number) => void;
+    /** 현재 커서의 마크다운 source offset. */
+    getCursorOffset: () => number | null;
+    /** 마크다운 source offset 으로 커서와 스크롤을 복원. */
+    focusAtOffset: (offset: number, scroll?: boolean) => boolean;
 }
 
 const lightTheme = EditorView.theme({
@@ -308,6 +312,21 @@ export const Editor = forwardRef<EditorHandle, EditorProps>(
                     effects: EditorView.scrollIntoView(pos, { y: 'center' }),
                 });
                 view.focus();
+            },
+            getCursorOffset: () => {
+                const view = cmRef.current?.view;
+                return view?.state.selection.main.head ?? null;
+            },
+            focusAtOffset: (offset: number, scroll = true) => {
+                const view = cmRef.current?.view;
+                if (!view) return false;
+                const pos = Math.min(Math.max(0, offset), view.state.doc.length);
+                view.dispatch({
+                    selection: { anchor: pos },
+                    effects: scroll ? EditorView.scrollIntoView(pos, { y: 'center' }) : [],
+                });
+                view.focus();
+                return true;
             },
         }), []);
 

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -288,13 +288,14 @@ interface FrontmatterParts {
     fields: { key: string; value: string }[];
     body: string;
     rawFrontmatter: string; // 편집 시 그대로 다시 붙이기 위해
+    sourceFrontmatterLength: number; // 커서 offset 계산용 원문 prefix 길이
 }
 
 function splitFrontmatter(md: string): FrontmatterParts {
-    if (!md.startsWith('---')) return { fields: [], body: md, rawFrontmatter: '' };
+    if (!md.startsWith('---')) return { fields: [], body: md, rawFrontmatter: '', sourceFrontmatterLength: 0 };
     const after = md.slice(3);
     const endIdx = after.indexOf('\n---');
-    if (endIdx === -1) return { fields: [], body: md, rawFrontmatter: '' };
+    if (endIdx === -1) return { fields: [], body: md, rawFrontmatter: '', sourceFrontmatterLength: 0 };
     const raw = after.slice(0, endIdx).trim();
     const body = after.slice(endIdx + 4).replace(/^\r?\n/, '');
     const rawFrontmatter = `---\n${raw}\n---\n`;
@@ -313,7 +314,7 @@ function splitFrontmatter(md: string): FrontmatterParts {
         }
         fields.push({ key, value });
     }
-    return { fields, body, rawFrontmatter };
+    return { fields, body, rawFrontmatter, sourceFrontmatterLength: md.length - body.length };
 }
 
 // ─── HTML 테이블 블록 (병합 셀 — MarkdownTable 확장이 직렬화) 분리 ───
@@ -1266,6 +1267,7 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     const richEditorRef = useRef<Editor | null>(null);
     const bodyRef = useRef('');
     const rawFrontmatterRef = useRef('');
+    const sourceFrontmatterLengthRef = useRef(0);
     useImperativeHandle(ref, () => ({
         insertImageMarkdown: (relPath: string) => {
             richEditorRef.current?.chain().focus().setImage({ src: relPath }).run();
@@ -1286,12 +1288,12 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             const plainOffset = richVisibleOffsetAt(editor, editor.state.selection.from);
             const current: string = editor.storage.markdown?.getMarkdown() ?? bodyRef.current;
             const bodyMarkdown = normalizeSerializedMarkdown(stripDisplayHelpers(current));
-            return rawFrontmatterRef.current.length + visibleOffsetToMarkdownOffset(bodyMarkdown, plainOffset);
+            return sourceFrontmatterLengthRef.current + visibleOffsetToMarkdownOffset(bodyMarkdown, plainOffset);
         },
         focusAtMarkdownOffset: (offset: number, scroll = true) => {
             const editor = richEditorRef.current;
             if (!editor) return false;
-            const bodyOffset = Math.max(0, offset - rawFrontmatterRef.current.length);
+            const bodyOffset = Math.max(0, offset - sourceFrontmatterLengthRef.current);
             const visibleOffset = markdownOffsetToVisibleOffset(bodyRef.current, bodyOffset);
             return focusRichEditorAtVisibleOffset(editor, visibleOffset, scroll);
         },
@@ -1301,16 +1303,18 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
         () => (filePath ? filePath.slice(0, filePath.lastIndexOf('/')) : null),
         [filePath],
     );
-    const { fields, body, rawFrontmatter } = useMemo(() => {
+    const { fields, body, rawFrontmatter, sourceFrontmatterLength } = useMemo(() => {
         const split = splitFrontmatter(content);
         return {
             fields: split.fields,
             body: split.body,
             rawFrontmatter: split.rawFrontmatter,
+            sourceFrontmatterLength: split.sourceFrontmatterLength,
         };
     }, [content]);
     bodyRef.current = body;
     rawFrontmatterRef.current = rawFrontmatter;
+    sourceFrontmatterLengthRef.current = sourceFrontmatterLength;
 
     // read-only 뷰 표시용 — 흐름도 데이터(markmind-flow JSON) 는 토글 off 시 숨긴다(표시만,
     // 원본은 보존). 편집(⌘3 Rich Text) 경로는 strip 하면 저장 시 블록이 사라지므로 건드리지 않는다.

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -29,7 +29,7 @@ import { TableHeader } from '@tiptap/extension-table-header';
 import { Markdown } from 'tiptap-markdown';
 import { SearchAndReplace } from '@sereneinserenade/tiptap-search-and-replace';
 import { Typography } from '@tiptap/extension-typography';
-import { TextSelection, Plugin, PluginKey } from '@tiptap/pm/state';
+import { TextSelection, Plugin, PluginKey, type Selection } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import { InlineCheckbox } from '../extensions/InlineCheckbox';
@@ -38,6 +38,7 @@ import { createImageInline } from '../extensions/ImageInline';
 import { resolveImageSrc } from '../lib/imageSrc';
 import { removeFlowchartBlock, hasFlowchartBlock } from '../lib/flowchartBlock';
 import { quoteLines } from '../lib/quoteMatch';
+import { markdownOffsetToVisibleOffset, visibleOffsetToMarkdownOffset } from '../lib/markdownCursor';
 import { TableTools } from './TableTools';
 import {
     Bold, Italic, Strikethrough, Code,
@@ -791,6 +792,115 @@ function buildQuoteDecos(doc: PMNode, texts: string[]): DecorationSet {
     });
     return DecorationSet.create(doc, decos);
 }
+
+function richLeafText(leaf: PMNode): string {
+    return leaf.type.name === 'hardBreak' ? '\n' : '';
+}
+
+function richTextBetween(doc: PMNode, from: number, to: number): string {
+    return doc.textBetween(from, to, '\n', richLeafText).replace(/\u200b/g, '');
+}
+
+function richVisibleOffsetAt(editor: Editor, pos: number): number {
+    const size = editor.state.doc.content.size;
+    const clamped = Math.max(0, Math.min(pos, size));
+    return richTextBetween(editor.state.doc, 0, clamped).length;
+}
+
+function richPosFromVisibleOffset(editor: Editor, visibleOffset: number): number {
+    const target = Math.max(0, visibleOffset);
+    const doc = editor.state.doc;
+    let visible = 0;
+    let firstTextBlock = true;
+    let found: number | null = null;
+    let fallback = doc.content.size;
+
+    doc.descendants((node, pos) => {
+        if (found != null) return false;
+
+        const leafText = node.isLeaf ? richLeafText(node).replace(/\u200b/g, '') : '';
+        if (node.isBlock && ((node.isLeaf && leafText.length > 0) || node.isTextblock)) {
+            if (firstTextBlock) {
+                firstTextBlock = false;
+            } else if (target <= visible + 1) {
+                found = Math.min(pos + (node.isTextblock ? 1 : 0), doc.content.size);
+                return false;
+            } else {
+                visible += 1;
+            }
+        }
+
+        if (node.isText && node.text) {
+            const clean = node.text.replace(/\u200b/g, '');
+            if (target <= visible + clean.length) {
+                found = pos + cleanToRaw(node.text, target - visible);
+                return false;
+            }
+            visible += clean.length;
+            fallback = pos + node.text.length;
+            return false;
+        }
+
+        if (node.isLeaf && leafText.length > 0) {
+            if (target <= visible + leafText.length) {
+                found = Math.min(pos + node.nodeSize, doc.content.size);
+                return false;
+            }
+            visible += leafText.length;
+            fallback = Math.min(pos + node.nodeSize, doc.content.size);
+            return false;
+        }
+
+        if (node.isTextblock && node.content.size === 0) {
+            fallback = Math.min(pos + 1, doc.content.size);
+        }
+
+        return undefined;
+    });
+
+    return Math.max(0, Math.min(found ?? fallback, doc.content.size));
+}
+
+function focusRichEditorAtVisibleOffset(editor: Editor, visibleOffset: number, scroll = true): boolean {
+    const size = editor.state.doc.content.size;
+    const pos = Math.max(0, Math.min(richPosFromVisibleOffset(editor, visibleOffset), size));
+    const $pos = editor.state.doc.resolve(pos);
+    let selection: Selection;
+    try {
+        selection = TextSelection.create(editor.state.doc, pos);
+    } catch {
+        selection = TextSelection.near($pos, 1);
+    }
+    editor.view.dispatch(editor.state.tr.setSelection(selection));
+    editor.view.focus();
+    if (scroll) centerRichSelection(editor, selection.from);
+    return true;
+}
+
+function centerRichSelection(editor: Editor, pos: number) {
+    const scroller = editor.view.dom.closest('.preview-wrapper') as HTMLElement | null;
+    if (!scroller) {
+        editor.view.dom.scrollIntoView({ block: 'center', behavior: 'auto' });
+        return;
+    }
+
+    let coords: { top: number; bottom: number };
+    try {
+        coords = editor.view.coordsAtPos(Math.max(0, Math.min(pos, editor.state.doc.content.size)));
+    } catch {
+        return;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const sticky = scroller.querySelector('.rich-sticky-top') as HTMLElement | null;
+    const stickyHeight = sticky?.getBoundingClientRect().height ?? 0;
+    const usableHeight = Math.max(1, scroller.clientHeight - stickyHeight);
+    const cursorTop = scroller.scrollTop + coords.top - scrollerRect.top;
+    const target = cursorTop - stickyHeight - usableHeight * 0.42;
+    const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    scroller.scrollTop = Math.max(0, Math.min(max, Math.round(target)));
+}
+
 function quoteHLPlugin() {
     return new Plugin({
         key: quoteHLKey,
@@ -835,6 +945,7 @@ function RichEditor({
     const editorInstanceRef = useRef<Editor | null>(null);
     // onUpdate 가 마지막으로 내보낸 body — 외부 content 변경(저장 flush 등) 감지용(#56).
     const lastEmittedBodyRef = useRef(body);
+    const didSkipInitialBodySyncRef = useRef(false);
     useEffect(() => {
         docDirRef.current = docDir;
     }, [docDir]);
@@ -1089,6 +1200,10 @@ function RichEditor({
     // 사용자가 편집 중인 변경은 덮어쓰지 않도록 — 직렬화 결과와 비교.
     useEffect(() => {
         if (!editor) return;
+        if (!didSkipInitialBodySyncRef.current) {
+            didSkipInitialBodySyncRef.current = true;
+            return;
+        }
         const current: string = editor.storage.markdown?.getMarkdown() ?? '';
         // onChange 와 동일 정규화를 거쳐 비교 — 안 그러면 저장본(정규화됨)과 늘
         // 달라 보여 매번 setContent(커서 점프) 가 발생.
@@ -1136,6 +1251,10 @@ export interface PreviewHandle {
     insertImageMarkdown: (relPath: string) => void;
     /** 드롭 좌표(client px)에 해당하는 위치에 이미지 삽입(#56). 좌표 무효면 커서 위치. */
     insertImageAtCoords: (relPath: string, clientX: number, clientY: number) => void;
+    /** 현재 Rich Text 커서에 대응하는 full markdown source offset. */
+    getMarkdownOffset: () => number | null;
+    /** full markdown source offset 으로 Rich Text 커서와 스크롤을 복원. */
+    focusAtMarkdownOffset: (offset: number, scroll?: boolean) => boolean;
 }
 
 export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
@@ -1145,6 +1264,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
     const [showFlow, setShowFlow] = useState(false);
     // Rich Text 모드의 editor 인스턴스 — App 이 drop 이미지를 여기로 삽입(#56)
     const richEditorRef = useRef<Editor | null>(null);
+    const bodyRef = useRef('');
+    const rawFrontmatterRef = useRef('');
     useImperativeHandle(ref, () => ({
         insertImageMarkdown: (relPath: string) => {
             richEditorRef.current?.chain().focus().setImage({ src: relPath }).run();
@@ -1158,6 +1279,21 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             } else {
                 editor.chain().focus().setImage({ src: relPath }).run();
             }
+        },
+        getMarkdownOffset: () => {
+            const editor = richEditorRef.current;
+            if (!editor) return null;
+            const plainOffset = richVisibleOffsetAt(editor, editor.state.selection.from);
+            const current: string = editor.storage.markdown?.getMarkdown() ?? bodyRef.current;
+            const bodyMarkdown = normalizeSerializedMarkdown(stripDisplayHelpers(current));
+            return rawFrontmatterRef.current.length + visibleOffsetToMarkdownOffset(bodyMarkdown, plainOffset);
+        },
+        focusAtMarkdownOffset: (offset: number, scroll = true) => {
+            const editor = richEditorRef.current;
+            if (!editor) return false;
+            const bodyOffset = Math.max(0, offset - rawFrontmatterRef.current.length);
+            const visibleOffset = markdownOffsetToVisibleOffset(bodyRef.current, bodyOffset);
+            return focusRichEditorAtVisibleOffset(editor, visibleOffset, scroll);
         },
     }), []);
     // 문서 디렉토리(POSIX) — 로컬 이미지 상대경로 해석 기준(#55). 미저장이면 null.
@@ -1173,6 +1309,8 @@ export const Preview = forwardRef<PreviewHandle, PreviewProps>(function Preview(
             rawFrontmatter: split.rawFrontmatter,
         };
     }, [content]);
+    bodyRef.current = body;
+    rawFrontmatterRef.current = rawFrontmatter;
 
     // read-only 뷰 표시용 — 흐름도 데이터(markmind-flow JSON) 는 토글 off 시 숨긴다(표시만,
     // 원본은 보존). 편집(⌘3 Rich Text) 경로는 strip 하면 저장 시 블록이 사라지므로 건드리지 않는다.

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -35,6 +35,20 @@ async function tauriWriteTextFile() {
   return writeTextFile;
 }
 
+async function showFileActionError(title: string, err: unknown) {
+  console.error(`[useFileSystem] ${title}:`, err);
+  if (!isTauri()) return;
+  try {
+    const { message } = await import('@tauri-apps/plugin-dialog');
+    await message(`${title}\n\n${String(err)}`, {
+      title: 'MarkMind',
+      kind: 'error',
+    });
+  } catch {
+    // dialog 자체가 실패한 경우 console 로그만 유지
+  }
+}
+
 // 같은 path 가 짧은 시간(StrictMode 이중 listen·중복 open-file 이벤트)에 두 번 들어오면
 // 새 창이 2개 열리므로(중복/빈 창) 1초 디바운스로 1회만 처리. 윈도우(webview)별 모듈
 // 스코프라 창마다 독립.
@@ -338,7 +352,7 @@ export function useFileSystem(
         }
       }
     } catch (err) {
-      console.error('Failed to open file:', err);
+      await showFileActionError('파일을 열 수 없습니다.', err);
     }
   }, [confirmUnsavedChanges]);
 
@@ -407,7 +421,7 @@ export function useFileSystem(
       setFileState((prev) => ({ ...prev, content: finalContent, filePath: path, fileName: name, isDirty: false }));
       return 'saved';
     } catch (err) {
-      console.error('Failed to save file:', err);
+      await showFileActionError('파일을 저장할 수 없습니다.', err);
       return 'failed';
     }
   }, []);
@@ -428,7 +442,7 @@ export function useFileSystem(
       const save = await tauriSave();
       const selected = await save({
         filters: [{ name: 'Markdown', extensions: ['md', 'markdown'] }],
-        defaultPath: fileState.fileName,
+        defaultPath: fileNameRef.current,
       });
       if (!selected) return;
 
@@ -438,9 +452,9 @@ export function useFileSystem(
       const name = selected.split('/').pop() || 'Untitled.md';
       setFileState((prev) => ({ ...prev, content: finalContent, filePath: selected, fileName: name, isDirty: false }));
     } catch (err) {
-      console.error('Failed to save file:', err);
+      await showFileActionError('다른 이름으로 저장할 수 없습니다.', err);
     }
-  }, [fileState.fileName]);
+  }, []);
 
   // ─── New File ───
   const newFile = useCallback(async () => {

--- a/src/hooks/useNativeMenu.ts
+++ b/src/hooks/useNativeMenu.ts
@@ -15,29 +15,31 @@
  * - On web (non-Tauri) this hook is a no-op; the toolbar keeps its dropdowns.
  */
 
-import { useEffect, useRef } from 'react';
-import type { CheckMenuItem } from '@tauri-apps/api/menu';
+import { useEffect, useRef, useState } from 'react';
+import type { CheckMenuItem, Menu } from '@tauri-apps/api/menu';
 import type { ViewMode } from '../components/Toolbar';
 import type { RecentFile } from './useRecentFiles';
+
+type MenuActionResult = unknown | Promise<unknown>;
 
 export interface UseNativeMenuOptions {
     /** Only build the native menu when true (= running under Tauri). */
     enabled: boolean;
     viewMode: ViewMode;
     recentFiles: RecentFile[];
-    onNewFile: () => void;
-    onOpenFile: () => void;
-    onSaveFile: () => void;
-    onSaveFileAs: () => void;
-    onExportPdf: () => void;
-    onShowSettings: () => void;
-    onShowTutorial: () => void;
-    onOpenFromDrive: () => void;
-    onSaveToDrive: () => void;
-    onOpenRecent: (path: string) => void;
-    onViewModeChange: (mode: ViewMode) => void;
-    onUndo: () => void;
-    onRedo: () => void;
+    onNewFile: () => MenuActionResult;
+    onOpenFile: () => MenuActionResult;
+    onSaveFile: () => MenuActionResult;
+    onSaveFileAs: () => MenuActionResult;
+    onExportPdf: () => MenuActionResult;
+    onShowSettings: () => MenuActionResult;
+    onShowTutorial: () => MenuActionResult;
+    onOpenFromDrive: () => MenuActionResult;
+    onSaveToDrive: () => MenuActionResult;
+    onOpenRecent: (path: string) => MenuActionResult;
+    onViewModeChange: (mode: ViewMode) => MenuActionResult;
+    onUndo: () => MenuActionResult;
+    onRedo: () => MenuActionResult;
 }
 
 /** View menu order = shortcut order. ⌘7 is intentionally left unassigned. */
@@ -70,6 +72,44 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
     ref.current = opts;
     // CheckMenuItem handles by mode, for cheap check-state updates.
     const checksRef = useRef<Record<string, CheckMenuItem>>({});
+    const currentMenuRef = useRef<Menu | null>(null);
+    const [focusEpoch, setFocusEpoch] = useState(0);
+
+    // macOS app menu is global, but MarkMind has multiple webview windows. If an
+    // inactive or soon-to-close window owns the global menu, File actions can run
+    // against the wrong webview and native dialogs appear to do nothing. Rebuild
+    // from the focused window whenever focus returns to this webview.
+    useEffect(() => {
+        if (!opts.enabled) return;
+        let disposed = false;
+        let unlisten: (() => void) | null = null;
+        (async () => {
+            const { getCurrentWindow } = await import('@tauri-apps/api/window');
+            const win = getCurrentWindow();
+            const fn = await win.onFocusChanged(({ payload: focused }) => {
+                if (focused) setFocusEpoch((n) => n + 1);
+            });
+            if (disposed) { Promise.resolve(fn()).catch(() => {}); return; }
+            unlisten = fn;
+            if (await win.isFocused()) setFocusEpoch((n) => n + 1);
+        })().catch((e) => console.error('[useNativeMenu] focus listener failed:', e));
+
+        return () => {
+            disposed = true;
+            if (unlisten) Promise.resolve(unlisten()).catch(() => {});
+        };
+    }, [opts.enabled]);
+
+    const runAction = (name: string, fn: () => MenuActionResult) => {
+        try {
+            const result = fn();
+            if (result && typeof result === 'object' && typeof (result as Promise<unknown>).catch === 'function') {
+                (result as Promise<unknown>).catch((e) => console.error(`[useNativeMenu] action failed: ${name}`, e));
+            }
+        } catch (e) {
+            console.error(`[useNativeMenu] action failed: ${name}`, e);
+        }
+    };
 
     // Build / rebuild the menu. Rebuilds only when the recent-files list changes
     // (the only data baked into items); handlers go through `ref`, viewMode is
@@ -78,7 +118,15 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
         if (!opts.enabled) return;
         let disposed = false;
         (async () => {
-            const { Menu, Submenu, MenuItem, CheckMenuItem, PredefinedMenuItem } = await import('@tauri-apps/api/menu');
+            const [
+                { Menu, Submenu, MenuItem, CheckMenuItem, PredefinedMenuItem },
+                { getCurrentWindow },
+            ] = await Promise.all([
+                import('@tauri-apps/api/menu'),
+                import('@tauri-apps/api/window'),
+            ]);
+            const win = getCurrentWindow();
+            if (!(await win.isFocused())) return;
             const h = () => ref.current;
             const sep = () => PredefinedMenuItem.new({ item: 'Separator' });
 
@@ -105,7 +153,11 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
                     } catch { /* lastOpened 폴백 */ }
                     // 네이티브 메뉴는 CSS 가 안 먹으므로 파일명 글자수를 직접 제한(말줄임).
                     const name = f.name.length > 48 ? `${f.name.slice(0, 47)}…` : f.name;
-                    return MenuItem.new({ id: `recent:${f.path}`, text: `${name}    ${formatRecentDate(ts)}`, action: () => h().onOpenRecent(f.path) });
+                    return MenuItem.new({
+                        id: `recent:${f.path}`,
+                        text: `${name}    ${formatRecentDate(ts)}`,
+                        action: () => runAction('open recent', () => h().onOpenRecent(f.path)),
+                    });
                 }))
                 : [await MenuItem.new({ id: 'recent-empty', text: '최근 파일 없음', enabled: false, action: () => {} })];
             const recentSubmenu = await Submenu.new({ text: 'Open Recent', items: recentItems });
@@ -113,21 +165,21 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
             const fileMenu = await Submenu.new({
                 text: 'File',
                 items: [
-                    await MenuItem.new({ id: 'new', text: 'New', accelerator: 'CmdOrCtrl+N', action: () => h().onNewFile() }),
-                    await MenuItem.new({ id: 'open', text: 'Open…', accelerator: 'CmdOrCtrl+O', action: () => h().onOpenFile() }),
+                    await MenuItem.new({ id: 'new', text: 'New', accelerator: 'CmdOrCtrl+N', action: () => runAction('new', () => h().onNewFile()) }),
+                    await MenuItem.new({ id: 'open', text: 'Open…', accelerator: 'CmdOrCtrl+O', action: () => runAction('open', () => h().onOpenFile()) }),
                     recentSubmenu,
                     await sep(),
-                    await MenuItem.new({ id: 'save', text: 'Save', accelerator: 'CmdOrCtrl+S', action: () => h().onSaveFile() }),
-                    await MenuItem.new({ id: 'saveas', text: 'Save As…', accelerator: 'CmdOrCtrl+Shift+S', action: () => h().onSaveFileAs() }),
+                    await MenuItem.new({ id: 'save', text: 'Save', accelerator: 'CmdOrCtrl+S', action: () => runAction('save', () => h().onSaveFile()) }),
+                    await MenuItem.new({ id: 'saveas', text: 'Save As…', accelerator: 'CmdOrCtrl+Shift+S', action: () => runAction('save as', () => h().onSaveFileAs()) }),
                     await sep(),
-                    await MenuItem.new({ id: 'export', text: 'Export as PDF…', accelerator: 'CmdOrCtrl+P', action: () => h().onExportPdf() }),
+                    await MenuItem.new({ id: 'export', text: 'Export as PDF…', accelerator: 'CmdOrCtrl+P', action: () => runAction('export pdf', () => h().onExportPdf()) }),
                     await sep(),
-                    await MenuItem.new({ id: 'drive-open', text: 'Open from Google Drive…', action: () => h().onOpenFromDrive() }),
-                    await MenuItem.new({ id: 'drive-save', text: 'Save to Google Drive…', action: () => h().onSaveToDrive() }),
+                    await MenuItem.new({ id: 'drive-open', text: 'Open from Google Drive…', action: () => runAction('open from drive', () => h().onOpenFromDrive()) }),
+                    await MenuItem.new({ id: 'drive-save', text: 'Save to Google Drive…', action: () => runAction('save to drive', () => h().onSaveToDrive()) }),
                     await sep(),
                     // Settings — 앱 메뉴(MarkMind) 대신 File 메뉴에 배치(사용자 선호: File 이 직관적).
                     // ⌘, 단축키도 함께 이동(앱 메뉴 항목을 제거해 중복 없음).
-                    await MenuItem.new({ id: 'file-settings', text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => h().onShowSettings() }),
+                    await MenuItem.new({ id: 'file-settings', text: 'Settings…', accelerator: 'CmdOrCtrl+,', action: () => runAction('settings', () => h().onShowSettings()) }),
                 ],
             });
 
@@ -135,8 +187,8 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
                 text: 'Edit',
                 items: [
                     // 전역 content 스택(#74)에 연결 — webview native undo 대신 일원화.
-                    await MenuItem.new({ id: 'undo', text: 'Undo', accelerator: 'CmdOrCtrl+Z', action: () => h().onUndo() }),
-                    await MenuItem.new({ id: 'redo', text: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', action: () => h().onRedo() }),
+                    await MenuItem.new({ id: 'undo', text: 'Undo', accelerator: 'CmdOrCtrl+Z', action: () => runAction('undo', () => h().onUndo()) }),
+                    await MenuItem.new({ id: 'redo', text: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', action: () => runAction('redo', () => h().onRedo()) }),
                     await sep(),
                     await PredefinedMenuItem.new({ item: 'Cut' }),
                     await PredefinedMenuItem.new({ item: 'Copy' }),
@@ -154,7 +206,7 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
                     text: v.label,
                     accelerator: v.accelerator,
                     checked: ref.current.viewMode === v.mode,
-                    action: () => h().onViewModeChange(v.mode),
+                    action: () => runAction(`view:${v.mode}`, () => h().onViewModeChange(v.mode)),
                 });
                 checks[v.mode] = item;
                 viewItems.push(item);
@@ -173,17 +225,22 @@ export function useNativeMenu(opts: UseNativeMenuOptions) {
 
             const helpMenu = await Submenu.new({
                 text: 'Help',
-                items: [await MenuItem.new({ id: 'tutorial', text: 'Tutorial', action: () => h().onShowTutorial() })],
+                items: [await MenuItem.new({ id: 'tutorial', text: 'Tutorial', action: () => runAction('tutorial', () => h().onShowTutorial()) })],
             });
 
             const menu = await Menu.new({ items: [appMenu, fileMenu, editMenu, viewMenu, windowMenu, helpMenu] });
-            if (disposed) return;
+            if (disposed || !(await win.isFocused())) return;
             checksRef.current = checks;
+            const previousMenu = currentMenuRef.current;
+            currentMenuRef.current = menu;
             await menu.setAsAppMenu();
+            if (previousMenu && previousMenu.rid !== menu.rid) {
+                previousMenu.close().catch(() => {});
+            }
         })().catch((e) => console.error('[useNativeMenu] build failed:', e));
 
         return () => { disposed = true; };
-    }, [opts.enabled, opts.recentFiles]);
+    }, [opts.enabled, opts.recentFiles, focusEpoch]);
 
     // Reflect the active view mode without rebuilding the whole menu.
     useEffect(() => {

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -38,6 +38,17 @@ describe('markdownCursor', () => {
     expect(visibleOffsetToMarkdownOffset(md, visibleMultiply)).toBe(multiplyOffset);
   });
 
+  it('does not skip visible spaces or punctuation when restoring markdown offsets', () => {
+    expect(visibleOffsetToMarkdownOffset('a b', 1)).toBe(1);
+
+    const md = 'Keep [literal] (paren) text';
+    const visible = markdownVisibleText(md);
+    const bracketOffset = visible.indexOf('[');
+    const parenOffset = visible.indexOf('(');
+    expect(visibleOffsetToMarkdownOffset(md, bracketOffset)).toBe(md.indexOf('['));
+    expect(visibleOffsetToMarkdownOffset(md, parenOffset)).toBe(md.indexOf('('));
+  });
+
   it('keeps fenced code text but ignores fence markers', () => {
     const md = ['Before', '```ts', 'const x = 1;', '```', 'After'].join('\n');
     expect(markdownVisibleText(md)).toBe(['Before', 'const x = 1;', 'After'].join('\n'));

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -46,6 +46,11 @@ describe('markdownCursor', () => {
     expect(visibleOffsetToMarkdownOffset(md, afterOffset)).toBe(md.indexOf(' after'));
   });
 
+  it('preserves unmatched marker characters in partially matched emphasis runs', () => {
+    expect(markdownVisibleText('**bold*')).toBe('*bold');
+    expect(markdownVisibleText('***bold**')).toBe('*bold');
+  });
+
   it('keeps backslashes visible unless they escape markdown punctuation', () => {
     const md = String.raw`C:\Users and \alpha and \*literal star\*`;
     const visible = markdownVisibleText(md);

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  markdownOffsetToVisibleOffset,
+  markdownVisibleText,
+  visibleOffsetToMarkdownOffset,
+} from './markdownCursor';
+
+describe('markdownCursor', () => {
+  it('maps markdown syntax to rendered text offsets', () => {
+    const md = ['# Title', '', '- **Alpha** item', '- [x] Done', 'Plain [link](target.md)'].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Title', 'Alpha item', 'Done', 'Plain link'].join('\n'));
+
+    const mdOffset = md.indexOf('item');
+    const visibleOffset = markdownOffsetToVisibleOffset(md, mdOffset);
+    expect(markdownVisibleText(md).slice(visibleOffset, visibleOffset + 4)).toBe('item');
+  });
+
+  it('round-trips a visible offset back near the source text', () => {
+    const md = ['## Heading', '', 'Paragraph with *emphasis* and [docs](./docs.md).'].join('\n');
+    const visible = markdownVisibleText(md);
+    const visibleOffset = visible.indexOf('docs');
+    const mdOffset = visibleOffsetToMarkdownOffset(md, visibleOffset);
+    expect(md.slice(mdOffset, mdOffset + 4)).toBe('docs');
+  });
+
+  it('keeps fenced code text but ignores fence markers', () => {
+    const md = ['Before', '```ts', 'const x = 1;', '```', 'After'].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Before', 'const x = 1;', 'After'].join('\n'));
+  });
+
+  it('ignores non-text rich nodes while preserving nearby source offsets', () => {
+    const md = ['Before', '![diagram](./diagram.png)', '---', 'After'].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Before', '', 'After'].join('\n'));
+
+    const afterOffset = md.indexOf('After');
+    expect(markdownOffsetToVisibleOffset(md, afterOffset)).toBe('Before\n\n'.length);
+  });
+
+  it('collapses markdown blank separators like the rich text document', () => {
+    const md = ['First', '', '', 'Second'].join('\n');
+    expect(markdownVisibleText(md)).toBe('First\nSecond');
+
+    const secondOffset = md.indexOf('Second');
+    const visibleOffset = markdownOffsetToVisibleOffset(md, secondOffset);
+    expect(markdownVisibleText(md).slice(visibleOffset, visibleOffset + 6)).toBe('Second');
+    expect(visibleOffsetToMarkdownOffset(md, visibleOffset)).toBe(secondOffset);
+  });
+
+  it('keeps source offsets stable for CRLF documents', () => {
+    const md = ['First', '', 'Second'].join('\r\n');
+    expect(markdownVisibleText(md)).toBe('First\nSecond');
+
+    const secondOffset = md.indexOf('Second');
+    const visibleOffset = markdownOffsetToVisibleOffset(md, secondOffset);
+    expect(visibleOffset).toBe('First\n'.length);
+    expect(visibleOffsetToMarkdownOffset(md, visibleOffset)).toBe(secondOffset);
+  });
+
+  it('treats explicit empty paragraph markers as empty rich text blocks', () => {
+    const md = ['First', '&nbsp;', 'Second'].join('\n');
+    expect(markdownVisibleText(md)).toBe('First\n\nSecond');
+
+    const secondOffset = md.indexOf('Second');
+    expect(markdownOffsetToVisibleOffset(md, secondOffset)).toBe('First\n\n'.length);
+  });
+
+  it('maps GFM table syntax to rich text cell offsets', () => {
+    const md = ['Before', '| A | B |', '| --- | --- |', '| 1 | **Two** |', 'After'].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Before', 'A', 'B', '1', 'Two', 'After'].join('\n'));
+
+    const twoOffset = md.indexOf('Two');
+    const visibleOffset = markdownOffsetToVisibleOffset(md, twoOffset);
+    expect(markdownVisibleText(md).slice(visibleOffset, visibleOffset + 3)).toBe('Two');
+    expect(md.slice(visibleOffsetToMarkdownOffset(md, visibleOffset), twoOffset + 3)).toContain('Two');
+  });
+
+  it('maps HTML table blocks to rich text cell offsets', () => {
+    const md = [
+      'Before',
+      '<table>',
+      '<tr><th>A</th><th>B</th></tr>',
+      '<tr><td>1</td><td><p>Two</p></td></tr>',
+      '</table>',
+      'After',
+    ].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Before', 'A', 'B', '1', 'Two', 'After'].join('\n'));
+
+    const afterOffset = md.indexOf('After');
+    expect(markdownOffsetToVisibleOffset(md, afterOffset)).toBe('Before\nA\nB\n1\nTwo\n'.length);
+  });
+});

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -86,6 +86,16 @@ describe('markdownCursor', () => {
     expect(markdownOffsetToVisibleOffset(md, afterOffset)).toBe('Before\n\n'.length);
   });
 
+  it('skips reference link definitions because they are not rendered body text', () => {
+    const md = ['Before', '[docs]: https://example.com', 'After'].join('\n');
+    expect(markdownVisibleText(md)).toBe(['Before', 'After'].join('\n'));
+
+    const afterOffset = md.indexOf('After');
+    const visibleOffset = markdownOffsetToVisibleOffset(md, afterOffset);
+    expect(visibleOffset).toBe('Before\n'.length);
+    expect(visibleOffsetToMarkdownOffset(md, visibleOffset)).toBe(afterOffset);
+  });
+
   it('collapses markdown blank separators like the rich text document', () => {
     const md = ['First', '', '', 'Second'].join('\n');
     expect(markdownVisibleText(md)).toBe('First\nSecond');

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -38,6 +38,25 @@ describe('markdownCursor', () => {
     expect(visibleOffsetToMarkdownOffset(md, visibleMultiply)).toBe(multiplyOffset);
   });
 
+  it('handles nested emphasis where delimiter runs are split by the markdown parser', () => {
+    const md = '**bold *em*** after';
+    expect(markdownVisibleText(md)).toBe('bold em after');
+
+    const afterOffset = markdownVisibleText(md).indexOf(' after');
+    expect(visibleOffsetToMarkdownOffset(md, afterOffset)).toBe(md.indexOf(' after'));
+  });
+
+  it('keeps backslashes visible unless they escape markdown punctuation', () => {
+    const md = String.raw`C:\Users and \alpha and \*literal star\*`;
+    const visible = markdownVisibleText(md);
+    expect(visible).toBe(String.raw`C:\Users and \alpha and *literal star*`);
+
+    const sourceBackslash = md.indexOf(String.raw`\Users`);
+    const visibleBackslash = visible.indexOf(String.raw`\Users`);
+    expect(markdownOffsetToVisibleOffset(md, sourceBackslash)).toBe(visibleBackslash);
+    expect(visibleOffsetToMarkdownOffset(md, visibleBackslash)).toBe(sourceBackslash);
+  });
+
   it('does not skip visible spaces or punctuation when restoring markdown offsets', () => {
     expect(visibleOffsetToMarkdownOffset('a b', 1)).toBe(1);
 

--- a/src/lib/markdownCursor.test.ts
+++ b/src/lib/markdownCursor.test.ts
@@ -23,6 +23,21 @@ describe('markdownCursor', () => {
     expect(md.slice(mdOffset, mdOffset + 4)).toBe('docs');
   });
 
+  it('preserves literal marker characters that are not markdown delimiters', () => {
+    const md = 'Use foo_bar with 2 * 3 and ~home~ paths, then **bold** and ~~gone~~.';
+    expect(markdownVisibleText(md)).toBe('Use foo_bar with 2 * 3 and ~home~ paths, then bold and gone.');
+
+    const underscoreOffset = md.indexOf('_');
+    const visibleUnderscore = markdownOffsetToVisibleOffset(md, underscoreOffset);
+    expect(markdownVisibleText(md)[visibleUnderscore]).toBe('_');
+    expect(visibleOffsetToMarkdownOffset(md, visibleUnderscore)).toBe(underscoreOffset);
+
+    const multiplyOffset = md.indexOf('*');
+    const visibleMultiply = markdownOffsetToVisibleOffset(md, multiplyOffset);
+    expect(markdownVisibleText(md)[visibleMultiply]).toBe('*');
+    expect(visibleOffsetToMarkdownOffset(md, visibleMultiply)).toBe(multiplyOffset);
+  });
+
   it('keeps fenced code text but ignores fence markers', () => {
     const md = ['Before', '```ts', 'const x = 1;', '```', 'After'].join('\n');
     expect(markdownVisibleText(md)).toBe(['Before', 'const x = 1;', 'After'].join('\n'));

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -57,6 +57,107 @@ function destinationEnd(src: string, openParen: number): number {
   return -1;
 }
 
+function isWhitespace(ch: string | undefined): boolean {
+  return ch == null || /\s/.test(ch);
+}
+
+function isPunctuation(ch: string | undefined): boolean {
+  return ch != null && /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(ch);
+}
+
+function isEscaped(src: string, index: number): boolean {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && src[i] === '\\'; i -= 1) backslashes += 1;
+  return backslashes % 2 === 1;
+}
+
+function delimiterRunAt(src: string, index: number): { char: string; start: number; length: number } | null {
+  const char = src[index];
+  if (char !== '*' && char !== '_' && char !== '~') return null;
+  let start = index;
+  while (start > 0 && src[start - 1] === char) start -= 1;
+  let end = index + 1;
+  while (end < src.length && src[end] === char) end += 1;
+  return { char, start, length: end - start };
+}
+
+function delimiterCanOpen(src: string, run: { char: string; start: number; length: number }): boolean {
+  if (isEscaped(src, run.start)) return false;
+  if (run.char === '~' && run.length < 2) return false;
+  const before = run.start > 0 ? src[run.start - 1] : undefined;
+  const after = src[run.start + run.length];
+  if (after == null || isWhitespace(after)) return false;
+  const leftFlanking = !isPunctuation(after) || before == null || isWhitespace(before) || isPunctuation(before);
+  if (!leftFlanking) return false;
+  if (run.char === '_') {
+    const rightFlanking = before != null
+      && !isWhitespace(before)
+      && (!isPunctuation(before) || after == null || isWhitespace(after) || isPunctuation(after));
+    return !rightFlanking || isPunctuation(before);
+  }
+  return true;
+}
+
+function delimiterCanClose(src: string, run: { char: string; start: number; length: number }): boolean {
+  if (isEscaped(src, run.start)) return false;
+  if (run.char === '~' && run.length < 2) return false;
+  const before = run.start > 0 ? src[run.start - 1] : undefined;
+  const after = src[run.start + run.length];
+  if (before == null || isWhitespace(before)) return false;
+  const rightFlanking = !isPunctuation(before) || after == null || isWhitespace(after) || isPunctuation(after);
+  if (!rightFlanking) return false;
+  if (run.char === '_') {
+    const leftFlanking = after != null
+      && !isWhitespace(after)
+      && (!isPunctuation(after) || before == null || isWhitespace(before) || isPunctuation(before));
+    return !leftFlanking || isPunctuation(after);
+  }
+  return true;
+}
+
+function hasClosingDelimiter(src: string, run: { char: string; start: number; length: number }): boolean {
+  for (let i = run.start + run.length; i < src.length; i += 1) {
+    if (src[i] !== run.char || isEscaped(src, i)) continue;
+    const candidate = delimiterRunAt(src, i);
+    if (!candidate) continue;
+    i = candidate.start + candidate.length - 1;
+    if (candidate.length >= run.length && delimiterCanClose(src, candidate)) return true;
+  }
+  return false;
+}
+
+function hasOpeningDelimiter(src: string, run: { char: string; start: number; length: number }): boolean {
+  for (let i = run.start - 1; i >= 0; i -= 1) {
+    if (src[i] !== run.char || isEscaped(src, i)) continue;
+    const candidate = delimiterRunAt(src, i);
+    if (!candidate) continue;
+    i = candidate.start;
+    if (candidate.length >= run.length && delimiterCanOpen(src, candidate)) return true;
+  }
+  return false;
+}
+
+function isHiddenEmphasisDelimiter(src: string, index: number): boolean {
+  const run = delimiterRunAt(src, index);
+  if (!run) return false;
+  return (delimiterCanOpen(src, run) && hasClosingDelimiter(src, run))
+    || (delimiterCanClose(src, run) && hasOpeningDelimiter(src, run));
+}
+
+function isHiddenLineBlockPosition(markdown: string, index: number): boolean {
+  const lineStart = markdown.lastIndexOf('\n', Math.max(0, index - 1)) + 1;
+  const nextLf = markdown.indexOf('\n', lineStart);
+  const rawLineEnd = nextLf === -1 ? markdown.length : nextLf;
+  const lineEnd = rawLineEnd > lineStart && markdown[rawLineEnd - 1] === '\r' ? rawLineEnd - 1 : rawLineEnd;
+  if (index < lineStart || index >= lineEnd) return false;
+
+  const line = markdown.slice(lineStart, lineEnd);
+  if (isThematicBreak(line)) return true;
+
+  const { prefixLength } = stripLinePrefixInfo(line);
+  return index - lineStart < prefixLength;
+}
+
 function inlineVisibleText(src: string): string {
   let out = '';
   for (let i = 0; i < src.length; i += 1) {
@@ -105,7 +206,7 @@ function inlineVisibleText(src: string): string {
       continue;
     }
 
-    if (ch === '*' || ch === '_' || ch === '~') {
+    if ((ch === '*' || ch === '_' || ch === '~') && isHiddenEmphasisDelimiter(src, i)) {
       while (src[i + 1] === ch) i += 1;
       continue;
     }
@@ -173,7 +274,7 @@ function inlineVisibleLengthBefore(src: string, col: number): number {
       continue;
     }
 
-    if (ch === '*' || ch === '_' || ch === '~') {
+    if ((ch === '*' || ch === '_' || ch === '~') && isHiddenEmphasisDelimiter(src, i)) {
       while (src[i + 1] === ch) i += 1;
       continue;
     }
@@ -187,7 +288,8 @@ function inlineVisibleLengthBefore(src: string, col: number): number {
 function isSkippableMarkdownSyntax(markdown: string, index: number): boolean {
   const ch = markdown[index];
   if (!ch) return false;
-  if ('#>-+*![]()`~_ '.includes(ch)) return true;
+  if (ch === '*' || ch === '_' || ch === '~') return isHiddenLineBlockPosition(markdown, index) || isHiddenEmphasisDelimiter(markdown, index);
+  if ('#>-+![]()` '.includes(ch)) return true;
   if (ch === '\t') return true;
   if (/\d/.test(ch)) {
     const rest = markdown.slice(index);

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -65,6 +65,10 @@ function isPunctuation(ch: string | undefined): boolean {
   return ch != null && /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(ch);
 }
 
+function isEscapableMarkdownPunctuation(ch: string | undefined): boolean {
+  return isPunctuation(ch);
+}
+
 function isEscaped(src: string, index: number): boolean {
   let backslashes = 0;
   for (let i = index - 1; i >= 0 && src[i] === '\\'; i -= 1) backslashes += 1;
@@ -121,7 +125,7 @@ function hasClosingDelimiter(src: string, run: { char: string; start: number; le
     const candidate = delimiterRunAt(src, i);
     if (!candidate) continue;
     i = candidate.start + candidate.length - 1;
-    if (candidate.length >= run.length && delimiterCanClose(src, candidate)) return true;
+    if (delimiterCanClose(src, candidate)) return true;
   }
   return false;
 }
@@ -132,7 +136,7 @@ function hasOpeningDelimiter(src: string, run: { char: string; start: number; le
     const candidate = delimiterRunAt(src, i);
     if (!candidate) continue;
     i = candidate.start;
-    if (candidate.length >= run.length && delimiterCanOpen(src, candidate)) return true;
+    if (delimiterCanOpen(src, candidate)) return true;
   }
   return false;
 }
@@ -163,7 +167,7 @@ function inlineVisibleText(src: string): string {
   for (let i = 0; i < src.length; i += 1) {
     const ch = src[i];
 
-    if (ch === '\\' && i + 1 < src.length) {
+    if (ch === '\\' && i + 1 < src.length && isEscapableMarkdownPunctuation(src[i + 1])) {
       out += src[i + 1];
       i += 1;
       continue;
@@ -224,7 +228,7 @@ function inlineVisibleLengthBefore(src: string, col: number): number {
     if (i >= limit) break;
     const ch = src[i];
 
-    if (ch === '\\' && i + 1 < src.length) {
+    if (ch === '\\' && i + 1 < src.length && isEscapableMarkdownPunctuation(src[i + 1])) {
       if (limit > i + 1) len += 1;
       i += 1;
       continue;

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -488,6 +488,10 @@ function isThematicBreak(line: string): boolean {
     || /^(_[ \t]*){3,}$/.test(trimmed);
 }
 
+function isReferenceDefinition(line: string): boolean {
+  return /^[ \t]{0,3}\[[^\]\n]+]:[ \t]*\S/.test(line);
+}
+
 function decodeHtmlEntity(entity: string): string {
   if (entity === 'amp') return '&';
   if (entity === 'lt') return '<';
@@ -651,6 +655,10 @@ function visibleLines(markdown: string): { lines: VisibleLine[]; total: number }
     }
 
     if (!inFence && isThematicBreak(line)) {
+      continue;
+    }
+
+    if (!inFence && isReferenceDefinition(line)) {
       continue;
     }
 

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -119,33 +119,77 @@ function delimiterCanClose(src: string, run: { char: string; start: number; leng
   return true;
 }
 
-function hasClosingDelimiter(src: string, run: { char: string; start: number; length: number }): boolean {
-  for (let i = run.start + run.length; i < src.length; i += 1) {
-    if (src[i] !== run.char || isEscaped(src, i)) continue;
-    const candidate = delimiterRunAt(src, i);
-    if (!candidate) continue;
-    i = candidate.start + candidate.length - 1;
-    if (delimiterCanClose(src, candidate)) return true;
-  }
-  return false;
+interface EmphasisRun {
+  char: string;
+  start: number;
+  length: number;
+  openMatched: number;
+  closeMatched: number;
+  canOpen: boolean;
+  canClose: boolean;
 }
 
-function hasOpeningDelimiter(src: string, run: { char: string; start: number; length: number }): boolean {
-  for (let i = run.start - 1; i >= 0; i -= 1) {
-    if (src[i] !== run.char || isEscaped(src, i)) continue;
-    const candidate = delimiterRunAt(src, i);
-    if (!candidate) continue;
-    i = candidate.start;
-    if (delimiterCanOpen(src, candidate)) return true;
+function hideOpeningDelimiters(hidden: Set<number>, run: EmphasisRun, count: number) {
+  for (let i = 0; i < count; i += 1) {
+    hidden.add(run.start + run.length - run.openMatched - 1);
+    run.openMatched += 1;
   }
-  return false;
+}
+
+function hideClosingDelimiters(hidden: Set<number>, run: EmphasisRun, count: number) {
+  for (let i = 0; i < count; i += 1) {
+    hidden.add(run.start + run.closeMatched);
+    run.closeMatched += 1;
+  }
+}
+
+function hiddenEmphasisDelimiterIndexes(src: string): Set<number> {
+  const hidden = new Set<number>();
+  const openers: Record<string, EmphasisRun[]> = { '*': [], '_': [], '~': [] };
+
+  for (let i = 0; i < src.length; i += 1) {
+    const rawRun = delimiterRunAt(src, i);
+    if (!rawRun) continue;
+    i = rawRun.start + rawRun.length - 1;
+
+    const run: EmphasisRun = {
+      ...rawRun,
+      openMatched: 0,
+      closeMatched: 0,
+      canOpen: delimiterCanOpen(src, rawRun),
+      canClose: delimiterCanClose(src, rawRun),
+    };
+    if (!run.canOpen && !run.canClose) continue;
+
+    if (run.canClose) {
+      const stack = openers[run.char];
+      let remainingClose = run.length;
+      const unit = run.char === '~' ? 2 : 1;
+      while (remainingClose >= unit && stack.length > 0) {
+        const opener = stack[stack.length - 1];
+        const remainingOpen = opener.length - opener.openMatched - opener.closeMatched;
+        if (remainingOpen < unit) {
+          stack.pop();
+          continue;
+        }
+        const match = unit * Math.min(Math.floor(remainingOpen / unit), Math.floor(remainingClose / unit));
+        hideOpeningDelimiters(hidden, opener, match);
+        hideClosingDelimiters(hidden, run, match);
+        remainingClose -= match;
+        if (opener.length - opener.openMatched - opener.closeMatched < unit) stack.pop();
+      }
+    }
+
+    if (run.canOpen && run.length - run.openMatched - run.closeMatched > 0) {
+      openers[run.char].push(run);
+    }
+  }
+
+  return hidden;
 }
 
 function isHiddenEmphasisDelimiter(src: string, index: number): boolean {
-  const run = delimiterRunAt(src, index);
-  if (!run) return false;
-  return (delimiterCanOpen(src, run) && hasClosingDelimiter(src, run))
-    || (delimiterCanClose(src, run) && hasOpeningDelimiter(src, run));
+  return hiddenEmphasisDelimiterIndexes(src).has(index);
 }
 
 function isHiddenLineBlockPosition(markdown: string, index: number): boolean {
@@ -164,6 +208,7 @@ function isHiddenLineBlockPosition(markdown: string, index: number): boolean {
 
 function inlineVisibleText(src: string): string {
   let out = '';
+  const hiddenDelimiters = hiddenEmphasisDelimiterIndexes(src);
   for (let i = 0; i < src.length; i += 1) {
     const ch = src[i];
 
@@ -210,8 +255,7 @@ function inlineVisibleText(src: string): string {
       continue;
     }
 
-    if ((ch === '*' || ch === '_' || ch === '~') && isHiddenEmphasisDelimiter(src, i)) {
-      while (src[i + 1] === ch) i += 1;
+    if ((ch === '*' || ch === '_' || ch === '~') && hiddenDelimiters.has(i)) {
       continue;
     }
 
@@ -222,6 +266,7 @@ function inlineVisibleText(src: string): string {
 
 function inlineVisibleLengthBefore(src: string, col: number): number {
   const limit = Math.max(0, Math.min(col, src.length));
+  const hiddenDelimiters = hiddenEmphasisDelimiterIndexes(src);
   let len = 0;
 
   for (let i = 0; i < src.length; i += 1) {
@@ -278,8 +323,7 @@ function inlineVisibleLengthBefore(src: string, col: number): number {
       continue;
     }
 
-    if ((ch === '*' || ch === '_' || ch === '~') && isHiddenEmphasisDelimiter(src, i)) {
-      while (src[i + 1] === ch) i += 1;
+    if ((ch === '*' || ch === '_' || ch === '~') && hiddenDelimiters.has(i)) {
       continue;
     }
 

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -288,6 +288,9 @@ function inlineVisibleLengthBefore(src: string, col: number): number {
 function isSkippableMarkdownSyntax(markdown: string, index: number): boolean {
   const ch = markdown[index];
   if (!ch) return false;
+  if (markdownOffsetToVisibleOffset(markdown, index + 1) !== markdownOffsetToVisibleOffset(markdown, index)) {
+    return false;
+  }
   if (ch === '*' || ch === '_' || ch === '~') return isHiddenLineBlockPosition(markdown, index) || isHiddenEmphasisDelimiter(markdown, index);
   if ('#>-+![]()` '.includes(ch)) return true;
   if (ch === '\t') return true;

--- a/src/lib/markdownCursor.ts
+++ b/src/lib/markdownCursor.ts
@@ -1,0 +1,563 @@
+function stripLinePrefixInfo(line: string): { text: string; prefixLength: number } {
+  let out = line;
+  let prefixLength = 0;
+  while (true) {
+    const quote = out.match(/^[ \t]{0,3}>[ \t]?/);
+    if (!quote) break;
+    prefixLength += quote[0].length;
+    out = out.slice(quote[0].length);
+  }
+
+  const heading = out.match(/^[ \t]{0,3}#{1,6}[ \t]+/);
+  if (heading) {
+    prefixLength += heading[0].length;
+    out = out.slice(heading[0].length);
+  }
+
+  const list = out.match(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/);
+  if (list) {
+    prefixLength += list[0].length;
+    out = out.slice(list[0].length);
+  }
+
+  return { text: out, prefixLength };
+}
+
+function matchingBracket(src: string, start: number, open: string, close: string): number {
+  let depth = 0;
+  for (let i = start; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+    if (ch === open) depth += 1;
+    if (ch === close) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function destinationEnd(src: string, openParen: number): number {
+  let depth = 0;
+  for (let i = openParen; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+    if (ch === '(') depth += 1;
+    if (ch === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function inlineVisibleText(src: string): string {
+  let out = '';
+  for (let i = 0; i < src.length; i += 1) {
+    const ch = src[i];
+
+    if (ch === '\\' && i + 1 < src.length) {
+      out += src[i + 1];
+      i += 1;
+      continue;
+    }
+
+    if (ch === '!' && src[i + 1] === '[') {
+      const close = matchingBracket(src, i + 1, '[', ']');
+      if (close >= 0 && src[close + 1] === '(') {
+        const end = destinationEnd(src, close + 1);
+        if (end >= 0) {
+          i = end;
+          continue;
+        }
+      }
+    }
+
+    if (ch === '[') {
+      const close = matchingBracket(src, i, '[', ']');
+      if (close >= 0 && src[close + 1] === '(') {
+        const end = destinationEnd(src, close + 1);
+        if (end >= 0) {
+          out += inlineVisibleText(src.slice(i + 1, close));
+          i = end;
+          continue;
+        }
+      }
+    }
+
+    if (ch === '`') {
+      let ticks = 1;
+      while (src[i + ticks] === '`') ticks += 1;
+      const marker = '`'.repeat(ticks);
+      const end = src.indexOf(marker, i + ticks);
+      if (end >= 0) {
+        out += src.slice(i + ticks, end);
+        i = end + ticks - 1;
+        continue;
+      }
+      i += ticks - 1;
+      continue;
+    }
+
+    if (ch === '*' || ch === '_' || ch === '~') {
+      while (src[i + 1] === ch) i += 1;
+      continue;
+    }
+
+    out += ch;
+  }
+  return out.replace(/\u200b/g, '');
+}
+
+function inlineVisibleLengthBefore(src: string, col: number): number {
+  const limit = Math.max(0, Math.min(col, src.length));
+  let len = 0;
+
+  for (let i = 0; i < src.length; i += 1) {
+    if (i >= limit) break;
+    const ch = src[i];
+
+    if (ch === '\\' && i + 1 < src.length) {
+      if (limit > i + 1) len += 1;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '!' && src[i + 1] === '[') {
+      const close = matchingBracket(src, i + 1, '[', ']');
+      if (close >= 0 && src[close + 1] === '(') {
+        const end = destinationEnd(src, close + 1);
+        if (end >= 0) {
+          i = end;
+          continue;
+        }
+      }
+    }
+
+    if (ch === '[') {
+      const close = matchingBracket(src, i, '[', ']');
+      if (close >= 0 && src[close + 1] === '(') {
+        const end = destinationEnd(src, close + 1);
+        if (end >= 0) {
+          const textStart = i + 1;
+          if (limit > textStart) {
+            const label = src.slice(textStart, close);
+            len += limit < close
+              ? inlineVisibleLengthBefore(label, limit - textStart)
+              : inlineVisibleText(label).length;
+          }
+          i = end;
+          continue;
+        }
+      }
+    }
+
+    if (ch === '`') {
+      let ticks = 1;
+      while (src[i + ticks] === '`') ticks += 1;
+      const marker = '`'.repeat(ticks);
+      const end = src.indexOf(marker, i + ticks);
+      if (end >= 0) {
+        const textStart = i + ticks;
+        if (limit > textStart) len += Math.min(limit, end) - textStart;
+        i = end + ticks - 1;
+        continue;
+      }
+      i += ticks - 1;
+      continue;
+    }
+
+    if (ch === '*' || ch === '_' || ch === '~') {
+      while (src[i + 1] === ch) i += 1;
+      continue;
+    }
+
+    len += 1;
+  }
+
+  return len;
+}
+
+function isSkippableMarkdownSyntax(markdown: string, index: number): boolean {
+  const ch = markdown[index];
+  if (!ch) return false;
+  if ('#>-+*![]()`~_ '.includes(ch)) return true;
+  if (ch === '\t') return true;
+  if (/\d/.test(ch)) {
+    const rest = markdown.slice(index);
+    return /^\d+[.)][ \t]+/.test(rest);
+  }
+  if (ch === '.' || ch === ')') {
+    const before = markdown.slice(0, index);
+    return /\d+$/.test(before);
+  }
+  return false;
+}
+
+interface VisibleLine {
+  sourceStart: number;
+  sourceEnd: number;
+  visibleStart: number;
+  visible: string;
+  raw: string;
+  prefixLength: number;
+  inFence: boolean;
+  visibleLengthBefore?: (col: number) => number;
+}
+
+interface SourceLine {
+  text: string;
+  start: number;
+  end: number;
+  nextStart: number;
+}
+
+interface TableCell {
+  raw: string;
+  start: number;
+  end: number;
+}
+
+function splitSourceLines(markdown: string): SourceLine[] {
+  const lines: SourceLine[] = [];
+  let start = 0;
+  let i = 0;
+
+  while (i < markdown.length) {
+    const ch = markdown[i];
+    if (ch !== '\n' && ch !== '\r') {
+      i += 1;
+      continue;
+    }
+
+    const end = i;
+    const nextStart = ch === '\r' && markdown[i + 1] === '\n' ? i + 2 : i + 1;
+    lines.push({
+      text: markdown.slice(start, end),
+      start,
+      end,
+      nextStart,
+    });
+    start = nextStart;
+    i = nextStart;
+  }
+
+  lines.push({
+    text: markdown.slice(start),
+    start,
+    end: markdown.length,
+    nextStart: markdown.length,
+  });
+  return lines;
+}
+
+function trimCell(line: string, start: number, end: number): TableCell {
+  let cellStart = start;
+  let cellEnd = end;
+  while (cellStart < cellEnd && /[ \t]/.test(line[cellStart])) cellStart += 1;
+  while (cellEnd > cellStart && /[ \t]/.test(line[cellEnd - 1])) cellEnd -= 1;
+  return {
+    raw: line.slice(cellStart, cellEnd),
+    start: cellStart,
+    end: cellEnd,
+  };
+}
+
+function splitTableCells(line: string): TableCell[] | null {
+  const pipeIndexes: number[] = [];
+  let ticks = 0;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '\\') {
+      i += 1;
+      continue;
+    }
+    if (ch === '`') {
+      let count = 1;
+      while (line[i + count] === '`') count += 1;
+      ticks = ticks === count ? 0 : ticks || count;
+      i += count - 1;
+      continue;
+    }
+    if (ch === '|' && ticks === 0) pipeIndexes.push(i);
+  }
+
+  if (pipeIndexes.length === 0) return null;
+
+  const firstNonSpace = line.search(/\S/);
+  if (firstNonSpace === -1) return null;
+  const lastNonSpace = line.search(/\s*$/) - 1;
+  const hasLeadingPipe = pipeIndexes[0] === firstNonSpace;
+  const hasTrailingPipe = pipeIndexes[pipeIndexes.length - 1] === lastNonSpace;
+  const cells: TableCell[] = [];
+
+  if (hasLeadingPipe) {
+    const lastIndex = hasTrailingPipe ? pipeIndexes.length - 1 : pipeIndexes.length;
+    for (let i = 0; i < lastIndex; i += 1) {
+      const start = pipeIndexes[i] + 1;
+      const end = i + 1 < pipeIndexes.length ? pipeIndexes[i + 1] : line.length;
+      cells.push(trimCell(line, start, end));
+    }
+  } else {
+    let start = 0;
+    const lastIndex = hasTrailingPipe ? pipeIndexes.length - 1 : pipeIndexes.length;
+    for (let i = 0; i < lastIndex; i += 1) {
+      cells.push(trimCell(line, start, pipeIndexes[i]));
+      start = pipeIndexes[i] + 1;
+    }
+    if (!hasTrailingPipe) cells.push(trimCell(line, start, line.length));
+  }
+
+  return cells.length > 1 ? cells : null;
+}
+
+function isTableDelimiterLine(line: string): boolean {
+  const cells = splitTableCells(line);
+  return Boolean(cells?.length && cells.every((cell) => /^:?-+:?$/.test(cell.raw.trim())));
+}
+
+function isExplicitEmptyParagraph(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed === '&nbsp;' || trimmed === '\u00a0';
+}
+
+function isThematicBreak(line: string): boolean {
+  const trimmed = line.trim();
+  return /^(\*[ \t]*){3,}$/.test(trimmed)
+    || /^(-[ \t]*){3,}$/.test(trimmed)
+    || /^(_[ \t]*){3,}$/.test(trimmed);
+}
+
+function decodeHtmlEntity(entity: string): string {
+  if (entity === 'amp') return '&';
+  if (entity === 'lt') return '<';
+  if (entity === 'gt') return '>';
+  if (entity === 'quot') return '"';
+  if (entity === '#39' || entity === 'apos') return "'";
+  if (entity === 'nbsp') return ' ';
+  if (/^#\d+$/.test(entity)) return String.fromCodePoint(Number(entity.slice(1)));
+  if (/^#x[\da-f]+$/i.test(entity)) return String.fromCodePoint(Number.parseInt(entity.slice(2), 16));
+  return `&${entity};`;
+}
+
+function htmlVisibleText(src: string): string {
+  let out = '';
+  for (let i = 0; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === '<') {
+      const end = src.indexOf('>', i + 1);
+      if (end === -1) {
+        out += ch;
+        continue;
+      }
+      const tag = src.slice(i + 1, end).trim().toLowerCase();
+      if (tag.startsWith('br') || /^\/(?:p|div|li|h[1-6])\b/.test(tag)) out += '\n';
+      i = end;
+      continue;
+    }
+    if (ch === '&') {
+      const end = src.indexOf(';', i + 1);
+      if (end > i && end - i <= 12) {
+        out += decodeHtmlEntity(src.slice(i + 1, end));
+        i = end;
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out.replace(/\n+$/g, '');
+}
+
+function htmlVisibleLengthBefore(src: string, col: number): number {
+  return htmlVisibleText(src.slice(0, Math.max(0, Math.min(col, src.length)))).length;
+}
+
+function visibleLines(markdown: string): { lines: VisibleLine[]; total: number } {
+  const sourceLines = splitSourceLines(markdown);
+  const out: VisibleLine[] = [];
+  let inFence = false;
+  let fenceChar: '`' | '~' | null = null;
+  let fenceLen = 0;
+  let total = 0;
+
+  const pushLine = (
+    sourceLineStart: number,
+    raw: string,
+    sourceStartInLine: number,
+    sourceEndInLine: number,
+    visible: string,
+    prefixLength = 0,
+    inFenceLine = false,
+    visibleLengthBefore?: (col: number) => number,
+  ) => {
+    const visibleStart = out.length > 0 ? total + 1 : total;
+    total = visibleStart + visible.length;
+    out.push({
+      sourceStart: sourceLineStart + sourceStartInLine,
+      sourceEnd: sourceLineStart + sourceEndInLine,
+      visibleStart,
+      visible,
+      raw,
+      prefixLength,
+      inFence: inFenceLine,
+      visibleLengthBefore,
+    });
+  };
+
+  for (let i = 0; i < sourceLines.length; i += 1) {
+    const sourceLine = sourceLines[i];
+    const line = sourceLine.text;
+    const fence = line.match(/^[ ]{0,3}(([`~])\2{2,})/);
+    if (fence && (!inFence || (fence[2] === fenceChar && fence[1].length >= fenceLen))) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = fence[2] as '`' | '~';
+        fenceLen = fence[1].length;
+      } else {
+        inFence = false;
+        fenceChar = null;
+        fenceLen = 0;
+      }
+      continue;
+    }
+
+    if (!inFence) {
+      const nextLine = sourceLines[i + 1];
+      if (nextLine != null && splitTableCells(line) && isTableDelimiterLine(nextLine.text)) {
+        let tableLineIndex = i;
+        while (tableLineIndex < sourceLines.length) {
+          const tableSourceLine = sourceLines[tableLineIndex];
+          const tableLine = tableSourceLine.text;
+          const cells = splitTableCells(tableLine);
+          if (!cells) break;
+          if (!isTableDelimiterLine(tableLine)) {
+            for (const cell of cells) {
+              pushLine(
+                tableSourceLine.start,
+                cell.raw,
+                cell.start,
+                cell.end,
+                inlineVisibleText(cell.raw),
+              );
+            }
+          }
+          tableLineIndex += 1;
+        }
+        i = tableLineIndex - 1;
+        continue;
+      }
+    }
+
+    if (!inFence && /^[ \t]*<table[\s>]/i.test(line)) {
+      let closeLineIndex = -1;
+      for (let tableLineIndex = i; tableLineIndex < sourceLines.length; tableLineIndex += 1) {
+        if (/<\/table>[ \t]*$/i.test(sourceLines[tableLineIndex].text)) {
+          closeLineIndex = tableLineIndex;
+          break;
+        }
+      }
+      if (closeLineIndex >= 0) {
+        const blockStart = sourceLine.start;
+        const blockEnd = sourceLines[closeLineIndex].end;
+        const block = markdown.slice(blockStart, blockEnd);
+        const cellRe = /<(?:td|th)\b[^>]*>([\s\S]*?)<\/(?:td|th)>/gi;
+        let matched = false;
+        let match: RegExpExecArray | null;
+        while ((match = cellRe.exec(block))) {
+          matched = true;
+          const openEnd = match[0].indexOf('>') + 1;
+          const inner = match[1];
+          const innerStart = match.index + openEnd;
+          pushLine(
+            0,
+            inner,
+            blockStart + innerStart,
+            blockStart + innerStart + inner.length,
+            htmlVisibleText(inner),
+            0,
+            false,
+            (col) => htmlVisibleLengthBefore(inner, col),
+          );
+        }
+        if (matched) {
+          i = closeLineIndex;
+          continue;
+        }
+      }
+    }
+
+    if (!inFence && line.trim() === '') {
+      continue;
+    }
+
+    if (!inFence && isThematicBreak(line)) {
+      continue;
+    }
+
+    if (!inFence && isExplicitEmptyParagraph(line)) {
+      pushLine(sourceLine.start, line, 0, line.length, '');
+      continue;
+    }
+
+    const { text, prefixLength } = inFence
+      ? { text: line, prefixLength: 0 }
+      : stripLinePrefixInfo(line);
+    const visible = inFence ? text : inlineVisibleText(text);
+    pushLine(sourceLine.start, line, 0, line.length, visible, prefixLength, inFence);
+  }
+
+  return { lines: out, total };
+}
+
+export function markdownVisibleText(markdown: string): string {
+  return visibleLines(markdown).lines.map((line) => line.visible).join('\n');
+}
+
+export function markdownOffsetToVisibleOffset(markdown: string, offset: number): number {
+  const clamped = Math.max(0, Math.min(offset, markdown.length));
+  const { lines, total } = visibleLines(markdown);
+  if (lines.length === 0) return 0;
+
+  for (const line of lines) {
+    if (clamped <= line.sourceStart) return line.visibleStart;
+    if (clamped <= line.sourceEnd) {
+      const col = clamped - line.sourceStart;
+      if (line.inFence) return line.visibleStart + Math.min(col, line.visible.length);
+      if (line.visibleLengthBefore) return line.visibleStart + line.visibleLengthBefore(col);
+      const textCol = Math.max(0, col - line.prefixLength);
+      const stripped = line.raw.slice(line.prefixLength);
+      return line.visibleStart + inlineVisibleLengthBefore(stripped, textCol);
+    }
+  }
+
+  return total;
+}
+
+export function visibleOffsetToMarkdownOffset(markdown: string, visibleOffset: number): number {
+  const target = Math.max(0, visibleOffset);
+  let lo = 0;
+  let hi = markdown.length;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (markdownOffsetToVisibleOffset(markdown, mid) < target) lo = mid + 1;
+    else hi = mid;
+  }
+  while (lo < markdown.length && markdownOffsetToVisibleOffset(markdown, lo + 1) === target) {
+    lo += 1;
+  }
+  while (
+    lo < markdown.length
+    && markdownOffsetToVisibleOffset(markdown, lo) === target
+    && isSkippableMarkdownSyntax(markdown, lo)
+  ) {
+    lo += 1;
+  }
+  return lo;
+}


### PR DESCRIPTION
## Summary

- Tighten line spacing between Rich Text list items, including task lists.
- Rebuild the native macOS app menu from the focused webview and surface file action dialog errors so intermittent File > Save As/Open no-ops are easier to avoid and diagnose.
- Preserve cursor/focus when switching Markdown <-> Rich Text, including markdown/rich visible offset mapping and immediate non-animated Rich Text scroll restoration.
- Include the existing `src-tauri/Cargo.lock` package version sync that was reviewed earlier; no version bump command was run for this PR.

## Validation

- `npm run build`
- `npm test`