### PR TITLE
fix(ai): cancel native generation jobs

### DIFF
--- a/src-tauri/src/converters/commands.rs
+++ b/src-tauri/src/converters/commands.rs
@@ -8,7 +8,9 @@ use super::notes_pipeline::{self, NotesJobOptions, NotesJobResult};
 use super::ocr_pipeline::{self, OcrJobOptions, OcrJobResult};
 use super::progress::{ProgressEmitter, ProgressModelInfo};
 use serde::Deserialize;
+use std::future::Future;
 use tauri::AppHandle;
+use tokio_util::sync::CancellationToken;
 
 /// Frontend 가 jobId 전달하면 그걸 사용 — listener 필터링으로 다른 윈도우의 동시
 /// 진행 event 와 분리. 없으면 자체 생성 (backward compat).
@@ -67,6 +69,45 @@ pub fn get_conversions_dir() -> String {
 
 #[tauri::command]
 pub fn cancel_slide_job(job_id: String) -> bool {
+    super::cancel::cancel_job(&job_id)
+}
+
+const AI_CANCELLED_MESSAGE: &str = "사용자가 작업을 정지했습니다.";
+
+async fn run_cancellable_ai<F, T>(job_id: Option<String>, work: F) -> Result<T, String>
+where
+    F: Future<Output = Result<T, String>>,
+{
+    run_cancellable_ai_with_token(job_id, |_| work).await
+}
+
+async fn run_cancellable_ai_with_token<F, Fut, T>(
+    job_id: Option<String>,
+    make_work: F,
+) -> Result<T, String>
+where
+    F: FnOnce(Option<CancellationToken>) -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    let Some(job_id) = job_id
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        return make_work(None).await;
+    };
+
+    let _cancel_guard = super::cancel::job_guard(&job_id);
+    let cancel_token = super::cancel::register_job(&job_id);
+    let result = tokio::select! {
+        result = make_work(Some(cancel_token.clone())) => result,
+        _ = cancel_token.cancelled() => Err(AI_CANCELLED_MESSAGE.to_string()),
+    };
+    super::cancel::unregister_job(&job_id);
+    result
+}
+
+#[tauri::command]
+pub fn cancel_ai_generation(job_id: String) -> bool {
     super::cancel::cancel_job(&job_id)
 }
 
@@ -1292,39 +1333,43 @@ pub async fn ai_generate_claude(
     claude_auth: crate::subscription_auth::ClaudeAuthMode,
     max_tokens: Option<u32>,
     model: Option<String>,
+    job_id: Option<String>,
 ) -> Result<String, String> {
-    use super::keychain::{get_key, Provider};
-    use super::llm::anthropic::{self, ClaudeAuth, ClaudeOptions};
-    use crate::subscription_auth::ClaudeAuthMode;
+    run_cancellable_ai(job_id, async move {
+        use super::keychain::{get_key, Provider};
+        use super::llm::anthropic::{self, ClaudeAuth, ClaudeOptions};
+        use crate::subscription_auth::ClaudeAuthMode;
 
-    let model_id = model.as_deref().unwrap_or(super::MODEL_NOTES_CLAUDE);
-    let opts = ClaudeOptions {
-        max_output_tokens: Some(max_tokens.unwrap_or(16000)),
-        system,
-    };
+        let model_id = model.unwrap_or_else(|| super::MODEL_NOTES_CLAUDE.to_string());
+        let opts = ClaudeOptions {
+            max_output_tokens: Some(max_tokens.unwrap_or(16000)),
+            system,
+        };
 
-    let result = match claude_auth {
-        ClaudeAuthMode::Subscription => {
-            let token = crate::subscription_auth::claude_access_token().await?;
-            anthropic::generate_text(
-                ClaudeAuth::Subscription(&token),
-                model_id,
-                &prompt,
-                Some(opts),
-            )
-            .await
-        }
-        ClaudeAuthMode::ApiKey => {
-            let key = get_key(Provider::Claude)
-                .map_err(err_to_string)?
-                .ok_or_else(|| {
-                    "Claude API 키가 없습니다. Settings 에서 등록하거나 구독 로그인을 사용하세요."
-                        .to_string()
-                })?;
-            anthropic::generate_text(ClaudeAuth::ApiKey(&key), model_id, &prompt, Some(opts)).await
-        }
-    };
-    result.map(|r| r.text).map_err(err_to_string)
+        let result = match claude_auth {
+            ClaudeAuthMode::Subscription => {
+                let token = crate::subscription_auth::claude_access_token().await?;
+                anthropic::generate_text(
+                    ClaudeAuth::Subscription(&token),
+                    &model_id,
+                    &prompt,
+                    Some(opts),
+                )
+                .await
+            }
+            ClaudeAuthMode::ApiKey => {
+                let key = get_key(Provider::Claude)
+                    .map_err(err_to_string)?
+                    .ok_or_else(|| {
+                        "Claude API 키가 없습니다. Settings 에서 등록하거나 구독 로그인을 사용하세요."
+                            .to_string()
+                    })?;
+                anthropic::generate_text(ClaudeAuth::ApiKey(&key), &model_id, &prompt, Some(opts)).await
+            }
+        };
+        result.map(|r| r.text).map_err(err_to_string)
+    })
+    .await
 }
 
 // ─── 범용 ChatGPT(Codex 구독) 텍스트 생성 (React AI 모드) ────────────────────
