### PR TITLE
fix(markdown): preserve raw HTML round-trip

### DIFF
--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -89,4 +89,11 @@ describe('normalizeSerializedMarkdown', () => {
         expect(normalizeSerializedMarkdown('a &gt; b')).toBe('a > b');
         expect(normalizeSerializedMarkdown('| A |\n| --- |\n| a &gt; b |')).toBe('| A |\n| --- |\n| a > b |');
     });
+
+    it('requires a real tag boundary before restoring escaped HTML tags', () => {
+        expect(normalizeSerializedMarkdown('&lt;https://example.com&gt;')).toBe('&lt;https://example.com&gt;');
+        expect(normalizeSerializedMarkdown('&lt;user@example.com&gt;')).toBe('&lt;user@example.com&gt;');
+        expect(normalizeSerializedMarkdown('&lt;custom-element data-x=&quot;1&quot;&gt;x&lt;/custom-element&gt;'))
+            .toBe('<custom-element data-x="1">x</custom-element>');
+    });
 });

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -90,6 +90,15 @@ describe('normalizeSerializedMarkdown', () => {
         expect(normalizeSerializedMarkdown('| A |\n| --- |\n| a &gt; b |')).toBe('| A |\n| --- |\n| a > b |');
     });
 
+    it('preserves escaped greater-than at Markdown container content starts', () => {
+        expect(normalizeSerializedMarkdown('- &gt; note')).toBe('- &gt; note');
+        expect(normalizeSerializedMarkdown('> &gt; note')).toBe('> &gt; note');
+        expect(normalizeSerializedMarkdown('> - &gt; note')).toBe('> - &gt; note');
+        expect(normalizeSerializedMarkdown('- [ ] &gt; note')).toBe('- [ ] &gt; note');
+        expect(normalizeSerializedMarkdown('- a &gt; b')).toBe('- a > b');
+        expect(normalizeSerializedMarkdown('> a &gt; b')).toBe('> a > b');
+    });
+
     it('requires a real tag boundary before restoring escaped HTML tags', () => {
         expect(normalizeSerializedMarkdown('&lt;https://example.com&gt;')).toBe('&lt;https://example.com&gt;');
         expect(normalizeSerializedMarkdown('&lt;user@example.com&gt;')).toBe('&lt;user@example.com&gt;');

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -38,4 +38,41 @@ describe('normalizeSerializedMarkdown', () => {
         expect(normalizeSerializedMarkdown('| \\# A | 1\\. item |')).toBe('| # A | 1. item |');
         expect(normalizeSerializedMarkdown('line\\\nnext')).toBe('line\nnext');
     });
+
+    it('restores raw HTML comments, tags, and comparison brackets from rich text serialization', () => {
+        expect(normalizeSerializedMarkdown('&lt;!-- skip --&gt;')).toBe('<!-- skip -->');
+        expect(normalizeSerializedMarkdown('&lt;div class=&quot;note&quot; data-x=&quot;1&quot;&gt;x&lt;/div&gt;'))
+            .toBe('<div class="note" data-x="1">x</div>');
+        expect(normalizeSerializedMarkdown('a &lt; b &gt; c')).toBe('a < b > c');
+    });
+
+    it('restores footnote markers without touching code spans or fences', () => {
+        const fenced = [
+            '```md',
+            '&lt;div&gt;x&lt;/div&gt;',
+            String.raw`text\[^1\]`,
+            '```',
+            '&lt;section&gt;y&lt;/section&gt;',
+            String.raw`text\[^1\]`,
+            '`&lt;span&gt;z&lt;/span&gt;`',
+        ].join('\n');
+
+        expect(normalizeSerializedMarkdown(fenced)).toBe([
+            '```md',
+            '&lt;div&gt;x&lt;/div&gt;',
+            String.raw`text\[^1\]`,
+            '```',
+            '<section>y</section>',
+            'text[^1]',
+            '`&lt;span&gt;z&lt;/span&gt;`',
+        ].join('\n'));
+    });
+
+    it('restores escaped HTML in table serialization output without enabling preview rendering', () => {
+        expect(normalizeSerializedMarkdown('| A | B |\n| --- | --- |\n| &lt;span&gt;x&lt;/span&gt; | a &lt; b |'))
+            .toBe('| A | B |\n| --- | --- |\n| <span>x</span> | a < b |');
+        expect(normalizeSerializedMarkdown(
+            '&lt;table&gt;\n&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;X&lt;/td&gt;&lt;/tr&gt;\n&lt;/table&gt;',
+        )).toBe('<table>\n<tr><td colspan="2">X</td></tr>\n</table>');
+    });
 });

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -82,4 +82,11 @@ describe('normalizeSerializedMarkdown', () => {
         expect(normalizeSerializedMarkdown('&lt;span title=&quot;a &lt; b &gt; c&quot; data-x=&#39;1 &gt; 0&#39;&gt;x&lt;/span&gt;'))
             .toBe('<span title="a < b > c" data-x=\'1 > 0\'>x</span>');
     });
