### PR TITLE
[codex] fix(export): polish slideshow and pdf output

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "markmind",
   "display_name": "MarkMind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Connect Claude to your open MarkMind documents — read and edit live editor content (including unsaved changes) via the in-app MCP server.",
   "author": {
     "name": "KnowAI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markmind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markmind",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markmind",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markmind"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2556,6 +2556,8 @@ dependencies = [
  "ndarray",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-web-kit",
  "ort",
@@ -2951,7 +2953,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2962,10 +2966,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3050,6 +3057,17 @@ checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2556,8 +2556,6 @@ dependencies = [
  "ndarray",
  "objc2",
  "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-foundation",
  "objc2-web-kit",
  "ort",
@@ -2953,9 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
 ]
 
@@ -2966,13 +2962,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
- "objc2-metal",
 ]
 
 [[package]]
@@ -3057,17 +3050,6 @@ checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,8 +109,6 @@ objc2-app-kit = { version = "0.3", features = [
     "NSSharingService",
     "objc2-core-foundation",
 ] }
-objc2-core-foundation = { version = "0.3", features = ["CFString", "CFURL", "CFCGTypes"] }
-objc2-core-graphics = { version = "0.3", features = ["CGContext", "CGPDFContext", "CGPDFDocument", "CGPDFPage"] }
 objc2-web-kit = { version = "0.3", features = [
     "WKWebView",
 ] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markmind"
-version = "1.0.0"
+version = "1.0.1"
 description = "Minimal Markdown Editor for macOS"
 authors = ["you"]
 edition = "2021"
@@ -107,7 +107,10 @@ objc2-app-kit = { version = "0.3", features = [
     "NSPrintInfo",
     "NSPrintOperation",
     "NSSharingService",
+    "objc2-core-foundation",
 ] }
+objc2-core-foundation = { version = "0.3", features = ["CFString", "CFURL", "CFCGTypes"] }
+objc2-core-graphics = { version = "0.3", features = ["CGContext", "CGPDFContext", "CGPDFDocument", "CGPDFPage"] }
 objc2-web-kit = { version = "0.3", features = [
     "WKWebView",
 ] }

--- a/src-tauri/src/print_pdf.rs
+++ b/src-tauri/src/print_pdf.rs
@@ -20,6 +20,25 @@
 use tauri::{command, WebviewWindow};
 use tokio::sync::oneshot;
 
+#[cfg(target_os = "macos")]
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(target_os = "macos")]
+const MM_TO_PT: f64 = 72.0 / 25.4;
+#[cfg(target_os = "macos")]
+const PDF_MARGIN_X_MM: f64 = 8.0;
+#[cfg(target_os = "macos")]
+const PDF_MARGIN_TOP_MM: f64 = 12.0;
+#[cfg(target_os = "macos")]
+const PDF_MARGIN_BOTTOM_MM: f64 = 16.0;
+#[cfg(target_os = "macos")]
+const PDF_PAGE_NUMBER_BOTTOM_MM: f32 = 5.0;
+#[cfg(target_os = "macos")]
+const PDF_PAGE_NUMBER_FONT_PT: f32 = 8.5;
+
 #[command]
 pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), String> {
     #[cfg(not(target_os = "macos"))]
@@ -31,7 +50,13 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
     #[cfg(target_os = "macos")]
     {
         let (tx, rx) = oneshot::channel::<Result<(), String>>();
-        let path_clone = path.clone();
+        let raw_pdf_path = export_tmp_path(&path);
+        let raw_pdf_path = raw_pdf_path
+            .to_str()
+            .ok_or_else(|| "임시 PDF 경로가 UTF-8 이 아닙니다.".to_string())?
+            .to_string();
+        let _ = tokio::fs::remove_file(&raw_pdf_path).await;
+        let path_clone = raw_pdf_path.clone();
 
         window
             .with_webview(move |pw| {
@@ -43,7 +68,7 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
                     use objc2_app_kit::{
                         NSPrintInfo, NSPrintJobSavingURL, NSPrintSaveJob, NSWindow,
                     };
-                    use objc2_foundation::{NSString, NSURL};
+                    use objc2_foundation::{NSSize, NSString, NSURL};
                     use objc2_web_kit::WKWebView;
 
                     let _mtm = MainThreadMarker::new_unchecked();
@@ -59,6 +84,17 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
 
                     // NSPrintInfo 새 인스턴스 (sharedPrintInfo 잔여 상태 회피).
                     let info = NSPrintInfo::new();
+
+                    // 용지와 native margin hint 는 NSPrintInfo 에 맞추고, 실제 콘텐츠
+                    // 반복 여백은 print CSS 의 @page margin 과 같은 값으로 둔다.
+                    // body padding 은 multi-page 에서 첫/끝 페이지에만 치우칠 수 있다.
+                    info.setPaperSize(NSSize::new(595.2755905511812, 841.8897637795277));
+                    info.setTopMargin(PDF_MARGIN_TOP_MM * MM_TO_PT);
+                    info.setRightMargin(PDF_MARGIN_X_MM * MM_TO_PT);
+                    info.setBottomMargin(PDF_MARGIN_BOTTOM_MM * MM_TO_PT);
+                    info.setLeftMargin(PDF_MARGIN_X_MM * MM_TO_PT);
+                    info.setHorizontallyCentered(false);
+                    info.setVerticallyCentered(false);
 
                     // jobDisposition = save → PDF 저장 모드
                     info.setJobDisposition(NSPrintSaveJob);
@@ -97,6 +133,243 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
             .map_err(|e| format!("with_webview failed: {e}"))?;
 
         rx.await
-            .map_err(|_| "with_webview closure dropped".to_string())?
+            .map_err(|_| "with_webview closure dropped".to_string())??;
+
+        wait_for_pdf_write_to_finish(&raw_pdf_path).await?;
+
+        // WebKit 의 CSS page margin box(`@bottom-center`)는 앱 내 native print 에서
+        // 안정적으로 출력되지 않는다. WebKit 출력은 임시 파일로 받은 뒤 실제 text
+        // object 를 덧붙이고, 마지막에 최종 경로로 교체한다. 기존 PDF가 있는 경로에서도
+        // "기존 파일이 안정적"이라고 오판하는 race 를 피하기 위함이다.
+        let numbering_path = raw_pdf_path.clone();
+        match tokio::task::spawn_blocking(move || add_page_numbers_to_pdf(&numbering_path)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => log::warn!("PDF page number post-process skipped: {err}"),
+            Err(err) => log::warn!("PDF page number post-process task failed: {err}"),
+        }
+
+        tokio::fs::rename(&raw_pdf_path, &path)
+            .await
+            .map_err(|err| format!("PDF 최종 저장 실패: {err}"))?;
+
+        Ok(())
     }
+}
+
+#[cfg(target_os = "macos")]
+async fn wait_for_pdf_write_to_finish(path: &str) -> Result<(), String> {
+    let mut last_size = 0;
+    let mut stable_ticks = 0;
+
+    for _ in 0..300 {
+        if let Ok(meta) = tokio::fs::metadata(path).await {
+            let size = meta.len();
+            if size > 0 && size == last_size {
+                stable_ticks += 1;
+                if stable_ticks >= 5 {
+                    return Ok(());
+                }
+            } else {
+                stable_ticks = 0;
+                last_size = size;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err("PDF 저장 완료를 확인하지 못했습니다.".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn add_page_numbers_to_pdf(path: &str) -> Result<(), String> {
+    match add_page_numbers_to_pdf_with_pdfium(path) {
+        Ok(()) => Ok(()),
+        Err(pdfium_err) => {
+            log::warn!(
+                "PDFium page number post-process failed; falling back to CoreGraphics: {pdfium_err}"
+            );
+            add_page_numbers_to_pdf_with_core_graphics(path).map_err(|core_graphics_err| {
+                format!(
+                    "PDFium 실패: {pdfium_err}; CoreGraphics fallback 실패: {core_graphics_err}"
+                )
+            })
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn add_page_numbers_to_pdf_with_pdfium(path: &str) -> Result<(), String> {
+    use pdfium_render::prelude::*;
+
+    let pdfium = Pdfium::new(
+        Pdfium::bind_to_system_library()
+            .or_else(|_| {
+                Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+            })
+            .map_err(|err| format!("pdfium 로드 실패: {err}"))?,
+    );
+    let mut document = pdfium
+        .load_pdf_from_file(path, None)
+        .map_err(|err| format!("PDF 로드 실패: {err}"))?;
+    let font = document.fonts_mut().helvetica();
+    let font_size = PdfPoints::new(PDF_PAGE_NUMBER_FONT_PT);
+    let y = PdfPoints::new(PDF_PAGE_NUMBER_BOTTOM_MM * MM_TO_PT as f32);
+
+    document
+        .pages()
+        .watermark(|group, index, width, _height| {
+            let mut page_number =
+                PdfPageTextObject::new(&document, format!("{}", index + 1), font, font_size)?;
+            page_number.set_fill_color(PdfColor::GREY_40)?;
+            page_number.translate((width - page_number.width()?) / 2.0, y)?;
+            group.push(&mut page_number.into())
+        })
+        .map_err(|err| format!("페이지 번호 삽입 실패: {err}"))?;
+
+    let tmp_path = numbered_tmp_path(path);
+    let _ = std::fs::remove_file(&tmp_path);
+    document
+        .save_to_file(&tmp_path)
+        .map_err(|err| format!("번호 삽입 PDF 저장 실패: {err}"))?;
+    std::fs::rename(&tmp_path, path).map_err(|err| format!("번호 삽입 PDF 교체 실패: {err}"))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn add_page_numbers_to_pdf_with_core_graphics(path: &str) -> Result<(), String> {
+    use objc2_core_foundation::{CGAffineTransform, CGRect};
+    use objc2_core_graphics::{
+        CGContext, CGPDFBox, CGPDFContextClose, CGPDFContextCreateWithURL, CGPDFDocument, CGPDFPage,
+    };
+    use std::ffi::CString;
+
+    let input_url = cf_file_url(path)?;
+    let document = CGPDFDocument::with_url(Some(&input_url))
+        .ok_or_else(|| "CoreGraphics PDF 로드 실패".to_string())?;
+    let page_count = CGPDFDocument::number_of_pages(Some(&document));
+    if page_count == 0 {
+        return Ok(());
+    }
+
+    let tmp_path = numbered_tmp_path(path);
+    let tmp_path_str = tmp_path
+        .to_str()
+        .ok_or_else(|| "임시 PDF 경로가 UTF-8 이 아닙니다.".to_string())?;
+    let output_url = cf_file_url(tmp_path_str)?;
+    let _ = std::fs::remove_file(&tmp_path);
+    let context = unsafe { CGPDFContextCreateWithURL(Some(&output_url), std::ptr::null(), None) }
+        .ok_or_else(|| "CoreGraphics PDF context 생성 실패".to_string())?;
+    let font_name = CString::new("Helvetica").map_err(|err| err.to_string())?;
+
+    for page_number in 1..=page_count {
+        let page = CGPDFDocument::page(Some(&document), page_number)
+            .ok_or_else(|| format!("PDF 페이지 로드 실패: {page_number}"))?;
+        let media_box = CGPDFPage::box_rect(Some(&page), CGPDFBox::MediaBox);
+
+        unsafe {
+            CGContext::begin_page(Some(&context), &media_box as *const CGRect);
+        }
+        CGContext::save_g_state(Some(&context));
+        let transform =
+            CGPDFPage::drawing_transform(Some(&page), CGPDFBox::MediaBox, media_box, 0, true);
+        CGContext::concat_ctm(Some(&context), transform);
+        CGContext::draw_pdf_page(Some(&context), Some(&page));
+        CGContext::restore_g_state(Some(&context));
+        draw_page_number_core_graphics(&context, page_number, media_box, &font_name);
+        CGContext::end_page(Some(&context));
+    }
+
+    CGPDFContextClose(Some(&context));
+    drop(context);
+    drop(document);
+    std::fs::rename(&tmp_path, path).map_err(|err| format!("번호 삽입 PDF 교체 실패: {err}"))?;
+
+    fn identity_transform() -> CGAffineTransform {
+        CGAffineTransform {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            tx: 0.0,
+            ty: 0.0,
+        }
+    }
+
+    #[allow(deprecated)]
+    fn draw_page_number_core_graphics(
+        context: &CGContext,
+        page_number: usize,
+        media_box: CGRect,
+        font_name: &CString,
+    ) {
+        use objc2_core_graphics::CGTextEncoding;
+
+        let text = page_number.to_string();
+        let Ok(c_text) = CString::new(text.as_str()) else {
+            return;
+        };
+        let font_size = PDF_PAGE_NUMBER_FONT_PT as f64;
+        let approx_width = text.chars().count() as f64 * font_size * 0.55;
+        let x = media_box.origin.x + (media_box.size.width - approx_width) / 2.0;
+        let y = media_box.origin.y + PDF_PAGE_NUMBER_BOTTOM_MM as f64 * MM_TO_PT;
+
+        CGContext::set_rgb_fill_color(Some(context), 0.4, 0.4, 0.4, 1.0);
+        CGContext::set_text_matrix(Some(context), identity_transform());
+        unsafe {
+            CGContext::select_font(
+                Some(context),
+                font_name.as_ptr(),
+                font_size,
+                CGTextEncoding::EncodingMacRoman,
+            );
+            CGContext::show_text_at_point(Some(context), x, y, c_text.as_ptr(), text.len());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn cf_file_url(
+    path: &str,
+) -> Result<objc2_core_foundation::CFRetained<objc2_core_foundation::CFURL>, String> {
+    let cf_path = objc2_core_foundation::CFString::from_str(path);
+    objc2_core_foundation::CFURL::with_file_system_path(
+        None,
+        Some(&cf_path),
+        objc2_core_foundation::CFURLPathStyle::CFURLPOSIXPathStyle,
+        false,
+    )
+    .ok_or_else(|| format!("file URL 생성 실패: {path}"))
+}
+
+#[cfg(target_os = "macos")]
+fn export_tmp_path(path: &str) -> PathBuf {
+    let mut tmp = PathBuf::from(path);
+    let file_name = tmp
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("markmind-export.pdf");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    tmp.set_file_name(format!(
+        "{file_name}.markmind-export-{}-{nonce}.tmp.pdf",
+        std::process::id()
+    ));
+    tmp
+}
+
+#[cfg(target_os = "macos")]
+fn numbered_tmp_path(path: &str) -> PathBuf {
+    let mut tmp = PathBuf::from(path);
+    let file_name = tmp
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("{name}.markmind-numbered.tmp"))
+        .unwrap_or_else(|| "markmind-numbered.tmp.pdf".to_string());
+    tmp.set_file_name(file_name);
+    tmp
 }

--- a/src-tauri/src/print_pdf.rs
+++ b/src-tauri/src/print_pdf.rs
@@ -138,9 +138,9 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
         wait_for_pdf_write_to_finish(&raw_pdf_path).await?;
 
         // WebKit 의 CSS page margin box(`@bottom-center`)는 앱 내 native print 에서
-        // 안정적으로 출력되지 않는다. WebKit 출력은 임시 파일로 받은 뒤 실제 text
-        // object 를 덧붙이고, 마지막에 최종 경로로 교체한다. 기존 PDF가 있는 경로에서도
-        // "기존 파일이 안정적"이라고 오판하는 race 를 피하기 위함이다.
+        // 안정적으로 출력되지 않는다. WebKit 출력은 임시 파일로 받은 뒤 PDFium 으로
+        // 실제 text object 를 덧붙이고, 마지막에 최종 경로로 교체한다. PDFium 을
+        // 사용할 수 없으면 번호 삽입을 건너뛰어 원본 PDF의 링크 annotation 을 보존한다.
         let numbering_path = raw_pdf_path.clone();
         match tokio::task::spawn_blocking(move || add_page_numbers_to_pdf(&numbering_path)).await {
             Ok(Ok(())) => {}
@@ -182,19 +182,7 @@ async fn wait_for_pdf_write_to_finish(path: &str) -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 fn add_page_numbers_to_pdf(path: &str) -> Result<(), String> {
-    match add_page_numbers_to_pdf_with_pdfium(path) {
-        Ok(()) => Ok(()),
-        Err(pdfium_err) => {
-            log::warn!(
-                "PDFium page number post-process failed; falling back to CoreGraphics: {pdfium_err}"
-            );
-            add_page_numbers_to_pdf_with_core_graphics(path).map_err(|core_graphics_err| {
-                format!(
-                    "PDFium 실패: {pdfium_err}; CoreGraphics fallback 실패: {core_graphics_err}"
-                )
-            })
-        }
-    }
+    add_page_numbers_to_pdf_with_pdfium(path)
 }
 
 #[cfg(target_os = "macos")]
@@ -234,114 +222,6 @@ fn add_page_numbers_to_pdf_with_pdfium(path: &str) -> Result<(), String> {
     std::fs::rename(&tmp_path, path).map_err(|err| format!("번호 삽입 PDF 교체 실패: {err}"))?;
 
     Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn add_page_numbers_to_pdf_with_core_graphics(path: &str) -> Result<(), String> {
-    use objc2_core_foundation::{CGAffineTransform, CGRect};
-    use objc2_core_graphics::{
-        CGContext, CGPDFBox, CGPDFContextClose, CGPDFContextCreateWithURL, CGPDFDocument, CGPDFPage,
-    };
-    use std::ffi::CString;
-
-    let input_url = cf_file_url(path)?;
-    let document = CGPDFDocument::with_url(Some(&input_url))
-        .ok_or_else(|| "CoreGraphics PDF 로드 실패".to_string())?;
-    let page_count = CGPDFDocument::number_of_pages(Some(&document));
-    if page_count == 0 {
-        return Ok(());
-    }
-
-    let tmp_path = numbered_tmp_path(path);
-    let tmp_path_str = tmp_path
-        .to_str()
-        .ok_or_else(|| "임시 PDF 경로가 UTF-8 이 아닙니다.".to_string())?;
-    let output_url = cf_file_url(tmp_path_str)?;
-    let _ = std::fs::remove_file(&tmp_path);
-    let context = unsafe { CGPDFContextCreateWithURL(Some(&output_url), std::ptr::null(), None) }
-        .ok_or_else(|| "CoreGraphics PDF context 생성 실패".to_string())?;
-    let font_name = CString::new("Helvetica").map_err(|err| err.to_string())?;
-
-    for page_number in 1..=page_count {
-        let page = CGPDFDocument::page(Some(&document), page_number)
-            .ok_or_else(|| format!("PDF 페이지 로드 실패: {page_number}"))?;
-        let media_box = CGPDFPage::box_rect(Some(&page), CGPDFBox::MediaBox);
-
-        unsafe {
-            CGContext::begin_page(Some(&context), &media_box as *const CGRect);
-        }
-        CGContext::save_g_state(Some(&context));
-        let transform =
-            CGPDFPage::drawing_transform(Some(&page), CGPDFBox::MediaBox, media_box, 0, true);
-        CGContext::concat_ctm(Some(&context), transform);
-        CGContext::draw_pdf_page(Some(&context), Some(&page));
-        CGContext::restore_g_state(Some(&context));
-        draw_page_number_core_graphics(&context, page_number, media_box, &font_name);
-        CGContext::end_page(Some(&context));
-    }
-
-    CGPDFContextClose(Some(&context));
-    drop(context);
-    drop(document);
-    std::fs::rename(&tmp_path, path).map_err(|err| format!("번호 삽입 PDF 교체 실패: {err}"))?;
-
-    fn identity_transform() -> CGAffineTransform {
-        CGAffineTransform {
-            a: 1.0,
-            b: 0.0,
-            c: 0.0,
-            d: 1.0,
-            tx: 0.0,
-            ty: 0.0,
-        }
-    }
-
-    #[allow(deprecated)]
-    fn draw_page_number_core_graphics(
-        context: &CGContext,
-        page_number: usize,
-        media_box: CGRect,
-        font_name: &CString,
-    ) {
-        use objc2_core_graphics::CGTextEncoding;
-
-        let text = page_number.to_string();
-        let Ok(c_text) = CString::new(text.as_str()) else {
-            return;
-        };
-        let font_size = PDF_PAGE_NUMBER_FONT_PT as f64;
-        let approx_width = text.chars().count() as f64 * font_size * 0.55;
-        let x = media_box.origin.x + (media_box.size.width - approx_width) / 2.0;
-        let y = media_box.origin.y + PDF_PAGE_NUMBER_BOTTOM_MM as f64 * MM_TO_PT;
-
-        CGContext::set_rgb_fill_color(Some(context), 0.4, 0.4, 0.4, 1.0);
-        CGContext::set_text_matrix(Some(context), identity_transform());
-        unsafe {
-            CGContext::select_font(
-                Some(context),
-                font_name.as_ptr(),
-                font_size,
-                CGTextEncoding::EncodingMacRoman,
-            );
-            CGContext::show_text_at_point(Some(context), x, y, c_text.as_ptr(), text.len());
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn cf_file_url(
-    path: &str,
-) -> Result<objc2_core_foundation::CFRetained<objc2_core_foundation::CFURL>, String> {
-    let cf_path = objc2_core_foundation::CFString::from_str(path);
-    objc2_core_foundation::CFURL::with_file_system_path(
-        None,
-        Some(&cf_path),
-        objc2_core_foundation::CFURLPathStyle::CFURLPOSIXPathStyle,
-        false,
-    )
-    .ok_or_else(|| format!("file URL 생성 실패: {path}"))
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkMind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.yuhitomi.markmind",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -3200,10 +3200,13 @@ code.hljs {
    content 만 출력. 다크 모드 / 사용자 배경 → 흰 배경 강제, code/checkbox
    ink 보존, 페이지 break 자연 분할, 한글 줄바꿈 + 외부 링크 URL 노출. */
 
-/* @page margin 0 — dialog 의 NSPrintInfo margin (Standard ~12.7mm) 만 사용.
-   기존 20mm 가 dialog margin 위에 누적되어 A4 콘텐츠 영역이 ~145mm 까지 협소
-   → 표 마지막 컬럼 잘림. 우리 콘텐츠 가장자리 마진은 body padding 으로 처리. */
-@page { size: A4; margin: 0; }
+/* 실제 콘텐츠 여백은 @page margin 이 담당한다. body padding 은 multi-page 에서
+   첫/끝 페이지에만 치우칠 수 있어 쓰지 않는다. 페이지 번호는 PDF 후처리에서
+   실제 페이지 객체로 삽입하고, bottom margin 은 그 영역을 비워 둔다. */
+@page {
+  size: A4;
+  margin: 12mm 8mm 16mm 8mm;
+}
 
 @media print {
   /* 다크모드 + 사용자 배경 변수 override (light token 강제) */
@@ -3235,12 +3238,7 @@ code.hljs {
     overflow: visible !important;
     overflow-x: visible !important;
     margin: 0 !important;
-    /* 좌우 padding 명시 분리 — shorthand 가 inline/inherit 와 섞일 때 비대칭
-       가능성 차단. 사용자 보고 ~15px (~4mm) 좌측 잔존 마진 fix 시도. */
-    padding-top: 6mm !important;
-    padding-right: 8mm !important;
-    padding-bottom: 6mm !important;
-    padding-left: 8mm !important;
+    padding: 0 !important;
     box-sizing: border-box !important;
     font-size: 10.5pt;
     line-height: 1.55;

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -5,6 +5,8 @@
     position: fixed;
     inset: 0;
     z-index: 2000;
+    --slideshow-pad-y: clamp(1.5rem, 4vh, 3rem);
+    --slideshow-indicator-reserve: calc(4.25rem + env(safe-area-inset-bottom, 0px));
     /* 사용자 지정 배경 → 테마 프리뷰 배경 → 흰색 폴백 */
     background: var(--slideshow-bg, var(--preview-bg, #ffffff));
     overflow: hidden;
@@ -27,7 +29,8 @@
     overflow-y: auto;
     display: grid;
     place-items: center;
-    padding: clamp(1.5rem, 4vh, 3rem) clamp(1rem, 2.5vw, 2.5rem);
+    padding: var(--slideshow-pad-y) clamp(1rem, 2.5vw, 2.5rem);
+    padding-bottom: max(var(--slideshow-pad-y), var(--slideshow-indicator-reserve));
     -webkit-overflow-scrolling: touch;
 }
 
@@ -43,8 +46,66 @@
     /* 본문 색 = 테마 변수(라이트/다크 자동) — Rich Text(Preview) 와 동일 */
     color: var(--text-primary);
     /* 발표용 기본 크기(뷰포트 기반) × 사용자 배율. 내부 요소는 상대 단위로 따라옴. */
-    font-size: calc(clamp(0.95rem, 0.62rem + 0.7vw, 1.25rem) * var(--slideshow-scale, 1));
+    font-size: calc(clamp(0.95rem, 0.62rem + 0.7vw, 1.25rem) * var(--slideshow-scale, 1) * var(--slideshow-auto-scale, 1));
     line-height: var(--md-line-height, 1.7);
+}
+
+.slideshow-heading {
+    width: 100%;
+    margin-bottom: 0.9em;
+}
+
+.slideshow-heading > :first-child,
+.slideshow-body > :first-child {
+    margin-top: 0;
+}
+
+.slideshow-heading > :last-child,
+.slideshow-body > :last-child {
+    margin-bottom: 0;
+}
+
+.slideshow-body {
+    width: 100%;
+}
+
+.slideshow-content.markdown-body.auto-columns {
+    max-width: min(1320px, 100%);
+}
+
+.slideshow-content.markdown-body.auto-columns .slideshow-body {
+    column-count: 2;
+    column-gap: clamp(2rem, 4vw, 4rem);
+    column-rule: 1px solid var(--border-secondary, rgba(0, 0, 0, 0.08));
+}
+
+.slideshow-content.markdown-body.auto-columns .slideshow-body > * {
+    break-inside: avoid;
+}
+
+.slideshow-content.markdown-body li {
+    margin-block: 0.12em;
+}
+
+.slideshow-content.markdown-body li > ul,
+.slideshow-content.markdown-body li > ol {
+    margin-block: 0.12em;
+}
+
+.slideshow-content.markdown-body table {
+    font-size: 1em;
+}
+
+.slideshow-content.markdown-body th,
+.slideshow-content.markdown-body td {
+    font-size: 1em;
+}
+
+@media (max-width: 760px) {
+    .slideshow-content.markdown-body.auto-columns .slideshow-body {
+        column-count: 1;
+        column-rule: none;
+    }
 }
 
 /* 숨길 요소 — display:none 으로 비표시(공간도 제거). 인라인 코드(<code> 단독)는 유지. */
@@ -158,18 +219,99 @@
     pointer-events: none;
 }
 
-/* 페이지 인디케이터 — 배경 없이 텍스트만 */
+/* 페이지 인디케이터 — 클릭 시 목차 점프 */
 .slideshow-indicator {
     position: absolute;
-    bottom: 1.1rem;
+    bottom: calc(1.1rem + env(safe-area-inset-bottom, 0px));
     left: 50%;
     transform: translateX(-50%);
+    border: none;
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    background: transparent;
     color: var(--text-primary, #1a1a1a);
     font-size: 0.85rem;
     font-variant-numeric: tabular-nums;
     opacity: 0.4;
+    cursor: pointer;
     user-select: none;
-    pointer-events: none;
+    pointer-events: auto;
+    transition: opacity 0.18s ease, background 0.18s ease;
+}
+.slideshow-indicator:hover,
+.slideshow-indicator:focus-visible {
+    opacity: 0.85;
+    background: var(--bg-active, rgba(0, 0, 0, 0.06));
+    outline: none;
+}
+
+.slideshow-jump {
+    position: absolute;
+    bottom: calc(2.95rem + env(safe-area-inset-bottom, 0px));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: min(24rem, calc(100vw - 2rem));
+    padding: 0.5rem;
+    border: 1px solid var(--border-secondary, rgba(0, 0, 0, 0.1));
+    border-radius: 0.75rem;
+    background: var(--preview-bg, #ffffff);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+.slideshow-jump-list {
+    width: 100%;
+    max-height: min(18rem, 42vh);
+    overflow-y: auto;
+    padding: 0.15rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+.slideshow-jump-item {
+    width: 100%;
+    min-height: 2rem;
+    display: grid;
+    grid-template-columns: 2.1rem minmax(0, 1fr);
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.45rem 0.25rem calc(0.45rem + var(--slide-heading-indent, 0rem));
+    border: none;
+    border-radius: 0.45rem;
+    background: transparent;
+    color: var(--text-primary, #1a1a1a);
+    cursor: pointer;
+    text-align: left;
+}
+.slideshow-jump-item:hover,
+.slideshow-jump-item:focus-visible {
+    background: var(--bg-active, rgba(0, 0, 0, 0.06));
+    outline: none;
+}
+.slideshow-jump-item.active {
+    background: var(--bg-active, rgba(0, 0, 0, 0.09));
+}
+.slideshow-jump-item-index {
+    color: var(--text-secondary, var(--text-primary, #1a1a1a));
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.62;
+    text-align: right;
+}
+.slideshow-jump-item-title {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary, #1a1a1a);
+    font-size: 0.82rem;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.slideshow-jump-item.fallback .slideshow-jump-item-title {
+    color: var(--text-secondary, var(--text-primary, #1a1a1a));
+    opacity: 0.78;
 }
 
 /* 본문 명조 — App 의 data-font-family 규칙과 동일 패밀리 적용(portal 이라 직접 지정). */
@@ -179,13 +321,13 @@
 
 /* ── 여백 3단계 (상하=padding-block, 좌우=콘텐츠 max-width) — data-pad ── */
 .slideshow-root[data-pad='small'] .slideshow-slide {
-    padding-block: clamp(0.6rem, 1.5vh, 1.2rem);
+    --slideshow-pad-y: clamp(0.6rem, 1.5vh, 1.2rem);
 }
 .slideshow-root[data-pad='small'] .slideshow-content.markdown-body {
     max-width: 1200px;
 }
 .slideshow-root[data-pad='large'] .slideshow-slide {
-    padding-block: clamp(3rem, 8vh, 6rem);
+    --slideshow-pad-y: clamp(3rem, 8vh, 6rem);
 }
 .slideshow-root[data-pad='large'] .slideshow-content.markdown-body {
     max-width: 960px;

--- a/src/components/SlideshowView.css
+++ b/src/components/SlideshowView.css
@@ -50,36 +50,30 @@
     line-height: var(--md-line-height, 1.7);
 }
 
-.slideshow-heading {
-    width: 100%;
-    margin-bottom: 0.9em;
-}
-
-.slideshow-heading > :first-child,
-.slideshow-body > :first-child {
+.slideshow-content.markdown-body > :first-child {
     margin-top: 0;
 }
 
-.slideshow-heading > :last-child,
-.slideshow-body > :last-child {
+.slideshow-content.markdown-body > :last-child {
     margin-bottom: 0;
 }
 
-.slideshow-body {
-    width: 100%;
+.slideshow-content.markdown-body > :is(h1, h2, h3, h4, h5, h6):first-child {
+    margin-bottom: 0.9em;
 }
 
 .slideshow-content.markdown-body.auto-columns {
     max-width: min(1320px, 100%);
-}
-
-.slideshow-content.markdown-body.auto-columns .slideshow-body {
     column-count: 2;
     column-gap: clamp(2rem, 4vw, 4rem);
     column-rule: 1px solid var(--border-secondary, rgba(0, 0, 0, 0.08));
 }
 
-.slideshow-content.markdown-body.auto-columns .slideshow-body > * {
+.slideshow-content.markdown-body.auto-columns > :is(h1, h2, h3, h4, h5, h6):first-child {
+    column-span: all;
+}
+
+.slideshow-content.markdown-body.auto-columns > * {
     break-inside: avoid;
 }
 
@@ -102,7 +96,7 @@
 }
 
 @media (max-width: 760px) {
-    .slideshow-content.markdown-body.auto-columns .slideshow-body {
+    .slideshow-content.markdown-body.auto-columns {
         column-count: 1;
         column-rule: none;
     }

--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -7,7 +7,7 @@
 //
 // document.body 로 portal — App 의 transform/배경 등 어떤 조상 CSS 도 영향 없게.
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, ChevronLeft, ChevronRight, AArrowDown, AArrowUp, Moon, Sun, Frame } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
@@ -31,8 +31,61 @@ interface SlideshowViewProps {
     onClose: () => void;
 }
 
-/** 슬라이드 1장 — read-only 마크다운 렌더(Preview 의 플러그인/이미지 resolver 동일). */
-function SlideMarkdown({ md, docDir }: { md: string; docDir: string | null }) {
+const LEADING_ATX_HEADING_RE = /^\s{0,3}#{1,6}(?:\s+|$)/;
+const ATX_HEADING_LINE_RE = /^\s{0,3}(#{1,6})\s*(.*?)\s*#*\s*$/;
+const MIN_AUTO_FIT_SCALE = 0.72;
+const OVERFLOW_EPSILON_PX = 12;
+const AUTO_FIT_MARGIN = 0.96;
+
+function splitLeadingHeading(md: string): { heading: string; body: string } {
+    const lines = md.split('\n');
+    const firstContent = lines.findIndex((line) => line.trim() !== '');
+    if (firstContent < 0 || !LEADING_ATX_HEADING_RE.test(lines[firstContent])) {
+        return { heading: '', body: md };
+    }
+
+    const heading = lines.slice(0, firstContent + 1).join('\n');
+    let bodyStart = firstContent + 1;
+    while (bodyStart < lines.length && lines[bodyStart].trim() === '') bodyStart += 1;
+    return { heading, body: lines.slice(bodyStart).join('\n') };
+}
+
+function plainMarkdownText(text: string): string {
+    return text
+        .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+        .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+        .replace(/[`*_~]/g, '')
+        .replace(/<[^>]+>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function getSlideHeadingInfo(md: string, index: number): { title: string; level: number; fallback: boolean } {
+    const lines = md.split('\n');
+    for (const line of lines) {
+        if (!line.trim()) continue;
+        const heading = line.match(ATX_HEADING_LINE_RE);
+        if (heading) {
+            return {
+                title: plainMarkdownText(heading[2]) || `슬라이드 ${index + 1}`,
+                level: heading[1].length,
+                fallback: false,
+            };
+        }
+        const fallbackTitle = plainMarkdownText(line);
+        if (fallbackTitle) {
+            return {
+                title: fallbackTitle.length > 72 ? `${fallbackTitle.slice(0, 72)}...` : fallbackTitle,
+                level: 0,
+                fallback: true,
+            };
+        }
+    }
+    return { title: `슬라이드 ${index + 1}`, level: 0, fallback: true };
+}
+
+function MarkdownChunk({ md, docDir }: { md: string; docDir: string | null }) {
+    if (!md.trim()) return null;
     return (
         <ReactMarkdown
             remarkPlugins={[remarkFrontmatter, [remarkGfm, { singleTilde: false }], remarkSoftBreaks]}
@@ -48,6 +101,31 @@ function SlideMarkdown({ md, docDir }: { md: string; docDir: string | null }) {
     );
 }
 
+/** 슬라이드 1장 — read-only 마크다운 렌더(Preview 의 플러그인/이미지 resolver 동일). */
+function SlideMarkdown({ md, docDir }: { md: string; docDir: string | null }) {
+    const { heading, body } = useMemo(() => splitLeadingHeading(md), [md]);
+
+    return (
+        <>
+            {heading && (
+                <div className="slideshow-heading">
+                    <MarkdownChunk md={heading} docDir={docDir} />
+                </div>
+            )}
+            {body && (
+                <div className="slideshow-body">
+                    <MarkdownChunk md={body} docDir={docDir} />
+                </div>
+            )}
+        </>
+    );
+}
+
+function nextAutoFitScale(currentScale: number, scrollHeight: number, clientHeight: number): number {
+    const ratio = Math.max(0.1, clientHeight / scrollHeight);
+    return Math.max(MIN_AUTO_FIT_SCALE, Math.floor(currentScale * ratio * AUTO_FIT_MARGIN * 100) / 100);
+}
+
 export function SlideshowView({
     content,
     filePath,
@@ -57,11 +135,21 @@ export function SlideshowView({
     onClose,
 }: SlideshowViewProps) {
     const slides = useMemo(() => splitIntoSlides(content, settings), [content, settings]);
+    const slideHeadings = useMemo(
+        () => slides.map((slide, index) => getSlideHeadingInfo(slide, index)),
+        [slides],
+    );
     const docDir = useMemo(
         () => (filePath ? filePath.slice(0, filePath.lastIndexOf('/')) : null),
         [filePath],
     );
     const [current, setCurrent] = useState(0);
+    const [resizeTick, setResizeTick] = useState(0);
+    const slideRefs = useRef<Array<HTMLDivElement | null>>([]);
+    const jumpItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const [autoColumnSlides, setAutoColumnSlides] = useState<Record<number, { key: string; isLong: boolean }>>({});
+    const [autoFitSlides, setAutoFitSlides] = useState<Record<number, { key: string; scale: number }>>({});
+    const [jumpOpen, setJumpOpen] = useState(false);
 
     // 폰트 배율(전체 확대/축소) — 0.6~2.0, localStorage 영속.
     const [scale, setScale] = useState(() => {
@@ -83,6 +171,57 @@ export function SlideshowView({
     useEffect(() => { localStorage.setItem('markmind-slideshow-pad', String(padLevel)); }, [padLevel]);
     const cyclePad = useCallback(() => setPadLevel((p) => (p + 1) % 3), []);
 
+    const autoColumnKey = useMemo(
+        () => [scale, padLevel, settings.autoTwoColumn ? 1 : 0, resizeTick, slides.join('\u0000')].join('|'),
+        [padLevel, resizeTick, scale, settings.autoTwoColumn, slides],
+    );
+
+    const measureCurrentSlide = useCallback(() => {
+        if (!settings.autoTwoColumn) return;
+        const slide = slideRefs.current[current];
+        if (!slide) return;
+        const isLong = slide.scrollHeight > slide.clientHeight + 24;
+        const isAutoColumn = autoColumnSlides[current]?.key === autoColumnKey && autoColumnSlides[current]?.isLong;
+        setAutoColumnSlides((prev) => {
+            const existing = prev[current];
+            if (existing?.key === autoColumnKey && existing.isLong) return prev;
+            if (existing?.key === autoColumnKey && existing.isLong === isLong) return prev;
+            return { ...prev, [current]: { key: autoColumnKey, isLong } };
+        });
+
+        if (!isAutoColumn) return;
+        if (slide.scrollHeight <= slide.clientHeight + OVERFLOW_EPSILON_PX) return;
+        const currentAutoScale = autoFitSlides[current]?.key === autoColumnKey ? autoFitSlides[current].scale : 1;
+        const nextScale = nextAutoFitScale(currentAutoScale, slide.scrollHeight, slide.clientHeight);
+        setAutoFitSlides((prev) => {
+            const existing = prev[current];
+            if (nextScale >= currentAutoScale) return prev;
+            if (existing?.key === autoColumnKey && existing.scale === nextScale) return prev;
+            return { ...prev, [current]: { key: autoColumnKey, scale: nextScale } };
+        });
+    }, [autoColumnKey, autoColumnSlides, autoFitSlides, current, settings.autoTwoColumn]);
+
+    useEffect(() => {
+        const onResize = () => setResizeTick((tick) => tick + 1);
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, []);
+
+    useLayoutEffect(() => {
+        if (!settings.autoTwoColumn) return;
+        let frame = 0;
+        let timeout = 0;
+        measureCurrentSlide();
+        frame = requestAnimationFrame(() => {
+            measureCurrentSlide();
+            timeout = window.setTimeout(measureCurrentSlide, 180);
+        });
+        return () => {
+            cancelAnimationFrame(frame);
+            window.clearTimeout(timeout);
+        };
+    }, [autoColumnKey, current, measureCurrentSlide, resizeTick, scale, padLevel, slides, settings.autoTwoColumn]);
+
     // 다크 모드(발표 배경 반전) — localStorage 영속.
     const [dark, setDark] = useState(() => localStorage.getItem('markmind-slideshow-dark') === '1');
     useEffect(() => { localStorage.setItem('markmind-slideshow-dark', dark ? '1' : '0'); }, [dark]);
@@ -102,16 +241,45 @@ export function SlideshowView({
         setCurrent((c) => Math.min(c, Math.max(0, slides.length - 1)));
     }, [slides.length]);
 
+    useEffect(() => {
+        if (!jumpOpen) return;
+        const frame = requestAnimationFrame(() => {
+            jumpItemRefs.current[current]?.scrollIntoView({ block: 'nearest' });
+        });
+        return () => cancelAnimationFrame(frame);
+    }, [current, jumpOpen]);
+
     const go = useCallback(
         (delta: number) => {
+            setJumpOpen(false);
             setCurrent((c) => Math.max(0, Math.min(slides.length - 1, c + delta)));
         },
         [slides.length],
     );
 
+    const jumpToIndex = useCallback((index: number) => {
+        const next = Math.max(0, Math.min(slides.length - 1, index));
+        setCurrent(next);
+        setJumpOpen(false);
+    }, [slides.length]);
+
     // 키보드 네비 — 화살표/Space/PageUp·Down/Home·End/Esc.
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => {
+            const target = e.target;
+            const isEditing = target instanceof HTMLElement
+                && (target.tagName === 'INPUT'
+                    || target.tagName === 'TEXTAREA'
+                    || target.tagName === 'SELECT'
+                    || target.isContentEditable);
+            if (isEditing) {
+                if (e.key === 'Escape' && jumpOpen) {
+                    e.preventDefault();
+                    setJumpOpen(false);
+                }
+                return;
+            }
+
             switch (e.key) {
                 case 'ArrowRight':
                 case 'ArrowDown':
@@ -136,7 +304,11 @@ export function SlideshowView({
                     break;
                 case 'Escape':
                     e.preventDefault();
-                    onClose();
+                    if (jumpOpen) {
+                        setJumpOpen(false);
+                    } else {
+                        onClose();
+                    }
                     break;
                 case '+':
                 case '=':
@@ -152,7 +324,7 @@ export function SlideshowView({
         };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [go, onClose, slides.length, adjustScale]);
+    }, [go, jumpOpen, onClose, slides.length, adjustScale]);
 
     // 숨길 요소 → CSS 클래스(컨테이너에 부여, display:none 으로 비표시).
     const hideClasses = [
@@ -190,17 +362,34 @@ export function SlideshowView({
             } as React.CSSProperties}
         >
             <div className="slideshow-stage">
-                {slides.map((md, i) => (
-                    <div
-                        key={i}
-                        className={`slideshow-slide${i === current ? ' active' : ''}`}
-                        aria-hidden={i !== current}
-                    >
-                        <div className={`slideshow-content markdown-body ${hideClasses}`}>
-                            <SlideMarkdown md={md} docDir={docDir} />
+                {slides.map((md, i) => {
+                    const usesAutoColumns = settings.autoTwoColumn
+                        && autoColumnSlides[i]?.key === autoColumnKey
+                        && autoColumnSlides[i]?.isLong;
+                    const autoFitScale = autoFitSlides[i]?.key === autoColumnKey
+                        ? autoFitSlides[i].scale
+                        : 1;
+                    const contentStyle = autoFitScale < 1
+                        ? { '--slideshow-auto-scale': String(autoFitScale) } as React.CSSProperties
+                        : undefined;
+
+                    return (
+                        <div
+                            key={i}
+                            className={`slideshow-slide${i === current ? ' active' : ''}`}
+                            ref={(el) => { slideRefs.current[i] = el; }}
+                            aria-hidden={i !== current}
+                        >
+                            <div
+                                className={`slideshow-content markdown-body ${hideClasses}${usesAutoColumns ? ' auto-columns' : ''}`}
+                                style={contentStyle}
+                                onLoadCapture={i === current ? measureCurrentSlide : undefined}
+                            >
+                                <SlideMarkdown md={md} docDir={docDir} />
+                            </div>
                         </div>
-                    </div>
-                ))}
+                    );
+                })}
             </div>
 
             <div className="slideshow-fontctl">
@@ -241,9 +430,39 @@ export function SlideshowView({
                 <ChevronRight size={28} strokeWidth={1.5} />
             </button>
 
-            <div className="slideshow-indicator">
+            {jumpOpen && (
+                <nav
+                    className="slideshow-jump"
+                    aria-label="슬라이드 목차"
+                >
+                    <div className="slideshow-jump-list" aria-label="슬라이드 목록">
+                        {slideHeadings.map((item, index) => (
+                            <button
+                                key={`${index}-${item.title}`}
+                                type="button"
+                                className={`slideshow-jump-item${index === current ? ' active' : ''}${item.fallback ? ' fallback' : ''}`}
+                                style={{ '--slide-heading-indent': `${Math.min(Math.max(0, item.level - 1), 3) * 0.55}rem` } as React.CSSProperties}
+                                ref={(el) => { jumpItemRefs.current[index] = el; }}
+                                onClick={() => jumpToIndex(index)}
+                                aria-current={index === current ? 'page' : undefined}
+                            >
+                                <span className="slideshow-jump-item-index">{index + 1}</span>
+                                <span className="slideshow-jump-item-title">{item.title}</span>
+                            </button>
+                        ))}
+                    </div>
+                </nav>
+            )}
+
+            <button
+                type="button"
+                className="slideshow-indicator"
+                onClick={() => setJumpOpen((open) => !open)}
+                title="슬라이드 이동"
+                aria-label={`슬라이드 이동, 현재 ${current + 1} / ${slides.length}`}
+            >
                 {current + 1} / {slides.length}
-            </div>
+            </button>
         </div>,
         document.body,
     );

--- a/src/components/SlideshowView.tsx
+++ b/src/components/SlideshowView.tsx
@@ -31,24 +31,10 @@ interface SlideshowViewProps {
     onClose: () => void;
 }
 
-const LEADING_ATX_HEADING_RE = /^\s{0,3}#{1,6}(?:\s+|$)/;
 const ATX_HEADING_LINE_RE = /^\s{0,3}(#{1,6})\s*(.*?)\s*#*\s*$/;
 const MIN_AUTO_FIT_SCALE = 0.72;
 const OVERFLOW_EPSILON_PX = 12;
 const AUTO_FIT_MARGIN = 0.96;
-
-function splitLeadingHeading(md: string): { heading: string; body: string } {
-    const lines = md.split('\n');
-    const firstContent = lines.findIndex((line) => line.trim() !== '');
-    if (firstContent < 0 || !LEADING_ATX_HEADING_RE.test(lines[firstContent])) {
-        return { heading: '', body: md };
-    }
-
-    const heading = lines.slice(0, firstContent + 1).join('\n');
-    let bodyStart = firstContent + 1;
-    while (bodyStart < lines.length && lines[bodyStart].trim() === '') bodyStart += 1;
-    return { heading, body: lines.slice(bodyStart).join('\n') };
-}
 
 function plainMarkdownText(text: string): string {
     return text
@@ -103,22 +89,7 @@ function MarkdownChunk({ md, docDir }: { md: string; docDir: string | null }) {
 
 /** 슬라이드 1장 — read-only 마크다운 렌더(Preview 의 플러그인/이미지 resolver 동일). */
 function SlideMarkdown({ md, docDir }: { md: string; docDir: string | null }) {
-    const { heading, body } = useMemo(() => splitLeadingHeading(md), [md]);
-
-    return (
-        <>
-            {heading && (
-                <div className="slideshow-heading">
-                    <MarkdownChunk md={heading} docDir={docDir} />
-                </div>
-            )}
-            {body && (
-                <div className="slideshow-body">
-                    <MarkdownChunk md={body} docDir={docDir} />
-                </div>
-            )}
-        </>
-    );
+    return <MarkdownChunk md={md} docDir={docDir} />;
 }
 
 function nextAutoFitScale(currentScale: number, scrollHeight: number, clientHeight: number): number {

--- a/src/components/convert/SettingsView.tsx
+++ b/src/components/convert/SettingsView.tsx
@@ -784,6 +784,18 @@ export function SettingsView({ onDone, viewer }: SettingsViewProps) {
                         </div>
                     </section>
 
+                    <section className="convert-settings-section viewer-section">
+                        <label>슬라이드쇼 레이아웃</label>
+                        <label className="convert-option">
+                            <input
+                                type="checkbox"
+                                checked={viewer.slideshow.autoTwoColumn}
+                                onChange={(e) => viewer.onSlideshowChange({ autoTwoColumn: e.target.checked })}
+                            />
+                            <span>긴 슬라이드 2열</span>
+                        </label>
+                    </section>
+
                     {/* 슬라이드에서 숨길 요소 — 발표 시 특정 블록 비표시(2×2 체크박스). */}
                     <section className="convert-settings-section viewer-section">
                         <label>슬라이드에서 숨길 요소</label>

--- a/src/lib/pdf/exportVisualPdf.ts
+++ b/src/lib/pdf/exportVisualPdf.ts
@@ -17,7 +17,10 @@ const PX_PER_MM = 96 / 25.4;
 /** 캡처 해상도 배율. */
 const SCALE = 2;
 /** 페이지 가장자리 여백(mm). */
-const MARGIN_MM = 6;
+const MARGIN_X_MM = 8;
+const MARGIN_TOP_MM = 12;
+const MARGIN_BOTTOM_MM = 16;
+const PAGE_NUMBER_Y_OFFSET_MM = 5;
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
 export type VisualViewMode = 'gantt' | 'mindmap' | 'flowchart' | 'kanban';
@@ -237,15 +240,18 @@ async function captureKanban(): Promise<CapturedImage | null> {
 // ─── 공통: PDF 조립 / 저장 ────────────────────────────────────────────────────
 
 /** 콘텐츠 비율에 맞춘 단일 커스텀 페이지 PDF(잘림 0, orientation 자동). jsPDF 지연 로드. */
-async function imageToPdfBlob(img: CapturedImage, marginMm = MARGIN_MM): Promise<Blob> {
+async function imageToPdfBlob(img: CapturedImage): Promise<Blob> {
     const { jsPDF } = await import('jspdf');
     const cw = img.width / PX_PER_MM;
     const ch = img.height / PX_PER_MM;
-    const pageW = cw + marginMm * 2;
-    const pageH = ch + marginMm * 2;
+    const pageW = cw + MARGIN_X_MM * 2;
+    const pageH = ch + MARGIN_TOP_MM + MARGIN_BOTTOM_MM;
     const orientation = pageW >= pageH ? 'landscape' : 'portrait';
     const pdf = new jsPDF({ orientation, unit: 'mm', format: [pageW, pageH], compress: true });
-    pdf.addImage(img.dataUrl, 'PNG', marginMm, marginMm, cw, ch, undefined, 'FAST');
+    pdf.addImage(img.dataUrl, 'PNG', MARGIN_X_MM, MARGIN_TOP_MM, cw, ch, undefined, 'FAST');
+    pdf.setFontSize(8.5);
+    pdf.setTextColor(102);
+    pdf.text('1', pageW / 2, pageH - PAGE_NUMBER_Y_OFFSET_MM, { align: 'center' });
     return pdf.output('blob');
 }
 

--- a/src/lib/slideSplit.ts
+++ b/src/lib/slideSplit.ts
@@ -20,6 +20,8 @@ export interface SlideshowSettings {
     hideBlockquote: boolean;
     hideInlineCode: boolean;
     hideStrike: boolean;
+    // 긴 슬라이드 본문을 자동 2열로 표시(렌더러가 실제 overflow 기준으로 판정).
+    autoTwoColumn: boolean;
 }
 
 export const DEFAULT_SLIDESHOW_SETTINGS: SlideshowSettings = {
@@ -32,6 +34,7 @@ export const DEFAULT_SLIDESHOW_SETTINGS: SlideshowSettings = {
     hideBlockquote: false,
     hideInlineCode: false,
     hideStrike: false,
+    autoTwoColumn: true,
 };
 
 const STORAGE_KEY = 'markmind-slideshow-settings';


### PR DESCRIPTION
## Summary

- Polish slideshow rendering for dense content: automatic 2-column layout, auto-fit scaling, page-number safe area, and heading-based TOC navigation.
- Keep slideshow Markdown parsing at one parse per slide so reference-style links and image definitions still resolve.
- Fix native PDF output margins with print `@page` content margins aligned to macOS `NSPrintInfo` hints.
- Add PDF page numbers as real PDF text objects when PDFium is available, and skip numbering instead of rewriting with CoreGraphics when PDFium is unavailable so WebKit link annotations are preserved.
- Route WebKit PDF output through a temporary file before replacing the final path to avoid stale-file races.

## Root Cause

The previous PDF footer and margin attempt relied too much on print CSS body padding and CSS page counters. In macOS WKWebView native print output, body padding can be inconsistent across pages and CSS page counters/page margin boxes are not reliable. Separately, the first PDF fallback rewrote pages with CoreGraphics, which preserved visible page content but dropped PDF annotations such as clickable links.

For slideshow rendering, splitting the leading heading and body into separate `ReactMarkdown` parses broke Markdown reference definitions that were declared later in the same slide.

## Validation

- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`

Fixes #107
Fixes #108