@@ -1336,21 +1381,25 @@ pub async fn ai_generate_codex(
     system: Option<String>,
     prompt: String,
     model: Option<String>,
+    job_id: Option<String>,
 ) -> Result<String, String> {
-    use super::llm::openai_codex;
-    let tokens = crate::subscription_auth::read_codex_tokens()?;
-    let model_id = model.as_deref().unwrap_or(super::MODEL_CODEX);
-    openai_codex::generate_text(
-        &tokens.access_token,
-        tokens.account_id.as_deref(),
-        model_id,
-        system.as_deref(),
-        &prompt,
-        None,
-    )
+    run_cancellable_ai(job_id, async move {
+        use super::llm::openai_codex;
+        let tokens = crate::subscription_auth::read_codex_tokens()?;
+        let model_id = model.unwrap_or_else(|| super::MODEL_CODEX.to_string());
+        openai_codex::generate_text(
+            &tokens.access_token,
+            tokens.account_id.as_deref(),
+            &model_id,
+            system.as_deref(),
+            &prompt,
+            None,
+        )
+        .await
+        .map(|r| r.text)
+        .map_err(err_to_string)
+    })
     .await
-    .map(|r| r.text)
-    .map_err(err_to_string)
 }
 
 // ─── Gemini 구독(Antigravity CLI) 텍스트 생성 ───────────────────────────────
@@ -1362,9 +1411,19 @@ pub async fn ai_generate_gemini_agy(
     system: Option<String>,
     prompt: String,
     model: String,
+    job_id: Option<String>,
 ) -> Result<String, String> {
     use super::llm::gemini_agy;
-    gemini_agy::generate_text(&model, system.as_deref(), &prompt).await
+    run_cancellable_ai_with_token(job_id, |cancel_token| async move {
+        match cancel_token {
+            Some(token) => {
+                gemini_agy::generate_text_cancellable(&model, system.as_deref(), &prompt, token)
+                    .await
+            }
+            None => gemini_agy::generate_text(&model, system.as_deref(), &prompt).await,
+        }
+    })
+    .await
 }
 
 // ─── OpenAI API 키 텍스트 생성 (구독 codex 와 별개 경로) ─────────────────────
