### PR TITLE
[codex] Render flowcharts in rich text and PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
         "@tauri-apps/plugin-opener": "^2",
+        "@tiptap/extension-code-block": "^3.23.6",
         "@tiptap/extension-image": "^3.23.6",
         "@tiptap/extension-link": "^3.23.6",
         "@tiptap/extension-table": "^3.23.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-opener": "^2",
+    "@tiptap/extension-code-block": "^3.23.6",
     "@tiptap/extension-image": "^3.23.6",
     "@tiptap/extension-link": "^3.23.6",
     "@tiptap/extension-table": "^3.23.6",

--- a/sample-flowchart.md
+++ b/sample-flowchart.md
@@ -1,0 +1,101 @@
+# 문서 작성 승인 흐름
+
+이 파일은 **Flowchart View** 와 **Rich Text 모드**에서 `markmind-flow` 코드블록 보존을 확인하기 위한 샘플입니다.
+
+- Flowchart view에서는 아래 JSON이 다이어그램으로 표시됩니다.
+- Rich Text 모드에서는 같은 블록이 시각적인 flowchart 블록으로 표시됩니다.
+- Markdown으로 다시 전환해도 `markmind-flow` JSON이 그대로 보존되어야 합니다.
+
+```markmind-flow
+{
+  "title": "문서 작성 승인 흐름",
+  "direction": "LR",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "start",
+      "label": "Draft 작성",
+      "description": "초안 문서를 작성한다",
+      "position": {
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": "review",
+      "type": "process",
+      "label": "리뷰 요청",
+      "description": "담당자에게 검토를 요청한다",
+      "position": {
+        "x": 260,
+        "y": 0
+      }
+    },
+    {
+      "id": "approved",
+      "type": "decision",
+      "label": "승인?",
+      "description": "수정 없이 승인 가능한지 판단한다",
+      "position": {
+        "x": 520,
+        "y": 0
+      }
+    },
+    {
+      "id": "revise",
+      "type": "process",
+      "label": "수정 반영",
+      "description": "리뷰 의견을 반영한다",
+      "position": {
+        "x": 520,
+        "y": 190
+      }
+    },
+    {
+      "id": "publish",
+      "type": "end",
+      "label": "게시",
+      "description": "승인된 문서를 배포한다",
+      "position": {
+        "x": 790,
+        "y": 0
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-start-review",
+      "source": "start",
+      "target": "review"
+    },
+    {
+      "id": "e-review-approved",
+      "source": "review",
+      "target": "approved"
+    },
+    {
+      "id": "e-approved-publish",
+      "source": "approved",
+      "target": "publish",
+      "sourceHandle": "yes",
+      "label": "Yes",
+      "type": "conditional"
+    },
+    {
+      "id": "e-approved-revise",
+      "source": "approved",
+      "target": "revise",
+      "sourceHandle": "no",
+      "label": "No",
+      "type": "conditional"
+    },
+    {
+      "id": "e-revise-review",
+      "source": "revise",
+      "target": "review",
+      "label": "재검토",
+      "markerLoop": true
+    }
+  ]
+}
+```

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2556,6 +2556,8 @@ dependencies = [
  "ndarray",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "objc2-web-kit",
  "ort",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -113,3 +113,10 @@ objc2-web-kit = { version = "0.3", features = [
     "WKWebView",
 ] }
 objc2-foundation = { version = "0.3", features = ["NSURL", "NSString", "NSError", "NSDictionary", "NSArray"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFURL"] }
+objc2-core-graphics = { version = "0.3", default-features = false, features = [
+    "CGContext",
+    "CGPDFContext",
+    "CGPDFDocument",
+    "CGPDFPage",
+] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -116,7 +116,9 @@ objc2-foundation = { version = "0.3", features = ["NSURL", "NSString", "NSError"
 objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFURL"] }
 objc2-core-graphics = { version = "0.3", default-features = false, features = [
     "CGContext",
+    "CGPDFArray",
     "CGPDFContext",
+    "CGPDFDictionary",
     "CGPDFDocument",
     "CGPDFPage",
 ] }

--- a/src-tauri/src/print_pdf.rs
+++ b/src-tauri/src/print_pdf.rs
@@ -247,6 +247,11 @@ fn add_page_numbers_to_pdf_with_core_graphics(path: &str) -> Result<(), String> 
     if page_count == 0 {
         return Err("CoreGraphics PDF 페이지가 없습니다.".to_string());
     }
+    if core_graphics_pdf_has_page_annotations(&document, page_count)? {
+        return Err(
+            "CoreGraphics fallback 건너뜀: source PDF annotations/link 보존 필요".to_string(),
+        );
+    }
 
     let tmp_path = numbered_tmp_path(path);
     let _ = std::fs::remove_file(&tmp_path);
@@ -292,6 +297,32 @@ fn add_page_numbers_to_pdf_with_core_graphics(path: &str) -> Result<(), String> 
         .map_err(|err| format!("CoreGraphics 번호 삽입 PDF 교체 실패: {err}"))?;
 
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn core_graphics_pdf_has_page_annotations(
+    document: &objc2_core_graphics::CGPDFDocument,
+    page_count: usize,
+) -> Result<bool, String> {
+    use objc2_core_graphics::{CGPDFArray, CGPDFArrayRef, CGPDFDictionary, CGPDFPage};
+    use std::{ffi::c_char, ptr::NonNull};
+
+    const ANNOTS_KEY: &[u8] = b"Annots\0";
+    let key = NonNull::new(ANNOTS_KEY.as_ptr() as *mut c_char)
+        .ok_or_else(|| "CoreGraphics Annots key 생성 실패".to_string())?;
+
+    for index in 1..=page_count {
+        let page = objc2_core_graphics::CGPDFDocument::page(Some(document), index)
+            .ok_or_else(|| format!("CoreGraphics PDF 페이지 {index} annotation 검사 실패"))?;
+        let dict = CGPDFPage::dictionary(Some(&page));
+        let mut annots: CGPDFArrayRef = std::ptr::null_mut();
+        let has_annots = unsafe { CGPDFDictionary::array(dict, key, &mut annots) };
+        if has_annots && !annots.is_null() && unsafe { CGPDFArray::count(annots) } > 0 {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/print_pdf.rs
+++ b/src-tauri/src/print_pdf.rs
@@ -140,7 +140,7 @@ pub async fn export_pdf(window: WebviewWindow, path: String) -> Result<(), Strin
         // WebKit 의 CSS page margin box(`@bottom-center`)는 앱 내 native print 에서
         // 안정적으로 출력되지 않는다. WebKit 출력은 임시 파일로 받은 뒤 PDFium 으로
         // 실제 text object 를 덧붙이고, 마지막에 최종 경로로 교체한다. PDFium 을
-        // 사용할 수 없으면 번호 삽입을 건너뛰어 원본 PDF의 링크 annotation 을 보존한다.
+        // 사용할 수 없으면 CoreGraphics fallback 으로 페이지 번호 표시를 우선한다.
         let numbering_path = raw_pdf_path.clone();
         match tokio::task::spawn_blocking(move || add_page_numbers_to_pdf(&numbering_path)).await {
             Ok(Ok(())) => {}
@@ -182,7 +182,17 @@ async fn wait_for_pdf_write_to_finish(path: &str) -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 fn add_page_numbers_to_pdf(path: &str) -> Result<(), String> {
-    add_page_numbers_to_pdf_with_pdfium(path)
+    match add_page_numbers_to_pdf_with_pdfium(path) {
+        Ok(()) => Ok(()),
+        Err(pdfium_err) => {
+            log::warn!(
+                "PDFium page number post-process failed; falling back to CoreGraphics: {pdfium_err}"
+            );
+            add_page_numbers_to_pdf_with_core_graphics(path).map_err(|core_graphics_err| {
+                format!("PDFium 실패: {pdfium_err}; CoreGraphics fallback 실패: {core_graphics_err}")
+            })
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -222,6 +232,132 @@ fn add_page_numbers_to_pdf_with_pdfium(path: &str) -> Result<(), String> {
     std::fs::rename(&tmp_path, path).map_err(|err| format!("번호 삽입 PDF 교체 실패: {err}"))?;
 
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn add_page_numbers_to_pdf_with_core_graphics(path: &str) -> Result<(), String> {
+    use objc2_core_graphics::{
+        CGContext, CGPDFBox, CGPDFContextClose, CGPDFContextCreateWithURL, CGPDFDocument,
+    };
+
+    let source_url = cf_url_from_path(path, false)?;
+    let document = CGPDFDocument::with_url(Some(&source_url))
+        .ok_or_else(|| "CoreGraphics PDF 로드 실패".to_string())?;
+    let page_count = CGPDFDocument::number_of_pages(Some(&document));
+    if page_count == 0 {
+        return Err("CoreGraphics PDF 페이지가 없습니다.".to_string());
+    }
+
+    let tmp_path = numbered_tmp_path(path);
+    let _ = std::fs::remove_file(&tmp_path);
+    let tmp_path_string = tmp_path
+        .to_str()
+        .ok_or_else(|| "CoreGraphics 임시 PDF 경로가 UTF-8 이 아닙니다.".to_string())?
+        .to_string();
+    let output_url = cf_url_from_path(&tmp_path_string, false)?;
+    let context = unsafe {
+        CGPDFContextCreateWithURL(Some(&output_url), std::ptr::null(), None)
+            .ok_or_else(|| "CoreGraphics PDF context 생성 실패".to_string())?
+    };
+
+    for index in 1..=page_count {
+        let page = CGPDFDocument::page(Some(&document), index)
+            .ok_or_else(|| format!("CoreGraphics PDF 페이지 {index} 로드 실패"))?;
+        let media_box =
+            objc2_core_graphics::CGPDFPage::box_rect(Some(&page), CGPDFBox::MediaBox);
+
+        unsafe {
+            CGContext::begin_page(Some(&context), &media_box);
+        }
+
+        CGContext::save_g_state(Some(&context));
+        let rotation_angle = objc2_core_graphics::CGPDFPage::rotation_angle(Some(&page));
+        let transform = objc2_core_graphics::CGPDFPage::drawing_transform(
+            Some(&page),
+            CGPDFBox::MediaBox,
+            media_box,
+            rotation_angle,
+            true,
+        );
+        CGContext::concat_ctm(Some(&context), transform);
+        CGContext::draw_pdf_page(Some(&context), Some(&page));
+        CGContext::restore_g_state(Some(&context));
+
+        draw_page_number_with_core_graphics(&context, &media_box, index);
+        CGContext::end_page(Some(&context));
+    }
+
+    CGPDFContextClose(Some(&context));
+    std::fs::rename(&tmp_path, path)
+        .map_err(|err| format!("CoreGraphics 번호 삽입 PDF 교체 실패: {err}"))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn draw_page_number_with_core_graphics(
+    context: &objc2_core_graphics::CGContext,
+    media_box: &objc2_core_foundation::CGRect,
+    page_number: usize,
+) {
+    use objc2_core_foundation::CGAffineTransform;
+    use objc2_core_graphics::{CGContext, CGTextDrawingMode, CGTextEncoding};
+    use std::os::raw::c_char;
+
+    const HELVETICA: &[u8] = b"Helvetica\0";
+
+    let label = page_number.to_string();
+    let text_width = label.len() as f64 * PDF_PAGE_NUMBER_FONT_PT as f64 * 0.55;
+    let x = media_box.origin.x + (media_box.size.width - text_width) / 2.0;
+    let y = media_box.origin.y + PDF_PAGE_NUMBER_BOTTOM_MM as f64 * MM_TO_PT;
+
+    CGContext::save_g_state(Some(context));
+    CGContext::set_rgb_fill_color(Some(context), 0.4, 0.4, 0.4, 1.0);
+    CGContext::set_text_matrix(
+        Some(context),
+        CGAffineTransform {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            tx: 0.0,
+            ty: 0.0,
+        },
+    );
+    CGContext::set_text_drawing_mode(Some(context), CGTextDrawingMode::Fill);
+    unsafe {
+        CGContext::select_font(
+            Some(context),
+            HELVETICA.as_ptr().cast::<c_char>(),
+            PDF_PAGE_NUMBER_FONT_PT as f64,
+            CGTextEncoding::EncodingMacRoman,
+        );
+        CGContext::show_text_at_point(
+            Some(context),
+            x,
+            y,
+            label.as_bytes().as_ptr().cast::<c_char>(),
+            label.len(),
+        );
+    }
+    CGContext::restore_g_state(Some(context));
+}
+
+#[cfg(target_os = "macos")]
+fn cf_url_from_path(
+    path: &str,
+    is_directory: bool,
+) -> Result<objc2_core_foundation::CFRetained<objc2_core_foundation::CFURL>, String> {
+    unsafe {
+        objc2_core_foundation::CFURL::from_file_system_representation(
+            None,
+            path.as_bytes().as_ptr(),
+            path.len() as isize,
+            is_directory,
+        )
+    }
+    .ok_or_else(|| format!("파일 URL 생성 실패: {path}"))
 }
 
 #[cfg(target_os = "macos")]

--- a/src/App.css
+++ b/src/App.css
@@ -3309,6 +3309,16 @@ code.hljs {
     position: static !important;
     box-shadow: none !important;
     text-shadow: none !important;
+    caret-color: transparent !important;
+  }
+
+  *::selection {
+    background: transparent !important;
+    color: inherit !important;
+  }
+
+  .ProseMirror-selectednode {
+    outline: none !important;
   }
 
   /* 사용자 BackgroundPicker 의 !important 인라인 스타일 counter */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -470,7 +470,7 @@ function App() {
       // 다이얼로그 확정 후부터 진행 오버레이 — 캡처/PDF 가 끝나야 Finder 에 파일이 보이므로.
       setPdfExporting(true);
       try {
-        const blob = await buildVisualViewPdf(viewMode);
+        const blob = await buildVisualViewPdf(viewMode, content);
         if (blob) await writePdfBlob(blob, path);
       } catch (err) {
         console.error('[export_pdf visual] failed:', err);
@@ -490,8 +490,10 @@ function App() {
       await new Promise<void>((r) => setTimeout(r, 80));
     }
 
+    let cleanupRichFlowchartsForPrint: (() => void) | null = null;
+    let activeElementBeforePrint: HTMLElement | null = null;
     try {
-      const [{ save }, { invoke }] = await Promise.all([
+      const [{ save, message }, { invoke }] = await Promise.all([
         import('@tauri-apps/plugin-dialog'),
         import('@tauri-apps/api/core'),
       ]);
@@ -504,16 +506,39 @@ function App() {
         // 사용자 취소
         return;
       }
+
+      activeElementBeforePrint = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+      activeElementBeforePrint?.blur();
+      window.getSelection()?.removeAllRanges();
+      await new Promise<void>((r) => requestAnimationFrame(() => r()));
+
+      try {
+        const { prepareRichFlowchartsForPrint } = await import('./lib/pdf/richFlowchartPrint');
+        cleanupRichFlowchartsForPrint = await prepareRichFlowchartsForPrint();
+      } catch (err) {
+        console.error('[export_pdf] rich flowchart snapshot failed:', err);
+        await message('플로우차트를 PDF용 이미지로 변환하지 못했습니다. 잠시 후 다시 시도해주세요.', {
+          title: 'PDF 내보내기',
+          kind: 'error',
+        });
+        return;
+      }
+
       await invoke('export_pdf', { path });
     } catch (err) {
       console.error('[export_pdf] failed:', err);
     } finally {
+      cleanupRichFlowchartsForPrint?.();
       if (prevViewModeRef.current) {
         setViewMode(prevViewModeRef.current);
         prevViewModeRef.current = null;
+      } else if (activeElementBeforePrint?.isConnected) {
+        activeElementBeforePrint.focus({ preventScroll: true });
       }
     }
-  }, [viewMode, fileName]);
+  }, [viewMode, fileName, content]);
 
   // ⌘P / Ctrl+P 단축키 (IME 합성 중 보호)
   useEffect(() => {

--- a/src/components/FlowchartRichBlock.css
+++ b/src/components/FlowchartRichBlock.css
@@ -1,0 +1,109 @@
+.rich-flowchart-block {
+  position: relative;
+  margin: 1rem 0;
+  border: 1px solid var(--border-primary, #d8dee4);
+  border-radius: 8px;
+  background: var(--bg-secondary, #f8fafc);
+  overflow: hidden;
+}
+
+.rich-flowchart-block.ProseMirror-selectednode {
+  outline: 2px solid #4f46e5;
+  outline-offset: 2px;
+}
+
+.rich-flowchart-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 34px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-secondary, #e2e8f0);
+  color: var(--text-secondary, #667085);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.rich-flowchart-block__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary, #1f2937);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rich-flowchart-block__canvas.flowchart-view {
+  height: clamp(260px, 38vh, 460px);
+  background: var(--bg-primary, #ffffff);
+}
+
+.rich-flowchart-block .react-flow {
+  --xy-edge-label-background-color: #ffffff;
+  --xy-edge-label-color: #475467;
+}
+
+.rich-flowchart-block .react-flow__edge-textbg {
+  fill: #ffffff;
+}
+
+.rich-flowchart-block .react-flow__edge-text {
+  fill: #475467;
+}
+
+.rich-flowchart-block__error {
+  padding: 18px;
+  color: var(--text-secondary, #667085);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.rich-code-block pre {
+  margin: 1rem 0;
+}
+
+.rich-code-block__content {
+  white-space: pre;
+}
+
+.rich-flowchart-block__content-host {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.rich-flowchart-print-image {
+  display: none;
+  max-width: 100%;
+  height: auto;
+}
+
+@media print {
+  .rich-flowchart-block {
+    page-break-inside: avoid;
+    break-inside: avoid;
+    border: none !important;
+    background: #fff !important;
+    overflow: visible !important;
+  }
+
+  .rich-flowchart-block__content-host {
+    display: none !important;
+  }
+
+  .rich-flowchart-block.is-print-snapshot .rich-flowchart-block__header,
+  .rich-flowchart-block.is-print-snapshot .rich-flowchart-block__canvas {
+    display: none !important;
+  }
+
+  .rich-flowchart-block.is-print-snapshot .rich-flowchart-print-image {
+    display: block !important;
+    width: 88% !important;
+    max-width: 88% !important;
+    height: auto !important;
+    margin: 0 auto !important;
+  }
+}

--- a/src/components/FlowchartRichBlock.css
+++ b/src/components/FlowchartRichBlock.css
@@ -67,12 +67,14 @@
 }
 
 .rich-flowchart-block__content-host {
+  display: none;
   position: absolute;
   width: 1px;
   height: 1px;
   overflow: hidden;
   opacity: 0;
   pointer-events: none;
+  user-select: none;
 }
 
 .rich-flowchart-print-image {

--- a/src/components/FlowchartRichBlock.tsx
+++ b/src/components/FlowchartRichBlock.tsx
@@ -17,7 +17,7 @@ import {
 } from '@xyflow/react';
 import { assignFlowchartEdgeHandles, layoutFlowchart } from '../lib/dagre-layout';
 import type { StoredFlowchart } from '../lib/flowchartBlock';
-import { SHAPE_DIMENSIONS } from '../lib/flowchart-shapes';
+import { getShapeDimensions, normalizeFlowNodeType } from '../lib/flowchart-shapes';
 import type { FlowchartEdge, FlowchartNode } from '../types/flowchart';
 import '@xyflow/react/dist/style.css';
 import './FlowchartView.css';
@@ -77,7 +77,11 @@ function toReactFlow(nodes: FlowchartNode[], edges: FlowchartEdge[]): { nodes: N
       id: n.id,
       type: 'flow',
       position: n.position,
-      data: { label: n.label, flowType: n.type, description: n.description },
+      data: {
+        label: n.label,
+        flowType: normalizeFlowNodeType(n.type),
+        description: n.description,
+      },
     })),
     edges: edges.map((e) => ({
       id: e.id,
@@ -125,8 +129,9 @@ function preferredCanvasHeight(
   const byId = new Map(nodes.map((node) => [node.id, node]));
 
   for (const node of nodes) {
-    const dim = SHAPE_DIMENSIONS[node.type];
-    const height = node.type === 'image'
+    const nodeType = normalizeFlowNodeType(node.type);
+    const dim = getShapeDimensions(nodeType);
+    const height = nodeType === 'image'
       ? (node.image_height ?? dim.minHeight)
       : dim.minHeight;
     minY = Math.min(minY, node.position.y - height / 2);

--- a/src/components/FlowchartRichBlock.tsx
+++ b/src/components/FlowchartRichBlock.tsx
@@ -225,7 +225,13 @@ export function FlowchartCodeBlockNodeView({ node }: NodeViewProps) {
           </div>
         )}
       </div>
-      <NodeViewContent className="rich-flowchart-block__content-host" />
+      <NodeViewContent
+        className="rich-flowchart-block__content-host"
+        contentEditable={false}
+        aria-hidden="true"
+        tabIndex={-1}
+        spellCheck={false}
+      />
     </NodeViewWrapper>
   );
 }

--- a/src/components/FlowchartRichBlock.tsx
+++ b/src/components/FlowchartRichBlock.tsx
@@ -1,0 +1,226 @@
+import { useMemo } from 'react';
+import {
+  NodeViewContent,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from '@tiptap/react';
+import {
+  Background,
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from '@xyflow/react';
+import { assignFlowchartEdgeHandles, layoutFlowchart } from '../lib/dagre-layout';
+import type { StoredFlowchart } from '../lib/flowchartBlock';
+import { SHAPE_DIMENSIONS } from '../lib/flowchart-shapes';
+import type { FlowchartEdge, FlowchartNode } from '../types/flowchart';
+import '@xyflow/react/dist/style.css';
+import './FlowchartView.css';
+import './FlowchartRichBlock.css';
+
+interface FlowNodeData {
+  label: string;
+  flowType: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+function RichFlowNode({ data }: NodeProps) {
+  const d = data as FlowNodeData;
+  return (
+    <div
+      className={`flow-node flow-node--${d.flowType}`}
+      title={d.description || undefined}
+    >
+      <Handle type="source" position={Position.Right} id="right-source" />
+      <Handle type="target" position={Position.Right} id="right-target" />
+      <Handle type="source" position={Position.Left} id="left-source" />
+      <Handle type="target" position={Position.Left} id="left-target" />
+      <Handle type="source" position={Position.Top} id="top-source" />
+      <Handle type="target" position={Position.Top} id="top-target" />
+      <Handle type="source" position={Position.Bottom} id="bottom-source" />
+      <Handle type="target" position={Position.Bottom} id="bottom-target" />
+      <span className="flow-node__label">{d.label}</span>
+    </div>
+  );
+}
+
+const richNodeTypes = { flow: RichFlowNode };
+const RICH_CANVAS_MIN_HEIGHT = 360;
+const RICH_CANVAS_MAX_HEIGHT = 720;
+const RICH_CANVAS_VERTICAL_PADDING = 180;
+
+function parseStoredFlowchartJson(code: string): StoredFlowchart | null {
+  try {
+    const data = JSON.parse(code);
+    if (!Array.isArray(data?.nodes) || !Array.isArray(data?.edges)) return null;
+    const direction = data.direction === 'TB' ? 'TB' : data.direction === 'LR' ? 'LR' : undefined;
+    return {
+      title: typeof data.title === 'string' ? data.title : undefined,
+      direction,
+      nodes: data.nodes as FlowchartNode[],
+      edges: data.edges as FlowchartEdge[],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function toReactFlow(nodes: FlowchartNode[], edges: FlowchartEdge[]): { nodes: Node[]; edges: Edge[] } {
+  return {
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      type: 'flow',
+      position: n.position,
+      data: { label: n.label, flowType: n.type, description: n.description },
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      sourceHandle: e.sourceHandle,
+      targetHandle: e.targetHandle,
+      type: 'smoothstep',
+      pathOptions: e.markerLoop ? { offset: 48 } : undefined,
+      label: e.label,
+      markerStart: e.markerStart ? { type: MarkerType.ArrowClosed } : undefined,
+      markerEnd: e.markerEnd !== false ? { type: MarkerType.ArrowClosed } : undefined,
+    })),
+  };
+}
+
+function buildFlowchartGraph(flowchart: StoredFlowchart): {
+  graph: { nodes: Node[]; edges: Edge[] };
+  canvasHeight: number;
+} {
+  const rankdir = flowchart.direction ?? 'LR';
+  const seeded = flowchart.nodes.map((node) => ({
+    ...node,
+    position: node.position ?? { x: 0, y: 0 },
+  }));
+  const layouted = layoutFlowchart(seeded, flowchart.edges, { rankdir });
+  const merged = layouted.nodes.map((node) => {
+    const stored = flowchart.nodes.find((item) => item.id === node.id);
+    return stored?.position ? { ...node, position: stored.position } : node;
+  });
+  const edges = assignFlowchartEdgeHandles(layouted.edges, merged, rankdir);
+  const canvasHeight = preferredCanvasHeight(merged, edges, rankdir);
+  return { graph: toReactFlow(merged, edges), canvasHeight };
+}
+
+function preferredCanvasHeight(
+  nodes: FlowchartNode[],
+  edges: FlowchartEdge[],
+  rankdir: 'LR' | 'TB',
+): number {
+  if (nodes.length === 0) return RICH_CANVAS_MIN_HEIGHT;
+
+  let minY = Infinity;
+  let maxY = -Infinity;
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+
+  for (const node of nodes) {
+    const dim = SHAPE_DIMENSIONS[node.type];
+    const height = node.type === 'image'
+      ? (node.image_height ?? dim.minHeight)
+      : dim.minHeight;
+    minY = Math.min(minY, node.position.y - height / 2);
+    maxY = Math.max(maxY, node.position.y + height / 2);
+  }
+
+  for (const edge of edges) {
+    if (!edge.markerLoop || rankdir !== 'LR') continue;
+    const source = byId.get(edge.source);
+    const target = byId.get(edge.target);
+    if (!source || !target) continue;
+    minY = Math.min(minY, Math.min(source.position.y, target.position.y) - 96);
+  }
+
+  const span = Number.isFinite(minY) ? maxY - minY : RICH_CANVAS_MIN_HEIGHT;
+  return Math.max(
+    RICH_CANVAS_MIN_HEIGHT,
+    Math.min(RICH_CANVAS_MAX_HEIGHT, Math.ceil(span + RICH_CANVAS_VERTICAL_PADDING)),
+  );
+}
+
+function FlowchartPreview({ flowchart }: { flowchart: StoredFlowchart }) {
+  const { graph } = useMemo(() => buildFlowchartGraph(flowchart), [flowchart]);
+
+  return (
+    <ReactFlowProvider>
+      <ReactFlow
+        nodes={graph.nodes}
+        edges={graph.edges}
+        nodeTypes={richNodeTypes}
+        nodeOrigin={[0.5, 0.5]}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        panOnDrag={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        zoomOnDoubleClick={false}
+        fitView
+        fitViewOptions={{ padding: 0.3, maxZoom: 1 }}
+        minZoom={0.1}
+        maxZoom={2.5}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={20} size={1} />
+      </ReactFlow>
+    </ReactFlowProvider>
+  );
+}
+
+export function FlowchartCodeBlockNodeView({ node }: NodeViewProps) {
+  const language = typeof node.attrs.language === 'string' ? node.attrs.language : '';
+  const isFlowchart = language.trim() === 'markmind-flow';
+  const code = node.textContent;
+  const flowchart = useMemo(
+    () => (isFlowchart ? parseStoredFlowchartJson(code) : null),
+    [code, isFlowchart],
+  );
+  const canvasHeight = useMemo(
+    () => (flowchart ? buildFlowchartGraph(flowchart).canvasHeight : undefined),
+    [flowchart],
+  );
+
+  if (!isFlowchart) {
+    return (
+      <NodeViewWrapper className="rich-code-block">
+        <pre className={language ? `hljs language-${language}` : 'hljs'}>
+          <NodeViewContent className="rich-code-block__content" />
+        </pre>
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper className="rich-flowchart-block" data-flowchart-json={code}>
+      <div className="rich-flowchart-block__header" contentEditable={false}>
+        <span className="rich-flowchart-block__title">
+          {flowchart?.title || 'Flowchart'}
+        </span>
+      </div>
+      <div
+        className="rich-flowchart-block__canvas flowchart-view"
+        contentEditable={false}
+        style={canvasHeight ? { height: canvasHeight } : undefined}
+      >
+        {flowchart ? (
+          <FlowchartPreview flowchart={flowchart} />
+        ) : (
+          <div className="rich-flowchart-block__error">
+            Flowchart JSON을 읽을 수 없습니다. 아래 Source를 열어 원문을 확인하세요.
+          </div>
+        )}
+      </div>
+      <NodeViewContent className="rich-flowchart-block__content-host" />
+    </NodeViewWrapper>
+  );
+}

--- a/src/components/FlowchartView.tsx
+++ b/src/components/FlowchartView.tsx
@@ -28,7 +28,7 @@ import {
     type Connection,
 } from '@xyflow/react';
 import { Trash2, Play, Square, Split, ArrowRightLeft, Merge, CircleStop, Network, type LucideIcon } from 'lucide-react';
-import { layoutFlowchart } from '../lib/dagre-layout';
+import { assignFlowchartEdgeHandles, layoutFlowchart } from '../lib/dagre-layout';
 import { parseFlowchartBlock, upsertFlowchartBlock, type StoredFlowchart } from '../lib/flowchartBlock';
 import type { FlowchartNode, FlowchartEdge, FlowNodeType } from '../types/flowchart';
 import { FlowchartPanel } from './FlowchartPanel';
@@ -205,13 +205,15 @@ function FlowchartViewInner({ content, fileName, onChange, flowchartPanelOpen, o
     }, [isAi, rfNodes.length]);
 
     const syncFromStored = useCallback((stored: StoredFlowchart) => {
+        const rankdir = stored.direction ?? 'LR';
         const seeded = stored.nodes.map((n) => ({ ...n, position: n.position ?? { x: 0, y: 0 } }));
-        const lo = layoutFlowchart(seeded, stored.edges, { rankdir: stored.direction ?? 'LR' });
+        const lo = layoutFlowchart(seeded, stored.edges, { rankdir });
         const merged = lo.nodes.map((n) => {
             const sn = stored.nodes.find((s) => s.id === n.id);
             return sn?.position ? { ...n, position: sn.position } : n;
         });
-        const rf = toReactFlow(merged, lo.edges);
+        const edges = assignFlowchartEdgeHandles(lo.edges, merged, rankdir);
+        const rf = toReactFlow(merged, edges);
         setRfNodes(rf.nodes);
         setRfEdges(rf.edges);
     }, [setRfNodes, setRfEdges]);

--- a/src/components/FlowchartView.tsx
+++ b/src/components/FlowchartView.tsx
@@ -30,6 +30,7 @@ import {
 import { Trash2, Play, Square, Split, ArrowRightLeft, Merge, CircleStop, Network, type LucideIcon } from 'lucide-react';
 import { assignFlowchartEdgeHandles, layoutFlowchart } from '../lib/dagre-layout';
 import { parseFlowchartBlock, upsertFlowchartBlock, type StoredFlowchart } from '../lib/flowchartBlock';
+import { normalizeFlowNodeType } from '../lib/flowchart-shapes';
 import type { FlowchartNode, FlowchartEdge, FlowNodeType } from '../types/flowchart';
 import { FlowchartPanel } from './FlowchartPanel';
 import '@xyflow/react/dist/style.css';
@@ -153,7 +154,11 @@ function toReactFlow(nodes: FlowchartNode[], edges: FlowchartEdge[]): { nodes: N
             id: n.id,
             type: 'flow',
             position: n.position,
-            data: { label: n.label, flowType: n.type, description: n.description },
+            data: {
+                label: n.label,
+                flowType: normalizeFlowNodeType(n.type),
+                description: n.description,
+            },
         })),
         edges: edges.map((e) => ({
             id: e.id,

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -35,6 +35,7 @@ import type { Node as PMNode } from '@tiptap/pm/model';
 import { InlineCheckbox } from '../extensions/InlineCheckbox';
 import { MarkdownTable } from '../extensions/MarkdownTable';
 import { createImageInline } from '../extensions/ImageInline';
+import { FlowchartCodeBlock } from '../extensions/FlowchartCodeBlock';
 import { resolveImageSrc } from '../lib/imageSrc';
 import { removeFlowchartBlock, hasFlowchartBlock } from '../lib/flowchartBlock';
 import { quoteLines } from '../lib/quoteMatch';
@@ -908,7 +909,7 @@ function RichEditor({
         extensions: [
             StarterKit.configure({
                 heading: { levels: [1, 2, 3, 4, 5, 6] },
-                codeBlock: { HTMLAttributes: { class: 'hljs' } },
+                codeBlock: false,
                 // undo/redo 끄기 — App 전역 content 스택으로 일원화(#74 유니버설 undo).
                 undoRedo: false,
                 // bold/italic/strike 는 expel 끈 커스텀으로 대체(아래) — blockquote 직렬화 버그 회피.
@@ -919,6 +920,7 @@ function RichEditor({
             ItalicNoExpel,
             BoldNoExpel,
             StrikeNoExpel,
+            FlowchartCodeBlock.configure({ HTMLAttributes: { class: 'hljs' } }),
             // autolink: false — `arena.ai` 같은 평문 URL 이 자동으로 링크되는 동작 끄기
             // (사용자가 명시적으로 toolbar Link 버튼/⌘K 로만 링크 생성)
             Link.configure({ openOnClick: false, autolink: false }),

--- a/src/extensions/FlowchartCodeBlock.ts
+++ b/src/extensions/FlowchartCodeBlock.ts
@@ -1,0 +1,9 @@
+import { CodeBlock } from '@tiptap/extension-code-block';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { FlowchartCodeBlockNodeView } from '../components/FlowchartRichBlock';
+
+export const FlowchartCodeBlock = CodeBlock.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(FlowchartCodeBlockNodeView);
+  },
+});

--- a/src/extensions/FlowchartCodeBlock.ts
+++ b/src/extensions/FlowchartCodeBlock.ts
@@ -2,8 +2,15 @@ import { CodeBlock } from '@tiptap/extension-code-block';
 import { ReactNodeViewRenderer } from '@tiptap/react';
 import { FlowchartCodeBlockNodeView } from '../components/FlowchartRichBlock';
 
+function isInsideReadOnlyFlowchart(event: Event): boolean {
+  return event.target instanceof Element
+    && event.target.closest('.rich-flowchart-block') !== null;
+}
+
 export const FlowchartCodeBlock = CodeBlock.extend({
   addNodeView() {
-    return ReactNodeViewRenderer(FlowchartCodeBlockNodeView);
+    return ReactNodeViewRenderer(FlowchartCodeBlockNodeView, {
+      stopEvent: ({ event }) => isInsideReadOnlyFlowchart(event),
+    });
   },
 });

--- a/src/lib/dagre-layout.test.ts
+++ b/src/lib/dagre-layout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { assignFlowchartEdgeHandles } from './dagre-layout';
+import type { FlowchartEdge, FlowchartNode } from '../types/flowchart';
+
+describe('assignFlowchartEdgeHandles', () => {
+    it('routes LR branch edges from the nearest vertical side instead of wrapping right-to-left', () => {
+        const nodes: FlowchartNode[] = [
+            { id: 'start', type: 'start', label: 'Draft 작성', position: { x: 0, y: 0 } },
+            { id: 'review', type: 'process', label: '리뷰 요청', position: { x: 260, y: 0 } },
+            { id: 'approved', type: 'decision', label: '승인?', position: { x: 520, y: 0 } },
+            { id: 'revise', type: 'process', label: '수정 반영', position: { x: 520, y: 190 } },
+            { id: 'publish', type: 'end', label: '게시', position: { x: 790, y: 0 } },
+        ];
+        const edges: FlowchartEdge[] = [
+            { id: 'e-start-review', source: 'start', target: 'review' },
+            { id: 'e-review-approved', source: 'review', target: 'approved' },
+            { id: 'e-approved-publish', source: 'approved', target: 'publish', label: 'Yes' },
+            { id: 'e-approved-revise', source: 'approved', target: 'revise', label: 'No' },
+            { id: 'e-revise-review', source: 'revise', target: 'review', label: '재검토', markerLoop: true },
+        ];
+
+        const routed = assignFlowchartEdgeHandles(edges, nodes, 'LR');
+        const byId = new Map(routed.map((edge) => [edge.id, edge]));
+
+        expect(byId.get('e-approved-publish')).toMatchObject({
+            sourceHandle: 'right-source',
+            targetHandle: 'left-target',
+        });
+        expect(byId.get('e-approved-revise')).toMatchObject({
+            sourceHandle: 'bottom-source',
+            targetHandle: 'top-target',
+        });
+        expect(byId.get('e-revise-review')).toMatchObject({
+            sourceHandle: 'top-source',
+            targetHandle: 'top-target',
+        });
+    });
+});

--- a/src/lib/dagre-layout.ts
+++ b/src/lib/dagre-layout.ts
@@ -11,8 +11,8 @@
  */
 
 import dagre from 'dagre'
-import { FlowchartEdge, FlowchartNode, FlowNodeType } from '../types/flowchart'
-import { SHAPE_DIMENSIONS } from './flowchart-shapes'
+import { FlowchartEdge, FlowchartNode } from '../types/flowchart'
+import { getShapeDimensions } from './flowchart-shapes'
 
 /** Canvas snap grid step — must match GRID_SIZE in flowchart-canvas. */
 const GRID_SIZE = 20
@@ -157,10 +157,10 @@ export function layoutFlowchart(
             })
             continue
         }
-        const dim = SHAPE_DIMENSIONS[n.type as FlowNodeType]
+        const dim = getShapeDimensions(n.type)
         g.setNode(n.id, {
-            width: dim?.minWidth ?? 160,
-            height: dim?.minHeight ?? 60,
+            width: dim.minWidth,
+            height: dim.minHeight,
         })
     }
     for (const e of edges) {

--- a/src/lib/dagre-layout.ts
+++ b/src/lib/dagre-layout.ts
@@ -24,11 +24,63 @@ export interface LayoutOptions {
     nodesep?: number
     /** Spacing between adjacent ranks. Default 100. */
     ranksep?: number
+    /** Optional rendered size override, used by export renderers that do not use CSS boxes. */
+    getNodeSize?: (node: FlowchartNode) => { width: number; height: number } | undefined
 }
 
 export interface LayoutResult {
     nodes: FlowchartNode[]
     edges: FlowchartEdge[]
+}
+
+function directionalHandles(
+    edge: FlowchartEdge,
+    positions: Map<string, { x: number; y: number }>,
+    rankdir: 'LR' | 'TB',
+): { sourceHandle: string; targetHandle: string } {
+    const source = positions.get(edge.source)
+    const target = positions.get(edge.target)
+    if (!source || !target) {
+        return rankdir === 'TB'
+            ? { sourceHandle: 'bottom-source', targetHandle: 'top-target' }
+            : { sourceHandle: 'right-source', targetHandle: 'left-target' }
+    }
+
+    const dx = target.x - source.x
+    const dy = target.y - source.y
+    if (rankdir === 'LR') {
+        if (Math.abs(dy) > GRID_SIZE && Math.abs(dy) >= Math.abs(dx) * 0.45) {
+            return dy > 0
+                ? { sourceHandle: 'bottom-source', targetHandle: 'top-target' }
+                : { sourceHandle: 'top-source', targetHandle: 'bottom-target' }
+        }
+        return dx >= 0
+            ? { sourceHandle: 'right-source', targetHandle: 'left-target' }
+            : { sourceHandle: 'left-source', targetHandle: 'right-target' }
+    }
+
+    if (Math.abs(dx) > GRID_SIZE && Math.abs(dx) >= Math.abs(dy) * 0.45) {
+        return dx > 0
+            ? { sourceHandle: 'right-source', targetHandle: 'left-target' }
+            : { sourceHandle: 'left-source', targetHandle: 'right-target' }
+    }
+    return dy >= 0
+        ? { sourceHandle: 'bottom-source', targetHandle: 'top-target' }
+        : { sourceHandle: 'top-source', targetHandle: 'bottom-target' }
+}
+
+export function assignFlowchartEdgeHandles(
+    edges: FlowchartEdge[],
+    nodes: Pick<FlowchartNode, 'id' | 'position'>[],
+    rankdir: 'LR' | 'TB' = 'LR',
+): FlowchartEdge[] {
+    const positions = new Map(nodes.map(n => [n.id, n.position]))
+    const loopSource = rankdir === 'TB' ? 'left-source'  : 'top-source'
+    const loopTarget = rankdir === 'TB' ? 'left-target'  : 'top-target'
+    return edges.map(e => {
+        if (e.markerLoop) return { ...e, sourceHandle: loopSource, targetHandle: loopTarget }
+        return { ...e, ...directionalHandles(e, positions, rankdir) }
+    })
 }
 
 /**
@@ -82,6 +134,14 @@ export function layoutFlowchart(
 
     for (const n of nodes) {
         if (!connectedIds.has(n.id)) continue   // isolated → keep original pos
+        const customSize = options.getNodeSize?.(n)
+        if (customSize) {
+            g.setNode(n.id, {
+                width: customSize.width,
+                height: customSize.height,
+            })
+            continue
+        }
         // Image nodes carry their actual rendered dimensions on the node
         // itself (set when the file is dropped + adjusted by NodeResizer).
         // Falling through to SHAPE_DIMENSIONS would give them the same
@@ -248,8 +308,10 @@ export function layoutFlowchart(
         return { ...n, position: d }
     })
 
-    // Handle assignment matches the flow direction so smoothstep edges go
-    // straight along the rank axis instead of doubling back.
+    // Handle assignment follows the final node geometry. Branches that move
+    // off the main rank axis should leave from top/bottom (LR) or left/right
+    // (TB); forcing every LR edge to right→left makes lower branches wrap
+    // around the graph and visually tangle.
     //
     // Loop edges get the PERPENDICULAR side so the path arcs over (LR) /
     // beside (TB) the main flow body instead of looking like a forward
@@ -257,14 +319,7 @@ export function layoutFlowchart(
     // input" loop in an LR layout would still leave from the source's
     // right side and enter the target's left side — visually identical
     // to a normal arrow.
-    const fwdSource = rankdir === 'TB' ? 'bottom-source' : 'right-source'
-    const fwdTarget = rankdir === 'TB' ? 'top-target'    : 'left-target'
-    const loopSource = rankdir === 'TB' ? 'left-source'  : 'top-source'
-    const loopTarget = rankdir === 'TB' ? 'left-target'  : 'top-target'
-    const newEdges = edges.map(e => e.markerLoop
-        ? { ...e, sourceHandle: loopSource, targetHandle: loopTarget }
-        : { ...e, sourceHandle: fwdSource, targetHandle: fwdTarget }
-    )
+    const newEdges = assignFlowchartEdgeHandles(edges, newNodes, rankdir)
 
     return { nodes: newNodes, edges: newEdges }
 }

--- a/src/lib/flowchart-shapes.test.ts
+++ b/src/lib/flowchart-shapes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import type { FlowNodeType } from '../types/flowchart';
+import {
+  DEFAULT_FLOW_NODE_TYPE,
+  getShapeDimensions,
+  normalizeFlowNodeType,
+  SHAPE_DIMENSIONS,
+} from './flowchart-shapes';
+
+describe('flowchart shape helpers', () => {
+  it('falls back to process for unknown persisted node types', () => {
+    const legacyType = 'legacy-task' as FlowNodeType;
+
+    expect(DEFAULT_FLOW_NODE_TYPE).toBe('process');
+    expect(normalizeFlowNodeType(legacyType)).toBe('process');
+    expect(getShapeDimensions(legacyType)).toEqual(SHAPE_DIMENSIONS.process);
+  });
+});

--- a/src/lib/flowchart-shapes.ts
+++ b/src/lib/flowchart-shapes.ts
@@ -6,10 +6,15 @@
  */
 import type { FlowNodeType } from '../types/flowchart';
 
-export const SHAPE_DIMENSIONS: Record<
-    FlowNodeType,
-    { minWidth: number; minHeight: number; maxWidth: number }
-> = {
+export interface ShapeDimensions {
+    minWidth: number;
+    minHeight: number;
+    maxWidth: number;
+}
+
+export const DEFAULT_FLOW_NODE_TYPE: FlowNodeType = 'process';
+
+export const SHAPE_DIMENSIONS: Record<FlowNodeType, ShapeDimensions> = {
     start: { minWidth: 120, minHeight: 60, maxWidth: 240 },
     end: { minWidth: 120, minHeight: 60, maxWidth: 240 },
     process: { minWidth: 160, minHeight: 60, maxWidth: 320 },
@@ -19,3 +24,16 @@ export const SHAPE_DIMENSIONS: Record<
     // image: 캔버스 최소 footprint. 실제 크기는 image_width/height 로 결정.
     image: { minWidth: 80, minHeight: 60, maxWidth: 800 },
 };
+
+export function isFlowNodeType(value: unknown): value is FlowNodeType {
+    return typeof value === 'string'
+        && Object.prototype.hasOwnProperty.call(SHAPE_DIMENSIONS, value);
+}
+
+export function normalizeFlowNodeType(value: unknown): FlowNodeType {
+    return isFlowNodeType(value) ? value : DEFAULT_FLOW_NODE_TYPE;
+}
+
+export function getShapeDimensions(value: unknown): ShapeDimensions {
+    return SHAPE_DIMENSIONS[normalizeFlowNodeType(value)];
+}

--- a/src/lib/pdf/exportVisualPdf.ts
+++ b/src/lib/pdf/exportVisualPdf.ts
@@ -214,12 +214,17 @@ async function captureFlowView(viewMode: 'mindmap' | 'flowchart'): Promise<Captu
 async function captureStoredFlowchart(sourceMarkdown?: string): Promise<CapturedImage | null> {
     const flowchart = sourceMarkdown ? parseFlowchartBlock(sourceMarkdown) : null;
     if (!flowchart) return null;
-    const snapshot = await flowchartToPngSnapshot(flowchart);
-    return {
-        dataUrl: snapshot.dataUrl,
-        width: snapshot.width,
-        height: snapshot.height,
-    };
+    try {
+        const snapshot = await flowchartToPngSnapshot(flowchart);
+        return {
+            dataUrl: snapshot.dataUrl,
+            width: snapshot.width,
+            height: snapshot.height,
+        };
+    } catch (error) {
+        console.warn('[pdf] Stored flowchart snapshot failed; falling back to DOM capture.', error);
+        return null;
+    }
 }
 
 // ─── 칸반(HTML board) ───────────────────────────────────────────────────────

--- a/src/lib/pdf/exportVisualPdf.ts
+++ b/src/lib/pdf/exportVisualPdf.ts
@@ -11,6 +11,8 @@
  * - 다이얼로그/진행표시는 호출부(App)가 제어 — build(캡처+PDF) 와 write(저장) 를 분리해
  *   "다이얼로그 → 진행표시 → 생성 → 저장" 흐름을 만든다(생성 지연 동안 progress 노출).
  */
+import { parseFlowchartBlock } from '../flowchartBlock';
+import { flowchartToPngSnapshot } from './flowchartSvgSnapshot';
 
 /** 96dpi 기준 CSS px → mm (jsPDF unit=mm). */
 const PX_PER_MM = 96 / 25.4;
@@ -209,6 +211,17 @@ async function captureFlowView(viewMode: 'mindmap' | 'flowchart'): Promise<Captu
     return withLightTheme(container, () => captureReactFlow(viewport, bounds));
 }
 
+async function captureStoredFlowchart(sourceMarkdown?: string): Promise<CapturedImage | null> {
+    const flowchart = sourceMarkdown ? parseFlowchartBlock(sourceMarkdown) : null;
+    if (!flowchart) return null;
+    const snapshot = await flowchartToPngSnapshot(flowchart);
+    return {
+        dataUrl: snapshot.dataUrl,
+        width: snapshot.width,
+        height: snapshot.height,
+    };
+}
+
 // ─── 칸반(HTML board) ───────────────────────────────────────────────────────
 
 async function captureHtmlElement(el: HTMLElement): Promise<CapturedImage> {
@@ -256,11 +269,13 @@ async function imageToPdfBlob(img: CapturedImage): Promise<Blob> {
 }
 
 /** 현재 시각 뷰를 PDF blob 으로(빈 뷰면 null). 캡처+PDF(무거움) — 다이얼로그/진행표시는 호출부. */
-export async function buildVisualViewPdf(viewMode: VisualViewMode): Promise<Blob | null> {
+export async function buildVisualViewPdf(viewMode: VisualViewMode, sourceMarkdown?: string): Promise<Blob | null> {
     const img = viewMode === 'gantt'
         ? await captureGantt()
         : viewMode === 'kanban'
             ? await captureKanban()
+            : viewMode === 'flowchart'
+                ? await captureStoredFlowchart(sourceMarkdown) ?? await captureFlowView(viewMode)
             : await captureFlowView(viewMode);
     if (!img) return null;
     return imageToPdfBlob(img);

--- a/src/lib/pdf/flowchartSvgSnapshot.test.ts
+++ b/src/lib/pdf/flowchartSvgSnapshot.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { StoredFlowchart } from '../flowchartBlock';
+import { flowchartToSvgSnapshot } from './flowchartSvgSnapshot';
+
+function decodeSvg(dataUrl: string): string {
+  return decodeURIComponent(dataUrl.replace(/^data:image\/svg\+xml;charset=utf-8,/, ''));
+}
+
+describe('flowchartToSvgSnapshot', () => {
+  it('renders a print-safe flowchart SVG with intact labels and padding', () => {
+    const flowchart: StoredFlowchart = {
+      title: '문서 작성 승인 흐름',
+      direction: 'LR',
+      nodes: [
+        { id: 'start', type: 'start', label: 'Draft 작성', position: { x: 0, y: 0 } },
+        { id: 'review', type: 'process', label: '리뷰 요청', position: { x: 260, y: 0 } },
+        { id: 'approved', type: 'decision', label: '승인?', position: { x: 520, y: 0 } },
+        { id: 'revise', type: 'process', label: '수정 반영', position: { x: 520, y: 190 } },
+        { id: 'publish', type: 'end', label: '게시', position: { x: 790, y: 0 } },
+      ],
+      edges: [
+        { id: 'e-start-review', source: 'start', target: 'review' },
+        { id: 'e-review-approved', source: 'review', target: 'approved' },
+        { id: 'e-approved-publish', source: 'approved', target: 'publish', label: 'Yes' },
+        { id: 'e-approved-revise', source: 'approved', target: 'revise', label: 'No' },
+        { id: 'e-revise-review', source: 'revise', target: 'review', label: '재검토', markerLoop: true },
+      ],
+    };
+
+    const snapshot = flowchartToSvgSnapshot(flowchart);
+    const svg = decodeSvg(snapshot.dataUrl);
+    const viewBox = /viewBox="([-.\d]+) ([-.\d]+) ([-.\d]+) ([-.\d]+)"/.exec(svg);
+
+    expect(snapshot.title).toBe('문서 작성 승인 흐름');
+    expect(snapshot.width).toBeGreaterThan(900);
+    expect(snapshot.height).toBeGreaterThan(260);
+    expect(svg).toContain('Draft 작성');
+    expect(svg).toContain('승인?');
+    expect(svg).toContain('재검토');
+    expect(svg).toContain('M 520 42 C 520 98, 520 104, 520 160');
+    expect(svg).toContain('marker-end="url(#flowchart-arrow-end)"');
+    expect(viewBox?.[3]).toBe(String(snapshot.width));
+    expect(viewBox?.[4]).toBe(String(snapshot.height));
+  });
+});

--- a/src/lib/pdf/flowchartSvgSnapshot.test.ts
+++ b/src/lib/pdf/flowchartSvgSnapshot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { FlowNodeType } from '../../types/flowchart';
 import type { StoredFlowchart } from '../flowchartBlock';
 import { flowchartToSvgSnapshot } from './flowchartSvgSnapshot';
 
@@ -41,5 +42,22 @@ describe('flowchartToSvgSnapshot', () => {
     expect(svg).toContain('marker-end="url(#flowchart-arrow-end)"');
     expect(viewBox?.[3]).toBe(String(snapshot.width));
     expect(viewBox?.[4]).toBe(String(snapshot.height));
+  });
+
+  it('renders unknown node types as process nodes instead of throwing', () => {
+    const flowchart: StoredFlowchart = {
+      title: 'Legacy flow',
+      direction: 'LR',
+      nodes: [
+        { id: 'legacy', type: 'legacy-task' as FlowNodeType, label: 'Legacy task', position: { x: 0, y: 0 } },
+      ],
+      edges: [],
+    };
+
+    const snapshot = flowchartToSvgSnapshot(flowchart);
+    const svg = decodeSvg(snapshot.dataUrl);
+
+    expect(svg).toContain('Legacy task');
+    expect(svg).toContain('rx="8" fill="#ffffff"');
   });
 });

--- a/src/lib/pdf/flowchartSvgSnapshot.ts
+++ b/src/lib/pdf/flowchartSvgSnapshot.ts
@@ -1,6 +1,6 @@
 import { assignFlowchartEdgeHandles, layoutFlowchart } from '../dagre-layout';
 import type { StoredFlowchart } from '../flowchartBlock';
-import { SHAPE_DIMENSIONS } from '../flowchart-shapes';
+import { getShapeDimensions, normalizeFlowNodeType } from '../flowchart-shapes';
 import type { FlowchartEdge, FlowchartNode, FlowNodeType } from '../../types/flowchart';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -118,8 +118,9 @@ function getNodePadding(type: FlowNodeType): { x: number; y: number } {
 }
 
 function buildSvgNode(node: FlowchartNode): SvgNode {
-  const dim = SHAPE_DIMENSIONS[node.type];
-  const padding = getNodePadding(node.type);
+  const flowType = normalizeFlowNodeType(node.type);
+  const dim = getShapeDimensions(flowType);
+  const padding = getNodePadding(flowType);
   const rawTextWidth = estimateTextWidth(node.label);
   const width = Math.ceil(Math.max(
     dim.minWidth,
@@ -127,7 +128,7 @@ function buildSvgNode(node: FlowchartNode): SvgNode {
   ));
   const lines = wrapText(node.label, Math.max(24, width - padding.x * 2));
   const height = Math.ceil(Math.max(dim.minHeight, lines.length * NODE_LINE_HEIGHT + padding.y * 2));
-  return { node, size: { width, height }, lines };
+  return { node: { ...node, type: flowType }, size: { width, height }, lines };
 }
 
 function escapeXml(value: string): string {

--- a/src/lib/pdf/flowchartSvgSnapshot.ts
+++ b/src/lib/pdf/flowchartSvgSnapshot.ts
@@ -1,0 +1,375 @@
+import { assignFlowchartEdgeHandles, layoutFlowchart } from '../dagre-layout';
+import type { StoredFlowchart } from '../flowchartBlock';
+import { SHAPE_DIMENSIONS } from '../flowchart-shapes';
+import type { FlowchartEdge, FlowchartNode, FlowNodeType } from '../../types/flowchart';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const SCALE = 2;
+const OUTER_PADDING_LEFT = 96;
+const OUTER_PADDING_RIGHT = 180;
+const OUTER_PADDING_Y = 88;
+const LOOP_OFFSET = 72;
+const EDGE_COLOR = '#b7bec8';
+const TEXT_COLOR = '#1f2937';
+const EDGE_LABEL_COLOR = '#475467';
+const FONT_FAMILY = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+const NODE_FONT_SIZE = 13;
+const EDGE_LABEL_FONT_SIZE = 12;
+const NODE_LINE_HEIGHT = 18;
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface SvgNode {
+  node: FlowchartNode;
+  size: Size;
+  lines: string[];
+}
+
+interface EdgeRoute {
+  edge: FlowchartEdge;
+  path: string;
+  label?: {
+    text: string;
+    x: number;
+    y: number;
+    width: number;
+  };
+  points: Point[];
+}
+
+export interface FlowchartImageSnapshot {
+  dataUrl: string;
+  width: number;
+  height: number;
+  title: string;
+}
+
+function estimateTextWidth(text: string, fontSize = NODE_FONT_SIZE): number {
+  return Array.from(text).reduce((sum, ch) => {
+    const code = ch.codePointAt(0) ?? 0;
+    if (/\s/.test(ch)) return sum + fontSize * 0.35;
+    if (code >= 0x2e80 || code > 0xffff) return sum + fontSize;
+    if (/[A-Z0-9]/.test(ch)) return sum + fontSize * 0.62;
+    if (/[a-z]/.test(ch)) return sum + fontSize * 0.54;
+    return sum + fontSize * 0.5;
+  }, 0);
+}
+
+function splitTokenByWidth(token: string, maxWidth: number): string[] {
+  const chunks: string[] = [];
+  let current = '';
+  for (const ch of Array.from(token)) {
+    const candidate = current + ch;
+    if (current && estimateTextWidth(candidate) > maxWidth) {
+      chunks.push(current);
+      current = ch;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function wrapText(text: string, maxWidth: number): string[] {
+  const normalized = text.replace(/\r/g, '').trim();
+  if (!normalized) return [''];
+
+  const lines: string[] = [];
+  for (const paragraph of normalized.split('\n')) {
+    let current = '';
+    const tokens = paragraph.split(/(\s+)/).filter((token) => token.length > 0);
+
+    for (const token of tokens) {
+      const candidate = current + token;
+      if (!current || estimateTextWidth(candidate) <= maxWidth) {
+        current = candidate;
+        continue;
+      }
+
+      if (current.trim()) lines.push(current.trim());
+      current = token.trimStart();
+
+      while (current && estimateTextWidth(current) > maxWidth) {
+        const [chunk, ...rest] = splitTokenByWidth(current, maxWidth);
+        lines.push(chunk);
+        current = rest.join('');
+      }
+    }
+
+    if (current.trim()) lines.push(current.trim());
+  }
+
+  return lines.length > 0 ? lines : [''];
+}
+
+function getNodePadding(type: FlowNodeType): { x: number; y: number } {
+  if (type === 'decision') return { x: 52, y: 26 };
+  if (type === 'merge') return { x: 14, y: 10 };
+  return { x: 20, y: 14 };
+}
+
+function buildSvgNode(node: FlowchartNode): SvgNode {
+  const dim = SHAPE_DIMENSIONS[node.type];
+  const padding = getNodePadding(node.type);
+  const rawTextWidth = estimateTextWidth(node.label);
+  const width = Math.ceil(Math.max(
+    dim.minWidth,
+    Math.min(dim.maxWidth, rawTextWidth + padding.x * 2),
+  ));
+  const lines = wrapText(node.label, Math.max(24, width - padding.x * 2));
+  const height = Math.ceil(Math.max(dim.minHeight, lines.length * NODE_LINE_HEIGHT + padding.y * 2));
+  return { node, size: { width, height }, lines };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function pointForHandle(node: FlowchartNode, size: Size, handle?: string): Point {
+  const x = node.position.x;
+  const y = node.position.y;
+  if (handle?.startsWith('left')) return { x: x - size.width / 2, y };
+  if (handle?.startsWith('right')) return { x: x + size.width / 2, y };
+  if (handle?.startsWith('top')) return { x, y: y - size.height / 2 };
+  if (handle?.startsWith('bottom')) return { x, y: y + size.height / 2 };
+  return { x: x + size.width / 2, y };
+}
+
+function sideFromHandle(handle?: string): 'left' | 'right' | 'top' | 'bottom' {
+  if (handle?.startsWith('left')) return 'left';
+  if (handle?.startsWith('top')) return 'top';
+  if (handle?.startsWith('bottom')) return 'bottom';
+  return 'right';
+}
+
+function normalForSide(side: 'left' | 'right' | 'top' | 'bottom'): Point {
+  if (side === 'left') return { x: -1, y: 0 };
+  if (side === 'right') return { x: 1, y: 0 };
+  if (side === 'top') return { x: 0, y: -1 };
+  return { x: 0, y: 1 };
+}
+
+function buildEdgeRoute(edge: FlowchartEdge, nodes: Map<string, SvgNode>, direction: 'LR' | 'TB'): EdgeRoute | null {
+  const source = nodes.get(edge.source);
+  const target = nodes.get(edge.target);
+  if (!source || !target) return null;
+
+  const sourceHandle = edge.sourceHandle ?? (direction === 'TB' ? 'bottom-source' : 'right-source');
+  const targetHandle = edge.targetHandle ?? (direction === 'TB' ? 'top-target' : 'left-target');
+  const start = pointForHandle(source.node, source.size, sourceHandle);
+  const end = pointForHandle(target.node, target.size, targetHandle);
+  const points = [start, end];
+  let path: string;
+  let labelPoint: Point = { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 - 8 };
+
+  if (edge.markerLoop) {
+    if (direction === 'TB') {
+      const loopX = Math.min(start.x, end.x) - LOOP_OFFSET;
+      path = `M ${start.x} ${start.y} H ${loopX} V ${end.y} H ${end.x}`;
+      points.push({ x: loopX, y: start.y }, { x: loopX, y: end.y });
+      labelPoint = { x: loopX, y: (start.y + end.y) / 2 - 8 };
+    } else {
+      const loopY = Math.min(start.y, end.y) - LOOP_OFFSET;
+      path = `M ${start.x} ${start.y} V ${loopY} H ${end.x} V ${end.y}`;
+      points.push({ x: start.x, y: loopY }, { x: end.x, y: loopY });
+      labelPoint = { x: (start.x + end.x) / 2, y: loopY - 10 };
+    }
+  } else {
+    const sourceSide = sideFromHandle(sourceHandle);
+    const targetSide = sideFromHandle(targetHandle);
+    const sourceNormal = normalForSide(sourceSide);
+    const targetNormal = normalForSide(targetSide);
+    const distance = Math.max(Math.abs(end.x - start.x), Math.abs(end.y - start.y));
+    const control = Math.max(56, Math.min(130, distance * 0.42));
+    const c1 = { x: start.x + sourceNormal.x * control, y: start.y + sourceNormal.y * control };
+    const c2 = { x: end.x + targetNormal.x * control, y: end.y + targetNormal.y * control };
+    path = `M ${start.x} ${start.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${end.x} ${end.y}`;
+    points.push(c1, c2);
+  }
+
+  const label = edge.label?.trim()
+    ? {
+        text: edge.label.trim(),
+        x: labelPoint.x,
+        y: labelPoint.y,
+        width: Math.ceil(estimateTextWidth(edge.label.trim(), EDGE_LABEL_FONT_SIZE) + 12),
+      }
+    : undefined;
+
+  if (label) {
+    points.push({ x: label.x - label.width / 2, y: label.y - 12 }, { x: label.x + label.width / 2, y: label.y + 6 });
+  }
+
+  return { edge, path, label, points };
+}
+
+function nodeShape(node: SvgNode): string {
+  const { x, y } = node.node.position;
+  const { width, height } = node.size;
+  const left = x - width / 2;
+  const top = y - height / 2;
+
+  if (node.node.type === 'start' || node.node.type === 'end') {
+    return `<rect x="${left}" y="${top}" width="${width}" height="${height}" rx="${height / 2}" fill="#dbeafe" stroke="#60a5fa" stroke-width="1.5" />`;
+  }
+
+  if (node.node.type === 'decision') {
+    const points = `${x},${top} ${left + width},${y} ${x},${top + height} ${left},${y}`;
+    return `<polygon points="${points}" fill="#fde68a" />`;
+  }
+
+  if (node.node.type === 'merge') {
+    const radius = Math.min(width, height) / 2;
+    return `<circle cx="${x}" cy="${y}" r="${radius}" fill="#e9d5ff" stroke="#c084fc" stroke-width="1.5" />`;
+  }
+
+  if (node.node.type === 'io') {
+    const skew = Math.min(22, width * 0.14);
+    const points = `${left + skew},${top} ${left + width},${top} ${left + width - skew},${top + height} ${left},${top + height}`;
+    return `<polygon points="${points}" fill="#dcfce7" stroke="#4ade80" stroke-width="1.5" />`;
+  }
+
+  return `<rect x="${left}" y="${top}" width="${width}" height="${height}" rx="8" fill="#ffffff" stroke="#d7dce2" stroke-width="1.2" />`;
+}
+
+function nodeText(node: SvgNode): string {
+  const { x, y } = node.node.position;
+  const firstY = y - ((node.lines.length - 1) * NODE_LINE_HEIGHT) / 2 + NODE_FONT_SIZE * 0.36;
+  const lines = node.lines.map((line, index) => (
+    `<tspan x="${x}" y="${firstY + index * NODE_LINE_HEIGHT}">${escapeXml(line)}</tspan>`
+  )).join('');
+  const weight = node.node.type === 'decision' ? 500 : 400;
+  const fill = node.node.type === 'decision' ? '#713f12' : TEXT_COLOR;
+  return `<text text-anchor="middle" font-family="${FONT_FAMILY}" font-size="${NODE_FONT_SIZE}" font-weight="${weight}" fill="${fill}">${lines}</text>`;
+}
+
+function edgeSvg(route: EdgeRoute): string {
+  const markerStart = route.edge.markerStart ? ' marker-start="url(#flowchart-arrow-start)"' : '';
+  const markerEnd = route.edge.markerEnd === false ? '' : ' marker-end="url(#flowchart-arrow-end)"';
+  const dash = route.edge.markerLoop ? ' stroke-dasharray="6 5"' : '';
+  const label = route.label
+    ? `<g><rect x="${route.label.x - route.label.width / 2}" y="${route.label.y - 15}" width="${route.label.width}" height="19" rx="4" fill="#ffffff" opacity="0.95" /><text x="${route.label.x}" y="${route.label.y}" text-anchor="middle" font-family="${FONT_FAMILY}" font-size="${EDGE_LABEL_FONT_SIZE}" fill="${EDGE_LABEL_COLOR}">${escapeXml(route.label.text)}</text></g>`
+    : '';
+  return `<path d="${route.path}" fill="none" stroke="${EDGE_COLOR}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"${dash}${markerStart}${markerEnd} />${label}`;
+}
+
+function collectBounds(nodes: SvgNode[], routes: EdgeRoute[]): { minX: number; minY: number; maxX: number; maxY: number } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const item of nodes) {
+    const { x, y } = item.node.position;
+    minX = Math.min(minX, x - item.size.width / 2);
+    minY = Math.min(minY, y - item.size.height / 2);
+    maxX = Math.max(maxX, x + item.size.width / 2);
+    maxY = Math.max(maxY, y + item.size.height / 2);
+  }
+
+  for (const route of routes) {
+    for (const point of route.points) {
+      minX = Math.min(minX, point.x);
+      minY = Math.min(minY, point.y);
+      maxX = Math.max(maxX, point.x);
+      maxY = Math.max(maxY, point.y);
+    }
+  }
+
+  if (!Number.isFinite(minX)) return { minX: 0, minY: 0, maxX: 1, maxY: 1 };
+  return { minX, minY, maxX, maxY };
+}
+
+function svgToDataUrl(svg: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+function hasPosition(node: FlowchartNode): boolean {
+  return Number.isFinite(node.position?.x) && Number.isFinite(node.position?.y);
+}
+
+async function svgDataUrlToPng(dataUrl: string, width: number, height: number): Promise<string> {
+  const image = new Image();
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error('Flowchart SVG 렌더 실패'));
+    image.src = dataUrl;
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.ceil(width * SCALE));
+  canvas.height = Math.max(1, Math.ceil(height * SCALE));
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas 2d 컨텍스트를 만들 수 없습니다.');
+
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  return canvas.toDataURL('image/png');
+}
+
+export function flowchartToSvgSnapshot(flowchart: StoredFlowchart): FlowchartImageSnapshot {
+  const direction = flowchart.direction ?? 'LR';
+  const baseNodes = flowchart.nodes.map((node) => ({
+    ...node,
+    position: node.position ?? { x: 0, y: 0 },
+  }));
+  const initialNodes = new Map(baseNodes.map((node) => [node.id, buildSvgNode(node)]));
+  const layouted = layoutFlowchart(baseNodes, flowchart.edges, {
+    rankdir: direction,
+    getNodeSize: (node) => initialNodes.get(node.id)?.size,
+  });
+  const mergedNodes = layouted.nodes.map((node) => {
+    const stored = flowchart.nodes.find((item) => item.id === node.id);
+    return stored && hasPosition(stored) ? { ...node, position: stored.position } : node;
+  });
+  const routedEdges = assignFlowchartEdgeHandles(layouted.edges, mergedNodes, direction);
+  const svgNodes = mergedNodes.map((node) => buildSvgNode(node));
+  const nodeMap = new Map(svgNodes.map((item) => [item.node.id, item]));
+  const routes = routedEdges
+    .map((edge) => buildEdgeRoute(edge, nodeMap, direction))
+    .filter((route): route is EdgeRoute => route !== null);
+  const bounds = collectBounds(svgNodes, routes);
+  const minX = Math.floor(bounds.minX - OUTER_PADDING_LEFT);
+  const minY = Math.floor(bounds.minY - OUTER_PADDING_Y);
+  const width = Math.ceil(bounds.maxX - bounds.minX + OUTER_PADDING_LEFT + OUTER_PADDING_RIGHT);
+  const height = Math.ceil(bounds.maxY - bounds.minY + OUTER_PADDING_Y * 2);
+  const title = flowchart.title?.trim() || 'Flowchart';
+
+  const edges = routes.map(edgeSvg).join('');
+  const nodes = svgNodes.map((node) => `<g>${nodeShape(node)}${nodeText(node)}</g>`).join('');
+  const svg = `<svg xmlns="${SVG_NS}" width="${width}" height="${height}" viewBox="${minX} ${minY} ${width} ${height}">
+<defs>
+  <marker id="flowchart-arrow-end" markerWidth="10" markerHeight="10" refX="8.5" refY="5" orient="auto" markerUnits="strokeWidth">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="${EDGE_COLOR}" />
+  </marker>
+  <marker id="flowchart-arrow-start" markerWidth="10" markerHeight="10" refX="1.5" refY="5" orient="auto-start-reverse" markerUnits="strokeWidth">
+    <path d="M 10 0 L 0 5 L 10 10 z" fill="${EDGE_COLOR}" />
+  </marker>
+</defs>
+<rect x="${minX}" y="${minY}" width="${width}" height="${height}" fill="#ffffff" />
+<g>${edges}</g>
+<g>${nodes}</g>
+</svg>`;
+
+  return { dataUrl: svgToDataUrl(svg), width, height, title };
+}
+
+export async function flowchartToPngSnapshot(flowchart: StoredFlowchart): Promise<FlowchartImageSnapshot> {
+  const svg = flowchartToSvgSnapshot(flowchart);
+  const dataUrl = await svgDataUrlToPng(svg.dataUrl, svg.width, svg.height);
+  return { ...svg, dataUrl };
+}

--- a/src/lib/pdf/richFlowchartPrint.ts
+++ b/src/lib/pdf/richFlowchartPrint.ts
@@ -1,0 +1,86 @@
+import type { StoredFlowchart } from '../flowchartBlock';
+import type { FlowchartEdge, FlowchartNode } from '../../types/flowchart';
+import { flowchartToPngSnapshot } from './flowchartSvgSnapshot';
+
+const SNAPSHOT_CLASS = 'is-print-snapshot';
+const PRINT_IMAGE_CLASS = 'rich-flowchart-print-image';
+const PRINT_IMAGE_WIDTH = '88%';
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function parseStoredFlowchartJson(code: string): StoredFlowchart | null {
+  try {
+    const data = JSON.parse(code);
+    if (!Array.isArray(data?.nodes) || !Array.isArray(data?.edges)) return null;
+    const direction = data.direction === 'TB' ? 'TB' : data.direction === 'LR' ? 'LR' : undefined;
+    return {
+      title: typeof data.title === 'string' ? data.title : undefined,
+      direction,
+      nodes: data.nodes as FlowchartNode[],
+      edges: data.edges as FlowchartEdge[],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readFlowchart(block: HTMLElement): StoredFlowchart | null {
+  const datasetJson = block.dataset.flowchartJson?.trim();
+  if (datasetJson) {
+    const parsed = parseStoredFlowchartJson(datasetJson);
+    if (parsed) return parsed;
+  }
+
+  const source = block.querySelector<HTMLElement>('.rich-flowchart-block__content-host')?.textContent?.trim();
+  return source ? parseStoredFlowchartJson(source) : null;
+}
+
+async function createFlowchartPrintImage(block: HTMLElement): Promise<HTMLImageElement | null> {
+  const flowchart = readFlowchart(block);
+  if (!flowchart || flowchart.nodes.length === 0) return null;
+
+  const snapshot = await flowchartToPngSnapshot(flowchart);
+  const img = document.createElement('img');
+  img.className = PRINT_IMAGE_CLASS;
+  img.src = snapshot.dataUrl;
+  img.alt = snapshot.title;
+  img.width = snapshot.width;
+  img.height = snapshot.height;
+  img.decoding = 'sync';
+  img.style.width = PRINT_IMAGE_WIDTH;
+  img.style.maxWidth = PRINT_IMAGE_WIDTH;
+  img.style.height = 'auto';
+  img.style.margin = '0 auto';
+  return img;
+}
+
+export async function prepareRichFlowchartsForPrint(): Promise<() => void> {
+  const blocks = Array.from(
+    document.querySelectorAll<HTMLElement>('.preview-rich-mode .rich-flowchart-block'),
+  );
+  if (blocks.length === 0) return () => {};
+
+  await document.fonts?.ready?.catch(() => undefined);
+  await nextFrame();
+
+  const cleanup: Array<() => void> = [];
+  for (const block of blocks) {
+    try {
+      const img = await createFlowchartPrintImage(block);
+      if (!img) continue;
+
+      block.appendChild(img);
+      block.classList.add(SNAPSHOT_CLASS);
+      cleanup.push(() => {
+        block.classList.remove(SNAPSHOT_CLASS);
+        img.remove();
+      });
+    } catch (err) {
+      console.warn('[export_pdf] rich flowchart snapshot skipped:', err);
+    }
+  }
+
+  return () => cleanup.reverse().forEach((restore) => restore());
+}


### PR DESCRIPTION
## Summary

- Render `markmind-flow` code blocks as read-only flowchart blocks in Rich Text while preserving the original JSON source.
- Export embedded flowcharts to PDF through a deterministic SVG/PNG snapshot path, aligned with the stored node positions used by Flowchart View and Rich Text.
- Restore reliable PDF page numbering with a CoreGraphics fallback and keep print margins, caret hiding, and flowchart overflow behavior stable.
- Add a preserved `sample-flowchart.md` fixture for manual verification.

## Root Cause

Rich Text and PDF export were rendering flowchart content through different paths. Rich Text needed a code-block NodeView to replace only `markmind-flow` blocks, while PDF export could not depend on the React Flow DOM capture path because it clipped edge content and did not share the same layout assumptions. Native PDF page numbering also needed a fallback because the previous post-processing path could fail silently.

## Validation

- `npm test`
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `git diff --check`

Refs #101
