### PR TITLE
chore(release): bump version to 1.0.0

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "markmind",
   "display_name": "MarkMind",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Connect Claude to your open MarkMind documents — read and edit live editor content (including unsaved changes) via the in-app MCP server.",
   "author": {
     "name": "KnowAI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "0.9.9",
+      "version": "1.0.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "0.9.9",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "0.9.9"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "0.9.9"
+version = "1.0.0"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bump MarkMind version from 0.9.9 to 1.0.0 across package, Tauri, Rust, and MCP manifest files.
- Include Cargo.lock package version sync.
- Final release bump after completing #81, #89, #92, #102, and #103.

## Validation
- npm test
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- npm run tauri:build