@@ -1375,16 +1434,20 @@ pub async fn ai_generate_openai(
     system: Option<String>,
     prompt: String,
     model: String,
+    job_id: Option<String>,
 ) -> Result<String, String> {
-    use super::keychain::{get_key, Provider};
-    use super::llm::openai_api;
-    let key = get_key(Provider::Openai)
-        .map_err(err_to_string)?
-        .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
-    openai_api::generate_text(&key, &model, system.as_deref(), &prompt, None)
-        .await
-        .map(|r| r.text)
-        .map_err(err_to_string)
+    run_cancellable_ai(job_id, async move {
+        use super::keychain::{get_key, Provider};
+        use super::llm::openai_api;
+        let key = get_key(Provider::Openai)
+            .map_err(err_to_string)?
+            .ok_or_else(|| "OpenAI API 키가 없습니다. Settings 에서 등록하세요.".to_string())?;
+        openai_api::generate_text(&key, &model, system.as_deref(), &prompt, None)
+            .await
+            .map(|r| r.text)
+            .map_err(err_to_string)
+    })
+    .await
 }
 
 // ─── Grok(xAI) API 키 텍스트 생성 ──────────────────────────────────────────
@@ -1397,9 +1460,13 @@ pub async fn ai_generate_grok(
     prompt: String,
     model: String,
     grok_auth: String,
+    job_id: Option<String>,
 ) -> Result<String, String> {
-    let key = grok_bearer(&grok_auth)?;
-    super::llm::grok::generate_text(&key, &model, system.as_deref(), &prompt).await
+    run_cancellable_ai(job_id, async move {
+        let key = grok_bearer(&grok_auth)?;
+        super::llm::grok::generate_text(&key, &model, system.as_deref(), &prompt).await
+    })
+    .await
 }
 
 /// Grok 호출에 쓸 Bearer 토큰 — 구독(auth.json OAuth) 또는 API 키(Keychain).