+
+    it('does not turn line-leading escaped greater-than text into blockquotes', () => {
+        expect(normalizeSerializedMarkdown('&gt; note')).toBe('&gt; note');
+        expect(normalizeSerializedMarkdown('  &gt; note')).toBe('  &gt; note');
+        expect(normalizeSerializedMarkdown('a &gt; b')).toBe('a > b');
+        expect(normalizeSerializedMarkdown('| A |\n| --- |\n| a &gt; b |')).toBe('| A |\n| --- |\n| a > b |');
+    });
 });

--- a/src/lib/markdownSerialization.test.ts
+++ b/src/lib/markdownSerialization.test.ts
@@ -75,4 +75,11 @@ describe('normalizeSerializedMarkdown', () => {
             '&lt;table&gt;\n&lt;tr&gt;&lt;td colspan=&quot;2&quot;&gt;X&lt;/td&gt;&lt;/tr&gt;\n&lt;/table&gt;',
         )).toBe('<table>\n<tr><td colspan="2">X</td></tr>\n</table>');
     });
+
+    it('does not treat escaped greater-than signs inside tag attributes as tag endings', () => {
+        expect(normalizeSerializedMarkdown('&lt;span title=&quot;a &gt; b&quot;&gt;x&lt;/span&gt;'))
+            .toBe('<span title="a > b">x</span>');
+        expect(normalizeSerializedMarkdown('&lt;span title=&quot;a &lt; b &gt; c&quot; data-x=&#39;1 &gt; 0&#39;&gt;x&lt;/span&gt;'))
+            .toBe('<span title="a < b > c" data-x=\'1 > 0\'>x</span>');
+    });
 });

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -44,6 +44,13 @@ function maskInlineCodeSpans(src: string, codes: string[]): string {
     return out;
 }
 
+function unescapeHtmlTagAttributes(value: string): string {
+    return value
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;|&#39;/g, "'")
+        .replace(/&amp;/g, '&');
+}
+
 // tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
 // 불필요한 기호 제거(선별적). 코드(펜스/인라인)는 보호.
 //   ① hardBreak 백슬래시: 라이브러리가 hardBreak 를 "\\\n" 로 직렬화 →
