### PR TITLE
fix(slideshow): preserve soft line breaks

### DIFF
--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -15,6 +15,7 @@ import remarkGfm from 'remark-gfm';
 import remarkFrontmatter from 'remark-frontmatter';
 import rehypeHighlight from 'rehype-highlight';
 import { resolveImageSrc } from '../lib/imageSrc';
+import { remarkSoftBreaks } from '../lib/remarkSoftBreaks';
 import { splitIntoSlides, type SlideshowSettings } from '../lib/slideSplit';
 import './SlideshowView.css';
 
@@ -34,7 +35,7 @@ interface SlideshowViewProps {
 function SlideMarkdown({ md, docDir }: { md: string; docDir: string | null }) {
     return (
         <ReactMarkdown
-            remarkPlugins={[remarkFrontmatter, [remarkGfm, { singleTilde: false }]]}
+            remarkPlugins={[remarkFrontmatter, [remarkGfm, { singleTilde: false }], remarkSoftBreaks]}
             rehypePlugins={[rehypeHighlight]}
             components={{
                 img: ({ node: _node, src, ...props }) => (

--- a/src/lib/remarkSoftBreaks.test.ts
+++ b/src/lib/remarkSoftBreaks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import type { Paragraph, Root } from 'mdast';
+import { remarkSoftBreaks } from './remarkSoftBreaks';
+
+function parseWithSoftBreaks(md: string): Root {
+    const processor = unified()
+        .use(remarkParse)
+        .use(remarkGfm, { singleTilde: false })
+        .use(remarkSoftBreaks);
+    const tree = processor.parse(md);
+    return processor.runSync(tree) as Root;
+}
+
+function collectTypes(node: unknown): string[] {
+    if (!node || typeof node !== 'object') return [];
+    const typed = node as { type?: string; children?: unknown[] };
+    const own = typed.type ? [typed.type] : [];
+    const children = Array.isArray(typed.children)
+        ? typed.children.flatMap((child) => collectTypes(child))
+        : [];
+    return [...own, ...children];
+}
+
+describe('remarkSoftBreaks', () => {
+    it('converts paragraph soft line breaks to break nodes', () => {
+        const tree = parseWithSoftBreaks('첫 줄\n둘째 줄\n셋째 줄');
+        const paragraph = tree.children[0] as Paragraph;
+
+        expect(paragraph.type).toBe('paragraph');
+        expect(paragraph.children.map((child) => child.type))
+            .toEqual(['text', 'break', 'text', 'break', 'text']);
+    });
+
+    it('preserves code block line endings', () => {
+        const tree = parseWithSoftBreaks(['```ts', 'const a = 1;', 'const b = 2;', '```'].join('\n'));
+
+        expect(tree.children[0]).toMatchObject({
+            type: 'code',
+            lang: 'ts',
+            value: 'const a = 1;\nconst b = 2;',
+        });
+        expect(collectTypes(tree).filter((type) => type === 'break')).toHaveLength(0);
+    });
+
+    it('works inside nested markdown containers', () => {
+        const tree = parseWithSoftBreaks(['> 발표 원고 첫 줄', '> 발표 원고 둘째 줄', '', '- 항목 첫 줄', '  항목 둘째 줄'].join('\n'));
+
+        expect(collectTypes(tree).filter((type) => type === 'break')).toHaveLength(2);
+    });
+});

--- a/src/lib/remarkSoftBreaks.ts
+++ b/src/lib/remarkSoftBreaks.ts
@@ -1,0 +1,41 @@
+import type { Root } from 'mdast';
+
+type MutableMdastNode = {
+    type?: string;
+    value?: string;
+    children?: MutableMdastNode[];
+    [key: string]: unknown;
+};
+
+function splitTextNode(node: MutableMdastNode): MutableMdastNode[] {
+    if (typeof node.value !== 'string' || !node.value.includes('\n')) return [node];
+
+    const parts = node.value.split('\n');
+    const out: MutableMdastNode[] = [];
+    parts.forEach((part, index) => {
+        if (part) out.push({ ...node, value: part });
+        if (index < parts.length - 1) out.push({ type: 'break' });
+    });
+    return out;
+}
+
+function transformSoftBreaks(parent: MutableMdastNode): void {
+    if (!Array.isArray(parent.children)) return;
+
+    const nextChildren: MutableMdastNode[] = [];
+    for (const child of parent.children) {
+        if (child.type === 'text') {
+            nextChildren.push(...splitTextNode(child));
+            continue;
+        }
+        transformSoftBreaks(child);
+        nextChildren.push(child);
+    }
+    parent.children = nextChildren;
+}
+
+export function remarkSoftBreaks() {
+    return (tree: Root) => {
+        transformSoftBreaks(tree as MutableMdastNode);
+    };
+}


### PR DESCRIPTION
## Summary
- Add a local remark plugin that converts soft line breaks in mdast text nodes to break nodes
- Use it in Slideshow markdown rendering so single newlines display as line breaks
- Cover paragraph, code block, blockquote, and list cases with tests

## Tests
- npm test -- src/lib/remarkSoftBreaks.test.ts
- npm test
- npm run build

Closes #103