### PR TITLE
fix(pptx): preserve source images after slide split

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -809,10 +809,6 @@ function App() {
         alert('AI 응답을 해석하지 못해 기본 레이아웃으로 저장합니다.\n(개발자 콘솔에 원문이 로깅되었습니다)');
         slides = markdownToSlides(content);
       }
-      if (slideImagePolicyMode(pptxOptions.imagePolicy) === 'sourceOnly') {
-        slides = preserveSourceImagesForPptx(slides, content);
-      }
-
       pushPptxProgressStep(jobId, '📊 슬라이드 레이아웃 검증 중...', undefined, 'pptx-layout-qa');
       slides = normalizeSlidesForPptx(slides);
       if (slides.length > PPTX_MAX_SLIDES) {
@@ -824,6 +820,9 @@ function App() {
           `${originalCount}장 → ${PPTX_MAX_SLIDES}장`,
           'pptx-slide-limit',
         );
+      }
+      if (slideImagePolicyMode(pptxOptions.imagePolicy) === 'sourceOnly') {
+        slides = preserveSourceImagesForPptx(slides, content);
       }
       const report = validateSlideDeck(slides);
       const issueSummary = summarizeSlideIssues(report);

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -448,6 +448,28 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBe('assets/second.png');
   });
 
+  it('source-map fallback으로 소비한 이미지를 split continuation의 slide-index fallback에서 중복하지 않음', () => {
+    const markdown = ['# Cover', 'Intro', '## Evidence', '![first](assets/first.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBeUndefined();
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -396,6 +396,29 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBe('assets/second.png');
   });
 
+  it('source-only PPTX 경로에서 sourceId 없는 split 첫 조각의 기존 원본 이미지도 fallback 순서에서 소비', () => {
+    const markdown = ['# Report', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            image: { src: 'assets/first.png', alt: 'first' },
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBe('assets/second.png');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -515,6 +515,30 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBeUndefined();
   });
 
+  it('sourceId가 유지된 split에서 두 번째 기존 이미지를 소비하면 첫 이미지를 continuation에 붙이지 않음', () => {
+    const markdown = ['# Report', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            sourceIds: ['S2'],
+            image: { src: 'assets/second.png', alt: 'second' },
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/second.png');
+    expect(merged[1].image?.src).toBeUndefined();
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -419,6 +419,35 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBe('assets/second.png');
   });
 
+  it('sourceId 없는 기존 원본 이미지가 첫 fallback 슬롯이 아니어도 continuation에 앞 이미지를 밀지 않음', () => {
+    const markdown = [
+      '# Cover',
+      '![cover](assets/cover.png)',
+      '## Evidence',
+      '![first](assets/first.png)',
+      '![second](assets/second.png)',
+    ].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            image: { src: 'assets/first.png', alt: 'first' },
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBe('assets/second.png');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -372,6 +372,30 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBe('assets/second.png');
   });
 
+  it('source-only PPTX 경로에서 split 첫 조각의 기존 원본 이미지도 소비 처리', () => {
+    const markdown = ['# Report', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            sourceIds: ['S2'],
+            image: { src: 'assets/first.png', alt: 'first' },
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBe('assets/second.png');
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -6,6 +6,7 @@ import {
   slideDeckFromLlmJson,
   slidesFromLlmJson,
 } from './markdownToSlides';
+import { normalizeSlidesForPptx } from './slideValidation';
 
 describe('markdownToSlides — 분할 규칙', () => {
   it('수평선(---) 으로 슬라이드를 나눈다', () => {
@@ -344,6 +345,29 @@ describe('slidesFromLlmJson', () => {
 
     const merged = preserveSourceImagesForPptx(aiSlides ?? [], markdown);
 
+    expect(merged[0].image?.src).toBe('assets/first.png');
+    expect(merged[1].image?.src).toBe('assets/second.png');
+  });
+
+  it('source-only PPTX 경로에서 split 이후 continuation에도 같은 sourceId 이미지를 보강', () => {
+    const markdown = ['# Report', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            sourceIds: ['S2'],
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
     expect(merged[0].image?.src).toBe('assets/first.png');
     expect(merged[1].image?.src).toBe('assets/second.png');
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -470,6 +470,28 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBeUndefined();
   });
 
+  it('source map S번호와 markdownToSlides index가 달라도 소비한 이미지를 slide-index fallback에서 중복하지 않음', () => {
+    const markdown = ['# Deck', '## Evidence', 'Body text', '### Chart', '![chart](assets/chart.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/chart.png');
+    expect(merged[1].image?.src).toBeUndefined();
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.test.ts
+++ b/src/lib/markdownToSlides.test.ts
@@ -492,6 +492,29 @@ describe('slidesFromLlmJson', () => {
     expect(merged[1].image?.src).toBeUndefined();
   });
 
+  it('source slide의 두 번째 이미지를 소비해도 같은 source slide의 첫 이미지를 continuation에 붙이지 않음', () => {
+    const markdown = ['# Deck', '## Evidence', '![first](assets/first.png)', '![second](assets/second.png)'].join('\n');
+    const aiSlides = slidesFromLlmJson(
+      JSON.stringify({
+        slides: [
+          {
+            title: 'Dense evidence',
+            layout: 'content',
+            image: { src: 'assets/second.png', alt: 'second' },
+            bullets: Array.from({ length: 14 }, (_, index) => `Evidence point ${index + 1}`),
+          },
+        ],
+      }),
+    );
+
+    const normalized = normalizeSlidesForPptx(aiSlides ?? []);
+    const merged = preserveSourceImagesForPptx(normalized, markdown);
+
+    expect(normalized).toHaveLength(2);
+    expect(merged[0].image?.src).toBe('assets/second.png');
+    expect(merged[1].image?.src).toBeUndefined();
+  });
+
   it('완전 비 JSON 은 null', () => {
     expect(slidesFromLlmJson('sorry, I cannot do that')).toBeNull();
   });

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -481,6 +481,13 @@ function slideHasImageSrc(slide: Slide): boolean {
   return Boolean(slide.image?.src?.trim() || slide.body.some((block) => block.kind === 'image' && block.src.trim()));
 }
 
+function existingSlideImageSrc(slide: Slide): string | undefined {
+  const imageSrc = slide.image?.src?.trim();
+  if (imageSrc) return imageSrc;
+  const block = slide.body.find((item): item is Extract<SlideBlock, { kind: 'image' }> => item.kind === 'image');
+  return block?.src.trim() || undefined;
+}
+
 function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
   const src = slide.image?.src?.trim();
   if (src) return { ...slide.image, src };
@@ -618,9 +625,39 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     usedSourceIndexes.add(sourceIndex);
     return image;
   };
+  const consumeExistingSourceImage = (slide: Slide, slideIndex: number) => {
+    const existingSrc = existingSlideImageSrc(slide);
+    if (!existingSrc) return;
+    for (const sourceId of slide.sourceIds ?? []) {
+      const normalized = sourceId.trim().toUpperCase();
+      const images = sourceImagesById.get(normalized);
+      const offset = sourceImageOffsets.get(normalized) ?? 0;
+      if (images?.[offset]?.src?.trim() === existingSrc) {
+        sourceImageOffsets.set(normalized, offset + 1);
+        return;
+      }
+      if (sourceImagesById.size === 0) {
+        const sourceIndex = sourceIndexFromId(sourceId);
+        if (sourceIndex === undefined || sourceIndex >= sourceSlides.length) continue;
+        const sourceImage = firstSourceImage(sourceSlides[sourceIndex]);
+        if (sourceImage?.src?.trim() === existingSrc) {
+          usedSourceIndexes.add(sourceIndex);
+          return;
+        }
+      }
+    }
+    if (!slide.sourceIds?.length && sourceImagesById.size === 0) {
+      const sourceSlide = sourceSlides[slideIndex];
+      const sourceImage = sourceSlide ? firstSourceImage(sourceSlide) : undefined;
+      if (sourceImage?.src?.trim() === existingSrc) usedSourceIndexes.add(slideIndex);
+    }
+  };
 
   return slides.map((slide, slideIndex) => {
-    if (slideHasImageSrc(slide)) return slide;
+    if (slideHasImageSrc(slide)) {
+      consumeExistingSourceImage(slide, slideIndex);
+      return slide;
+    }
     let image: SlideImageSpec | undefined;
     for (const sourceId of slide.sourceIds ?? []) {
       image = takeSourceImage(sourceId) ?? (sourceImagesById.size === 0 ? takeImage(sourceIndexFromId(sourceId)) : undefined);

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -599,10 +599,16 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
   const usedSourceIndexes = new Set<number>();
   const consumedSourceImages = new Set<string>();
   const sourceImageKey = (id: string, imageIndex: number) => `${id}\u0000${imageIndex}`;
-  const markSourceImageConsumed = (id: string, imageIndex: number) => {
+  const markSourceSlideUsedByImageSrc = (src: string | undefined) => {
+    const existingSrc = src?.trim();
+    if (!existingSrc) return;
+    sourceSlides.forEach((sourceSlide, sourceIndex) => {
+      if (firstSourceImage(sourceSlide)?.src?.trim() === existingSrc) usedSourceIndexes.add(sourceIndex);
+    });
+  };
+  const markSourceImageConsumed = (id: string, imageIndex: number, src: string | undefined) => {
     consumedSourceImages.add(sourceImageKey(id, imageIndex));
-    const sourceIndex = sourceIndexFromId(id);
-    if (sourceIndex !== undefined) usedSourceIndexes.add(sourceIndex);
+    markSourceSlideUsedByImageSrc(src);
     let offset = sourceImageOffsets.get(id) ?? 0;
     while (consumedSourceImages.has(sourceImageKey(id, offset))) offset += 1;
     sourceImageOffsets.set(id, offset);
@@ -620,7 +626,7 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     for (let imageIndex = 0; imageIndex < images.length; imageIndex += 1) {
       if (consumedSourceImages.has(sourceImageKey(normalized, imageIndex))) continue;
       if (images[imageIndex]?.src?.trim() === existingSrc) {
-        markSourceImageConsumed(normalized, imageIndex);
+        markSourceImageConsumed(normalized, imageIndex, images[imageIndex]?.src);
         return true;
       }
     }
@@ -631,7 +637,7 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
       const { id, image, imageIndex } = sourceImageEntries[entryIndex];
       if (consumedSourceImages.has(sourceImageKey(id, imageIndex))) continue;
       if (image.src?.trim() === existingSrc) {
-        markSourceImageConsumed(id, imageIndex);
+        markSourceImageConsumed(id, imageIndex, image.src);
         nextSourceImageIndex = entryIndex + 1;
         return true;
       }
@@ -645,14 +651,14 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     const offset = firstUnconsumedSourceImageIndex(normalized, images);
     const image = images?.[offset];
     if (!image) return undefined;
-    markSourceImageConsumed(normalized, offset);
+    markSourceImageConsumed(normalized, offset, image.src);
     return image;
   };
   const takeNextSourceImage = (): SlideImageSpec | undefined => {
     while (nextSourceImageIndex < sourceImageEntries.length) {
       const { id, image, imageIndex } = sourceImageEntries[nextSourceImageIndex++];
       if (consumedSourceImages.has(sourceImageKey(id, imageIndex))) continue;
-      markSourceImageConsumed(id, imageIndex);
+      markSourceImageConsumed(id, imageIndex, image.src);
       return image;
     }
     return undefined;

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -636,10 +636,15 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     const normalized = sourceId.trim().toUpperCase();
     const images = sourceImagesById.get(normalized);
     if (!images) return false;
-    for (let imageIndex = 0; imageIndex < images.length; imageIndex += 1) {
+    const firstUnconsumedIndex = firstUnconsumedSourceImageIndex(normalized, images);
+    for (let imageIndex = firstUnconsumedIndex; imageIndex < images.length; imageIndex += 1) {
       if (consumedSourceImages.has(sourceImageKey(normalized, imageIndex))) continue;
       if (images[imageIndex]?.src?.trim() === existingSrc) {
-        markSourceImageConsumed(normalized, imageIndex, images[imageIndex]?.src);
+        for (let consumeIndex = firstUnconsumedIndex; consumeIndex <= imageIndex; consumeIndex += 1) {
+          if (!consumedSourceImages.has(sourceImageKey(normalized, consumeIndex))) {
+            markSourceImageConsumed(normalized, consumeIndex, images[consumeIndex]?.src);
+          }
+        }
         return true;
       }
     }

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -601,6 +601,8 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
   const sourceImageKey = (id: string, imageIndex: number) => `${id}\u0000${imageIndex}`;
   const markSourceImageConsumed = (id: string, imageIndex: number) => {
     consumedSourceImages.add(sourceImageKey(id, imageIndex));
+    const sourceIndex = sourceIndexFromId(id);
+    if (sourceIndex !== undefined) usedSourceIndexes.add(sourceIndex);
     let offset = sourceImageOffsets.get(id) ?? 0;
     while (consumedSourceImages.has(sourceImageKey(id, offset))) offset += 1;
     sourceImageOffsets.set(id, offset);

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -597,21 +597,60 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
   );
   let nextSourceImageIndex = 0;
   const usedSourceIndexes = new Set<number>();
+  const consumedSourceImages = new Set<string>();
+  const sourceImageKey = (id: string, imageIndex: number) => `${id}\u0000${imageIndex}`;
+  const markSourceImageConsumed = (id: string, imageIndex: number) => {
+    consumedSourceImages.add(sourceImageKey(id, imageIndex));
+    let offset = sourceImageOffsets.get(id) ?? 0;
+    while (consumedSourceImages.has(sourceImageKey(id, offset))) offset += 1;
+    sourceImageOffsets.set(id, offset);
+  };
+  const firstUnconsumedSourceImageIndex = (id: string, images: SlideImageSpec[]): number => {
+    let offset = sourceImageOffsets.get(id) ?? 0;
+    while (offset < images.length && consumedSourceImages.has(sourceImageKey(id, offset))) offset += 1;
+    sourceImageOffsets.set(id, offset);
+    return offset;
+  };
+  const consumeSourceImageBySrc = (sourceId: string, existingSrc: string): boolean => {
+    const normalized = sourceId.trim().toUpperCase();
+    const images = sourceImagesById.get(normalized);
+    if (!images) return false;
+    for (let imageIndex = 0; imageIndex < images.length; imageIndex += 1) {
+      if (consumedSourceImages.has(sourceImageKey(normalized, imageIndex))) continue;
+      if (images[imageIndex]?.src?.trim() === existingSrc) {
+        markSourceImageConsumed(normalized, imageIndex);
+        return true;
+      }
+    }
+    return false;
+  };
+  const consumeFallbackSourceImageBySrc = (existingSrc: string): boolean => {
+    for (let entryIndex = nextSourceImageIndex; entryIndex < sourceImageEntries.length; entryIndex += 1) {
+      const { id, image, imageIndex } = sourceImageEntries[entryIndex];
+      if (consumedSourceImages.has(sourceImageKey(id, imageIndex))) continue;
+      if (image.src?.trim() === existingSrc) {
+        markSourceImageConsumed(id, imageIndex);
+        nextSourceImageIndex = entryIndex + 1;
+        return true;
+      }
+    }
+    return false;
+  };
   const takeSourceImage = (sourceId: string): SlideImageSpec | undefined => {
     const normalized = sourceId.trim().toUpperCase();
     const images = sourceImagesById.get(normalized);
-    const offset = sourceImageOffsets.get(normalized) ?? 0;
+    if (!images) return undefined;
+    const offset = firstUnconsumedSourceImageIndex(normalized, images);
     const image = images?.[offset];
     if (!image) return undefined;
-    sourceImageOffsets.set(normalized, offset + 1);
+    markSourceImageConsumed(normalized, offset);
     return image;
   };
   const takeNextSourceImage = (): SlideImageSpec | undefined => {
     while (nextSourceImageIndex < sourceImageEntries.length) {
       const { id, image, imageIndex } = sourceImageEntries[nextSourceImageIndex++];
-      const offset = sourceImageOffsets.get(id) ?? 0;
-      if (imageIndex !== offset) continue;
-      sourceImageOffsets.set(id, offset + 1);
+      if (consumedSourceImages.has(sourceImageKey(id, imageIndex))) continue;
+      markSourceImageConsumed(id, imageIndex);
       return image;
     }
     return undefined;
@@ -625,33 +664,11 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     usedSourceIndexes.add(sourceIndex);
     return image;
   };
-  const consumeNextSourceImage = (existingSrc: string): boolean => {
-    while (nextSourceImageIndex < sourceImageEntries.length) {
-      const { id, image, imageIndex } = sourceImageEntries[nextSourceImageIndex];
-      const offset = sourceImageOffsets.get(id) ?? 0;
-      if (imageIndex !== offset) {
-        nextSourceImageIndex += 1;
-        continue;
-      }
-      const sourceSrc = image.src?.trim();
-      if (!sourceSrc || sourceSrc !== existingSrc) return false;
-      nextSourceImageIndex += 1;
-      sourceImageOffsets.set(id, offset + 1);
-      return true;
-    }
-    return false;
-  };
   const consumeExistingSourceImage = (slide: Slide, slideIndex: number) => {
     const existingSrc = existingSlideImageSrc(slide);
     if (!existingSrc) return;
     for (const sourceId of slide.sourceIds ?? []) {
-      const normalized = sourceId.trim().toUpperCase();
-      const images = sourceImagesById.get(normalized);
-      const offset = sourceImageOffsets.get(normalized) ?? 0;
-      if (images?.[offset]?.src?.trim() === existingSrc) {
-        sourceImageOffsets.set(normalized, offset + 1);
-        return;
-      }
+      if (consumeSourceImageBySrc(sourceId, existingSrc)) return;
       if (sourceImagesById.size === 0) {
         const sourceIndex = sourceIndexFromId(sourceId);
         if (sourceIndex === undefined || sourceIndex >= sourceSlides.length) continue;
@@ -662,7 +679,7 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
         }
       }
     }
-    if (!slide.sourceIds?.length && sourceImagesById.size > 0 && consumeNextSourceImage(existingSrc)) {
+    if (!slide.sourceIds?.length && sourceImagesById.size > 0 && consumeFallbackSourceImageBySrc(existingSrc)) {
       return;
     }
     if (!slide.sourceIds?.length && sourceImagesById.size === 0) {

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -495,6 +495,19 @@ function firstSourceImage(slide: Slide): SlideImageSpec | undefined {
   return block?.src.trim() ? { src: block.src.trim(), alt: block.alt, kind: 'source', role: 'support' } : undefined;
 }
 
+function sourceImageSrcs(slide: Slide): string[] {
+  const srcs: string[] = [];
+  const imageSrc = slide.image?.src?.trim();
+  if (imageSrc) srcs.push(imageSrc);
+  slide.body.forEach((item) => {
+    if (item.kind === 'image') {
+      const src = item.src.trim();
+      if (src) srcs.push(src);
+    }
+  });
+  return srcs;
+}
+
 function sourceImagesFromLine(line: string): SlideImageSpec[] {
   return [...line.matchAll(/!\[([^\]]*)\]\(([^)]+)\)/g)]
     .map((img) => ({ src: img[2].trim(), alt: img[1], kind: 'source' as const, role: 'support' as const }))
@@ -603,7 +616,7 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     const existingSrc = src?.trim();
     if (!existingSrc) return;
     sourceSlides.forEach((sourceSlide, sourceIndex) => {
-      if (firstSourceImage(sourceSlide)?.src?.trim() === existingSrc) usedSourceIndexes.add(sourceIndex);
+      if (sourceImageSrcs(sourceSlide).includes(existingSrc)) usedSourceIndexes.add(sourceIndex);
     });
   };
   const markSourceImageConsumed = (id: string, imageIndex: number, src: string | undefined) => {

--- a/src/lib/markdownToSlides.ts
+++ b/src/lib/markdownToSlides.ts
@@ -625,6 +625,22 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
     usedSourceIndexes.add(sourceIndex);
     return image;
   };
+  const consumeNextSourceImage = (existingSrc: string): boolean => {
+    while (nextSourceImageIndex < sourceImageEntries.length) {
+      const { id, image, imageIndex } = sourceImageEntries[nextSourceImageIndex];
+      const offset = sourceImageOffsets.get(id) ?? 0;
+      if (imageIndex !== offset) {
+        nextSourceImageIndex += 1;
+        continue;
+      }
+      const sourceSrc = image.src?.trim();
+      if (!sourceSrc || sourceSrc !== existingSrc) return false;
+      nextSourceImageIndex += 1;
+      sourceImageOffsets.set(id, offset + 1);
+      return true;
+    }
+    return false;
+  };
   const consumeExistingSourceImage = (slide: Slide, slideIndex: number) => {
     const existingSrc = existingSlideImageSrc(slide);
     if (!existingSrc) return;
@@ -645,6 +661,9 @@ export function preserveSourceImagesForPptx(slides: Slide[], source: Slide[] | s
           return;
         }
       }
+    }
+    if (!slide.sourceIds?.length && sourceImagesById.size > 0 && consumeNextSourceImage(existingSrc)) {
+      return;
     }
     if (!slide.sourceIds?.length && sourceImagesById.size === 0) {
       const sourceSlide = sourceSlides[slideIndex];


### PR DESCRIPTION
## Summary
- Move source-only image preservation after PPTX slide normalization/splitting
- Keep source image assignment aligned with the final slide list
- Add regression coverage for split continuation slides consuming multiple images from the same sourceId

## Tests
- npm test -- src/lib/markdownToSlides.test.ts src/lib/slideValidation.test.ts
- npm test
- npm run build

Closes #92