@@ -54,6 +61,8 @@ function maskInlineCodeSpans(src: string, codes: string[]): string {
 //   ③ literal single tilde escape(\~): GFM strike 는 `~~`만 사용하므로 일반 텍스트의
 //      단일 물결표는 원문 품질을 위해 해제. `~~`/`~~~`를 새로 만들 수 있는 위치,
 //      이중 백슬래시, 코드 영역은 보존.
+//   ④ html:false 경로에서 raw HTML/주석/꺾쇠/footnote marker 가 entity 또는
+//      escape 로 변하는 것을 일부 복원한다. 전역 html:true 는 켜지 않는다(#89).
 export function normalizeSerializedMarkdown(md: string): string {
     // ── 코드펜스 보호 (joinBrokenTableRows 와 동일 마스킹) ──
     const fences: string[] = [];
@@ -106,6 +115,17 @@ export function normalizeSerializedMarkdown(md: string): string {
         if (prev === '\\' || prev === '~' || next === '~') return match;
         return '~';
     });
+
+    // ④ raw HTML/주석/비교 꺾쇠/footnote marker 복원
+    result = result
+        .replace(/&lt;!--([\s\S]*?)--&gt;/g, '<!--$1-->')
+        .replace(
+            /&lt;(\/?[A-Za-z][A-Za-z0-9:-]*(?:\s+[^<>\n]*?)?)&gt;/g,
+            (_match, inner: string) => `<${unescapeHtmlTagAttributes(inner)}>`,
+        )
+        .replace(/(^|[^\S\n])&lt;(?=[^\S\n])/g, '$1<')
+        .replace(/(^|[^\S\n])&gt;(?=[^\S\n])/g, '$1>')
+        .replace(/\\\[\^([^\]\n]+)\\\]/g, '[^$1]');
 
     // ── 복원 ──
     result = result.replace(/\x00MMC(\d+)\x00/g, (_, n) => codes[Number(n)]);

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -106,6 +106,16 @@ function restoreEscapedHtmlTags(src: string): string {
     return out;
 }
 
+function restoreComparisonGreaterThan(src: string): string {
+    return src.replace(/(^|[^\S\n])&gt;(?=[^\S\n])/g, (match, prefix: string, offset: number) => {
+        const entityStart = offset + prefix.length;
+        const lineStart = src.lastIndexOf('\n', entityStart - 1) + 1;
+        const beforeOnLine = src.slice(lineStart, entityStart);
+        if (/^[ \t]*$/.test(beforeOnLine)) return match;
+        return `${prefix}>`;
+    });
+}
+
 // tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
 // 불필요한 기호 제거(선별적). 코드(펜스/인라인)는 보호.
 //   ① hardBreak 백슬래시: 라이브러리가 hardBreak 를 "\\\n" 로 직렬화 →
@@ -175,8 +185,8 @@ export function normalizeSerializedMarkdown(md: string): string {
     result = result
         .replace(/&lt;!--([\s\S]*?)--&gt;/g, '<!--$1-->')
         .replace(/(^|[^\S\n])&lt;(?=[^\S\n])/g, '$1<')
-        .replace(/(^|[^\S\n])&gt;(?=[^\S\n])/g, '$1>')
         .replace(/\\\[\^([^\]\n]+)\\\]/g, '[^$1]');