@@ -1511,6 +1578,63 @@ pub async fn generate_image_grok(
 mod tests {
     use super::*;
     use tempfile::TempDir;
+    use tokio::sync::oneshot;
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    async fn cancellable_ai_returns_result_without_job_id() {
+        let result = run_cancellable_ai(None, async { Ok::<_, String>("done") })
+            .await
+            .expect("job without cancellation should complete");
+
+        assert_eq!(result, "done");
+    }
+
+    #[tokio::test]
+    async fn cancellable_ai_observes_cancel_before_registration() {
+        let job_id = format!("test-ai-{}", uuid::Uuid::new_v4());
+        assert!(super::super::cancel::cancel_job(&job_id));
+
+        let result = timeout(
+            Duration::from_secs(1),
+            run_cancellable_ai(Some(job_id), async {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok::<_, String>("late")
+            }),
+        )
+        .await
+        .expect("pre-cancelled job should return immediately");
+
+        assert_eq!(result.unwrap_err(), AI_CANCELLED_MESSAGE);
+    }
+
+    #[tokio::test]
+    async fn cancellable_ai_observes_cancel_while_running() {
+        let job_id = format!("test-ai-{}", uuid::Uuid::new_v4());
+        let cancel_job_id = job_id.clone();
+        let (started_tx, started_rx) = oneshot::channel();
+
+        let task = tokio::spawn(async move {
+            run_cancellable_ai(Some(job_id), async move {
+                let _ = started_tx.send(());
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok::<_, String>("late")
+            })
+            .await
+        });
+
+        started_rx
+            .await
+            .expect("cancellable job should start before test cancels it");
+        assert!(super::super::cancel::cancel_job(&cancel_job_id));
+
+        let result = timeout(Duration::from_secs(1), task)
+            .await
+            .expect("running job should observe cancellation")
+            .expect("task should not panic");
+
+        assert_eq!(result.unwrap_err(), AI_CANCELLED_MESSAGE);
+    }
 
     #[test]
     fn markdown_source_sections_preserve_heading_paths() {

--- a/src-tauri/src/converters/llm/gemini_agy.rs
+++ b/src-tauri/src/converters/llm/gemini_agy.rs
@@ -10,6 +10,12 @@
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::Read;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 /// 단일 프롬프트 응답(구독). model 은 agy 모델명. system 은 agy 가 별도 인자를 받지
 /// 않으므로 프롬프트 앞에 붙인다. PTY 호출은 blocking 이라 spawn_blocking 에서 실행.
@@ -18,17 +24,39 @@ pub async fn generate_text(
     system: Option<&str>,
     prompt: &str,
 ) -> Result<String, String> {
+    generate_text_inner(model, system, prompt, None).await
+}
+
+pub async fn generate_text_cancellable(
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+    cancel_token: CancellationToken,
+) -> Result<String, String> {
+    generate_text_inner(model, system, prompt, Some(cancel_token)).await
+}
+
+async fn generate_text_inner(
+    model: &str,
+    system: Option<&str>,
+    prompt: &str,
+    cancel_token: Option<CancellationToken>,
+) -> Result<String, String> {
     let model = model.to_string();
     let full = match system {
         Some(s) if !s.trim().is_empty() => format!("{s}\n\n{prompt}"),
         _ => prompt.to_string(),
     };
-    tokio::task::spawn_blocking(move || agy_call(&model, &full))
+    tokio::task::spawn_blocking(move || agy_call(&model, &full, cancel_token))
         .await
         .map_err(|e| format!("agy 태스크 조인 실패: {e}"))?
 }
 
-fn agy_call(model: &str, prompt: &str) -> Result<String, String> {
+fn agy_call(
+    model: &str,
+    prompt: &str,
+    cancel_token: Option<CancellationToken>,
+) -> Result<String, String> {
     let pty = native_pty_system();
     let pair = pty
         .openpty(PtySize {
@@ -47,21 +75,55 @@ fn agy_call(model: &str, prompt: &str) -> Result<String, String> {
     cmd.arg("--print-timeout");
     cmd.arg("180s");
 
-    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
-        format!("agy 실행 실패 — 설치/PATH 확인(brew install --cask antigravity-cli): {e}")
-    })?;
     let mut reader = pair
         .master
         .try_clone_reader()
         .map_err(|e| format!("PTY reader 생성 실패: {e}"))?;
+    let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
+        format!("agy 실행 실패 — 설치/PATH 확인(brew install --cask antigravity-cli): {e}")
+    })?;
+    let cancel_watcher = cancel_token.as_ref().map(|token| {
+        let token = token.clone();
+        let done = Arc::new(AtomicBool::new(false));
+        let done_for_thread = Arc::clone(&done);
+        let mut killer = child.clone_killer();
+        let handle = std::thread::spawn(move || {
+            while !done_for_thread.load(Ordering::Acquire) {
+                if token.is_cancelled() {
+                    let _ = killer.kill();
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        });
+        (done, handle)
+    });
     // slave 를 닫아야 자식 종료 시 reader 가 EOF 를 받는다(안 닫으면 read_to_end 가 행).
     drop(pair.slave);
 
     let mut raw = Vec::new();
-    reader
-        .read_to_end(&mut raw)
-        .map_err(|e| format!("PTY 읽기 실패: {e}"))?;
+    let read_result = reader.read_to_end(&mut raw);
+    if read_result.is_err()
+        && !cancel_token
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+    {
+        let _ = child.kill();
+    }
     let _ = child.wait();
+    if let Some((done, handle)) = cancel_watcher {
+        done.store(true, Ordering::Release);
+        let _ = handle.join();
+    }
+
+    if cancel_token
+        .as_ref()
+        .is_some_and(CancellationToken::is_cancelled)
+    {
+        return Err("사용자가 작업을 정지했습니다.".into());
+    }
+
+    read_result.map_err(|e| format!("PTY 읽기 실패: {e}"))?;
 
     let text = clean_output(&String::from_utf8_lossy(&raw));
     if text.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,6 +350,7 @@ pub fn run() {
             converters::commands::repair_html_slides_llm,
             converters::commands::generate_slide_markdown_draft,
             converters::commands::cancel_slide_job,
+            converters::commands::cancel_ai_generation,
             converters::commands::ai_generate_claude,
             converters::commands::ai_generate_codex,
             converters::commands::ai_generate_gemini_agy,

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -520,24 +520,55 @@ async function dispatchAI(systemPrompt: string, userContent: string, opts: Dispa
     }
 }
 
+function createAIJobId(): string {
+    const randomUUID = globalThis.crypto?.randomUUID?.bind(globalThis.crypto);
+    return `ai-${randomUUID ? randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
+}
+
+async function invokeCancellable<T>(
+    command: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+): Promise<T> {
+    const { invoke } = await import('@tauri-apps/api/core');
+    if (!signal) return invoke<T>(command, args);
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+
+    const jobId = createAIJobId();
+    let cancelRequested = false;
+    const cancel = () => {
+        if (cancelRequested) return;
+        cancelRequested = true;
+        void invoke('cancel_ai_generation', { jobId }).catch((err) => {
+            console.warn('[ai] cancel failed:', err);
+        });
+    };
+
+    signal.addEventListener('abort', cancel, { once: true });
+    try {
+        return await invoke<T>(command, { ...args, jobId });
+    } finally {
+        signal.removeEventListener('abort', cancel);
+    }
+}
+
 async function dispatchAIInner(
     systemPrompt: string,
     userContent: string,
     opts: DispatchOptions = {},
 ): Promise<string> {
     const sel = await resolveUsableTextSelection();
-    const { onStream } = opts;
+    const { onStream, signal } = opts;
     let modifiedText = '';
 
     if (sel.company === 'gemini') {
         if (sel.auth === 'subscription') {
             // Gemini 구독 = Antigravity CLI(agy) — Rust 경유(PTY). 스트리밍 미지원(완료 후 반환).
-            const { invoke } = await import('@tauri-apps/api/core');
-            modifiedText = await invoke<string>('ai_generate_gemini_agy', {
+            modifiedText = await invokeCancellable<string>('ai_generate_gemini_agy', {
                 system: systemPrompt,
                 prompt: userContent,
                 model: sel.model,
-            });
+            }, signal);
             if (onStream) onStream(modifiedText);
         } else {
             const apiKey = getApiKey();
@@ -571,34 +602,31 @@ async function dispatchAIInner(
         }
     } else if (sel.company === 'openai') {
         // ChatGPT — 구독(codex)이면 ai_generate_codex, API 키면 ai_generate_openai. Rust 경유.
-        const { invoke } = await import('@tauri-apps/api/core');
         const command = sel.auth === 'subscription' ? 'ai_generate_codex' : 'ai_generate_openai';
-        modifiedText = await invoke<string>(command, {
+        modifiedText = await invokeCancellable<string>(command, {
             system: systemPrompt,
             prompt: userContent,
             model: sel.model,
-        });
+        }, signal);
     } else if (sel.company === 'grok') {
         // Grok(xAI) — API 키 또는 구독(grok login OAuth 토큰). 둘 다 api.x.ai chat completions,
         // Rust 가 grokAuth 로 토큰 소스 분기. 구독은 유료(SuperGrok) 필요. 스트리밍 미지원.
-        const { invoke } = await import('@tauri-apps/api/core');
-        modifiedText = await invoke<string>('ai_generate_grok', {
+        modifiedText = await invokeCancellable<string>('ai_generate_grok', {
             system: systemPrompt,
             prompt: userContent,
             model: sel.model,
             grokAuth: sel.auth,
-        });
+        }, signal);
         if (onStream) onStream(modifiedText);
     } else {
         // Claude — 구독 OAuth 또는 API 키. Rust 경유. 스트리밍 미지원(완료 후 diff).
-        const { invoke } = await import('@tauri-apps/api/core');
-        modifiedText = await invoke<string>('ai_generate_claude', {
+        modifiedText = await invokeCancellable<string>('ai_generate_claude', {
             system: systemPrompt,
             prompt: userContent,
             claudeAuth: sel.auth,
             maxTokens: opts.maxTokens ?? 16000,
             model: sel.model,
-        });
+        }, signal);
     }
     return modifiedText;
 }


### PR DESCRIPTION
## Summary
- Wire AI AbortSignal cancellation through Tauri invoke job IDs.
- Add cancel_ai_generation and wrap native AI commands with CancellationToken-based cancellation.
- Abort reqwest-backed Claude/Codex/OpenAI/Grok futures and kill Gemini agy PTY subprocesses on cancel.
- Add Rust cancellation race tests for normal, pre-cancelled, and running jobs.

Closes #81

## Validation
- npm test
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- npm run tauri:build

## Notes
- Version remains 0.9.9; 1.0 bump is deferred until all target issues are complete.