### PR TITLE
fix(rich-text): preserve literal tilde serialization

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -39,6 +39,7 @@ import { resolveImageSrc } from '../lib/imageSrc';
 import { removeFlowchartBlock, hasFlowchartBlock } from '../lib/flowchartBlock';
 import { quoteLines } from '../lib/quoteMatch';
 import { markdownOffsetToVisibleOffset, visibleOffsetToMarkdownOffset } from '../lib/markdownCursor';
+import { normalizeSerializedMarkdown } from '../lib/markdownSerialization';
 import { TableTools } from './TableTools';
 import {
     Bold, Italic, Strikethrough, Code,
@@ -221,67 +222,6 @@ function joinBrokenTableRows(md: string): string {
 /** save 시점에 fixEmphasis 가 삽입한 zero-width 제거 */
 function stripDisplayHelpers(md: string): string {
     return md.replace(/​/g, '');
-}
-
-// tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
-// 불필요한 기호 제거(선별적). 코드(펜스/인라인)는 보호.
-//   ① hardBreak 백슬래시: 라이브러리가 hardBreak 를 "\\\n" 로 직렬화 →
-//      breaks:true 환경에선 '\n' 만으로 동일 렌더라 줄 끝 '\' 만 제거(개행 유지).
-//   ② 표 셀의 block-marker escape(\#,\>,\+,\-,\1.): 셀 안에선 헤딩/리스트/인용이
-//      될 수 없어 불필요 → 해제. 인라인 \*,\`,\[,\_ 는 보존(평문 특수문자 round-trip
-//      안전성 위해 — 사용자 선택).
-function normalizeSerializedMarkdown(md: string): string {
-    // ── 코드펜스 보호 (joinBrokenTableRows 와 동일 마스킹) ──
-    const fences: string[] = [];
-    const srcLines = md.split('\n');
-    const maskedLines: string[] = [];
-    let i = 0;
-    while (i < srcLines.length) {
-        const line = srcLines[i];
-        const open = line.match(/^[ ]{0,3}(([`~])\2{2,})/);
-        if (open) {
-            const ch = open[2];
-            const minLen = open[1].length;
-            const closeRe = new RegExp(`^[ ]{0,3}${ch === '`' ? '`' : '~'}{${minLen},}[ \\t]*$`);
-            let j = i + 1;
-            while (j < srcLines.length && !closeRe.test(srcLines[j])) j++;
-            const endIdx = j < srcLines.length ? j + 1 : j;
-            fences.push(srcLines.slice(i, endIdx).join('\n'));
-            maskedLines.push(`\x00MMN${fences.length - 1}\x00`);
-            i = endIdx;
-            continue;
-        }
-        maskedLines.push(line);
-        i++;
-    }
-    let result = maskedLines.join('\n');
-
-    // ── 인라인 코드 보호 (단일 라인) ──
-    const codes: string[] = [];
-    result = result.replace(/`[^`\n]*`/g, (m) => {
-        codes.push(m);
-        return `\x00MMC${codes.length - 1}\x00`;
-    });
-
-    // ① hardBreak 백슬래시 제거 (개행은 유지)
-    result = result.replace(/\\(?=\n)/g, '').replace(/\\$/, '');
-
-    // ② 표 행에서만 block-marker escape 해제
-    result = result
-        .split('\n')
-        .map((ln) => {
-            if (!/^\s*\|/.test(ln)) return ln;
-            return ln
-                .replace(/\\(#{1,6})/g, '$1')
-                .replace(/\\([>+\-])/g, '$1')
-                .replace(/(\d+)\\\./g, '$1.');
-        })
-        .join('\n');
-
-    // ── 복원 ──
-    result = result.replace(/\x00MMC(\d+)\x00/g, (_, n) => codes[Number(n)]);
-    result = result.replace(/\x00MMN(\d+)\x00/g, (_, n) => fences[Number(n)]);
-    return result;
 }
 
 interface FrontmatterParts {

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSerializedMarkdown } from './markdownSerialization';
+
+describe('normalizeSerializedMarkdown', () => {
+    it('unescapes literal single tildes from rich text serialization', () => {
+        expect(normalizeSerializedMarkdown(String.raw`5-2. 현재 \~ 3개월: 공개 베타`))
+            .toBe('5-2. 현재 ~ 3개월: 공개 베타');
+        expect(normalizeSerializedMarkdown(String.raw`3\~5줄, A \~ B, \~home\~`))
+            .toBe('3~5줄, A ~ B, ~home~');
+    });
+
+    it('keeps strike delimiters, tilde fences, and inline code intact', () => {
+        const fenced = [
+            '~~~',
+            String.raw`inside \~ code fence`,
+            '~~~',
+            String.raw`after \~ fence`,
+        ].join('\n');
+
+        expect(normalizeSerializedMarkdown('~~취소선~~')).toBe('~~취소선~~');
+        expect(normalizeSerializedMarkdown(fenced))
+            .toBe(['~~~', String.raw`inside \~ code fence`, '~~~', 'after ~ fence'].join('\n'));
+        expect(normalizeSerializedMarkdown('code `a\\~b` and text \\~ ok'))
+            .toBe('code `a\\~b` and text ~ ok');
+    });
+
+    it('does not create new double-tilde delimiters or remove escaped backslashes', () => {
+        expect(normalizeSerializedMarkdown(String.raw`\~\~not strike`)).toBe(String.raw`~\~not strike`);
+        expect(normalizeSerializedMarkdown(String.raw`literal backslash \\~ stays`))
+            .toBe(String.raw`literal backslash \\~ stays`);
+    });
+
+    it('keeps existing table and hard break normalizations', () => {
+        expect(normalizeSerializedMarkdown('| \\# A | 1\\. item |')).toBe('| # A | 1. item |');
+        expect(normalizeSerializedMarkdown('line\\\nnext')).toBe('line\nnext');
+    });
+});

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -22,6 +22,10 @@ describe('normalizeSerializedMarkdown', () => {
             .toBe(['~~~', String.raw`inside \~ code fence`, '~~~', 'after ~ fence'].join('\n'));
         expect(normalizeSerializedMarkdown('code `a\\~b` and text \\~ ok'))
             .toBe('code `a\\~b` and text ~ ok');
+        expect(normalizeSerializedMarkdown('code `` a \\~ b ` `` and text \\~ ok'))
+            .toBe('code `` a \\~ b ` `` and text ~ ok');
+        expect(normalizeSerializedMarkdown('code ``a\\~\nb`` and text \\~ ok'))
+            .toBe('code ``a\\~\nb`` and text ~ ok');
     });
 
     it('does not create new double-tilde delimiters or remove escaped backslashes', () => {

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -1,3 +1,49 @@
+function maskInlineCodeSpans(src: string, codes: string[]): string {
+    let out = '';
+    let i = 0;
+
+    while (i < src.length) {
+        if (src[i] !== '`') {
+            out += src[i];
+            i++;
+            continue;
+        }
+
+        let openLen = 1;
+        while (src[i + openLen] === '`') openLen++;
+
+        let closeStart = -1;
+        let closeEnd = -1;
+        let j = i + openLen;
+        while (j < src.length) {
+            if (src[j] !== '`') {
+                j++;
+                continue;
+            }
+            let closeLen = 1;
+            while (src[j + closeLen] === '`') closeLen++;
+            if (closeLen === openLen) {
+                closeStart = j;
+                closeEnd = j + closeLen;
+                break;
+            }
+            j += closeLen;
+        }
+
+        if (closeStart === -1) {
+            out += src.slice(i, i + openLen);
+            i += openLen;
+            continue;
+        }
+
+        codes.push(src.slice(i, closeEnd));
+        out += `\x00MMC${codes.length - 1}\x00`;
+        i = closeEnd;
+    }
+
+    return out;
+}
+
 // tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
 // 불필요한 기호 제거(선별적). 코드(펜스/인라인)는 보호.
 //   ① hardBreak 백슬래시: 라이브러리가 hardBreak 를 "\\\n" 로 직렬화 →
@@ -34,12 +80,9 @@ export function normalizeSerializedMarkdown(md: string): string {
     }
     let result = maskedLines.join('\n');
 
-    // ── 인라인 코드 보호 (단일 라인) ──
+    // ── 인라인 코드 보호 ──
     const codes: string[] = [];
-    result = result.replace(/`[^`\n]*`/g, (m) => {
-        codes.push(m);
-        return `\x00MMC${codes.length - 1}\x00`;
-    });
+    result = maskInlineCodeSpans(result, codes);
 
     // ① hardBreak 백슬래시 제거 (개행은 유지)
     result = result.replace(/\\(?=\n)/g, '').replace(/\\$/, '');

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -1,0 +1,71 @@
+// tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
+// 불필요한 기호 제거(선별적). 코드(펜스/인라인)는 보호.
+//   ① hardBreak 백슬래시: 라이브러리가 hardBreak 를 "\\\n" 로 직렬화 →
+//      breaks:true 환경에선 '\n' 만으로 동일 렌더라 줄 끝 '\' 만 제거(개행 유지).
+//   ② 표 셀의 block-marker escape(\#,\>,\+,\-,\1.): 셀 안에선 헤딩/리스트/인용이
+//      될 수 없어 불필요 → 해제. 인라인 \*,\`,\[,\_ 는 보존(평문 특수문자 round-trip
+//      안전성 위해 — 사용자 선택).
+//   ③ literal single tilde escape(\~): GFM strike 는 `~~`만 사용하므로 일반 텍스트의
+//      단일 물결표는 원문 품질을 위해 해제. `~~`/`~~~`를 새로 만들 수 있는 위치,
+//      이중 백슬래시, 코드 영역은 보존.
+export function normalizeSerializedMarkdown(md: string): string {
+    // ── 코드펜스 보호 (joinBrokenTableRows 와 동일 마스킹) ──
+    const fences: string[] = [];
+    const srcLines = md.split('\n');
+    const maskedLines: string[] = [];
+    let i = 0;
+    while (i < srcLines.length) {
+        const line = srcLines[i];
+        const open = line.match(/^[ ]{0,3}(([`~])\2{2,})/);
+        if (open) {
+            const ch = open[2];
+            const minLen = open[1].length;
+            const closeRe = new RegExp(`^[ ]{0,3}${ch === '`' ? '`' : '~'}{${minLen},}[ \\t]*$`);
+            let j = i + 1;
+            while (j < srcLines.length && !closeRe.test(srcLines[j])) j++;
+            const endIdx = j < srcLines.length ? j + 1 : j;
+            fences.push(srcLines.slice(i, endIdx).join('\n'));
+            maskedLines.push(`\x00MMN${fences.length - 1}\x00`);
+            i = endIdx;
+            continue;
+        }
+        maskedLines.push(line);
+        i++;
+    }
+    let result = maskedLines.join('\n');
+
+    // ── 인라인 코드 보호 (단일 라인) ──
+    const codes: string[] = [];
+    result = result.replace(/`[^`\n]*`/g, (m) => {
+        codes.push(m);
+        return `\x00MMC${codes.length - 1}\x00`;
+    });
+
+    // ① hardBreak 백슬래시 제거 (개행은 유지)
+    result = result.replace(/\\(?=\n)/g, '').replace(/\\$/, '');
+
+    // ② 표 행에서만 block-marker escape 해제
+    result = result
+        .split('\n')
+        .map((ln) => {
+            if (!/^\s*\|/.test(ln)) return ln;
+            return ln
+                .replace(/\\(#{1,6})/g, '$1')
+                .replace(/\\([>+\-])/g, '$1')
+                .replace(/(\d+)\\\./g, '$1.');
+        })
+        .join('\n');
+
+    // ③ 일반 텍스트의 literal single tilde escape 해제
+    result = result.replace(/\\~/g, (match, offset: number, src: string) => {
+        const prev = src[offset - 1];
+        const next = src[offset + 2];
+        if (prev === '\\' || prev === '~' || next === '~') return match;
+        return '~';
+    });
+
+    // ── 복원 ──
+    result = result.replace(/\x00MMC(\d+)\x00/g, (_, n) => codes[Number(n)]);
+    result = result.replace(/\x00MMN(\d+)\x00/g, (_, n) => fences[Number(n)]);
+    return result;
+}


### PR DESCRIPTION
## Summary
- Move rich-text markdown serialization normalization into a testable lib helper
- Unescape serializer-added literal single tilde escapes outside code/fences
- Preserve strike delimiters, tilde fences, inline code, and double-backslash escapes

## Tests
- npm test -- src/lib/markdownSerialization.test.ts
- npm test
- npm run build

Closes #102