+    result = restoreComparisonGreaterThan(result);
     result = restoreEscapedHtmlTags(result);
 
     // ── 복원 ──

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -59,9 +59,12 @@ function restoreEscapedHtmlTags(src: string): string {
     let i = 0;
 
     const isTagStart = (index: number): boolean => {
-        const first = src[index + 4];
-        if (first === '/') return /[A-Za-z]/.test(src[index + 5] ?? '');
-        return /[A-Za-z]/.test(first ?? '');
+        let cursor = index + 4;
+        if (src[cursor] === '/') cursor += 1;
+        if (!/[A-Za-z]/.test(src[cursor] ?? '')) return false;
+        cursor += 1;
+        while (/[A-Za-z0-9-]/.test(src[cursor] ?? '')) cursor += 1;
+        return src.startsWith('&gt;', cursor) || src[cursor] === '/' || /[ \t\r\n]/.test(src[cursor] ?? '');
     };
 
     while (i < src.length) {

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -46,9 +46,64 @@ function maskInlineCodeSpans(src: string, codes: string[]): string {
 
 function unescapeHtmlTagAttributes(value: string): string {
     return value
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
+        .replace(/&#34;/g, '"')
         .replace(/&apos;|&#39;/g, "'")
         .replace(/&amp;/g, '&');
+}
+
+function restoreEscapedHtmlTags(src: string): string {
+    let out = '';
+    let i = 0;
+
+    const isTagStart = (index: number): boolean => {
+        const first = src[index + 4];
+        if (first === '/') return /[A-Za-z]/.test(src[index + 5] ?? '');
+        return /[A-Za-z]/.test(first ?? '');
+    };
+
+    while (i < src.length) {
+        if (!src.startsWith('&lt;', i) || !isTagStart(i)) {
+            out += src[i];
+            i += 1;
+            continue;
+        }
+
+        let quote: '"' | "'" | null = null;
+        let close = -1;
+        let j = i + 4;
+        while (j < src.length) {
+            if (quote == null && src.startsWith('&gt;', j)) {
+                close = j;
+                break;
+            }
+            if (src[j] === '"' || src.startsWith('&quot;', j) || src.startsWith('&#34;', j)) {
+                quote = quote === '"' ? null : quote == null ? '"' : quote;
+                j += src[j] === '"' ? 1 : src.startsWith('&quot;', j) ? 6 : 5;
+                continue;
+            }
+            if (src[j] === "'" || src.startsWith('&apos;', j) || src.startsWith('&#39;', j)) {
+                quote = quote === "'" ? null : quote == null ? "'" : quote;
+                j += src[j] === "'" ? 1 : src.startsWith('&apos;', j) ? 6 : 5;
+                continue;
+            }
+            j += 1;
+        }
+
+        if (close === -1) {
+            out += src[i];
+            i += 1;
+            continue;
+        }
+
+        const inner = src.slice(i + 4, close);
+        out += `<${unescapeHtmlTagAttributes(inner)}>`;
+        i = close + 4;
+    }
+
+    return out;
 }
 
 // tiptap-markdown 0.9.0 직렬화(getMarkdown) 후처리 — round-trip 시 끼어드는
@@ -119,13 +174,10 @@ export function normalizeSerializedMarkdown(md: string): string {
     // ④ raw HTML/주석/비교 꺾쇠/footnote marker 복원
     result = result
         .replace(/&lt;!--([\s\S]*?)--&gt;/g, '<!--$1-->')
-        .replace(
-            /&lt;(\/?[A-Za-z][A-Za-z0-9:-]*(?:\s+[^<>\n]*?)?)&gt;/g,
-            (_match, inner: string) => `<${unescapeHtmlTagAttributes(inner)}>`,
-        )
         .replace(/(^|[^\S\n])&lt;(?=[^\S\n])/g, '$1<')
         .replace(/(^|[^\S\n])&gt;(?=[^\S\n])/g, '$1>')
         .replace(/\\\[\^([^\]\n]+)\\\]/g, '[^$1]');
+    result = restoreEscapedHtmlTags(result);
 
     // ── 복원 ──
     result = result.replace(/\x00MMC(\d+)\x00/g, (_, n) => codes[Number(n)]);

--- a/src/lib/markdownSerialization.ts
+++ b/src/lib/markdownSerialization.ts
@@ -109,12 +109,28 @@ function restoreEscapedHtmlTags(src: string): string {
     return out;
 }
 
+function isMarkdownContainerContentStart(prefix: string): boolean {
+    let rest = prefix;
+    let changed = true;
+
+    while (changed) {
+        const before = rest;
+        rest = rest
+            .replace(/^[ \t]{0,3}(?:>|&gt;)[ \t]?/, '')
+            .replace(/^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/, '')
+            .replace(/^[ \t]*\[[ xX]\][ \t]+/, '');
+        changed = rest !== before;
+    }
+
+    return /^[ \t]*$/.test(rest);
+}
+
 function restoreComparisonGreaterThan(src: string): string {
     return src.replace(/(^|[^\S\n])&gt;(?=[^\S\n])/g, (match, prefix: string, offset: number) => {
         const entityStart = offset + prefix.length;
         const lineStart = src.lastIndexOf('\n', entityStart - 1) + 1;
         const beforeOnLine = src.slice(lineStart, entityStart);
-        if (/^[ \t]*$/.test(beforeOnLine)) return match;
+        if (isMarkdownContainerContentStart(beforeOnLine)) return match;
         return `${prefix}>`;
     });
 }


### PR DESCRIPTION
## Summary
- restore escaped raw HTML comments/tags, comparison angle brackets, and footnote markers after rich text serialization
- keep global Markdown `html:false`; this only normalizes saved Markdown output and does not enable raw HTML preview rendering
- add regression tests for comments, tags, footnotes, code/fence protection, and table-related escaped HTML output

Closes #89

## Tests
- npm test
- npm run build